### PR TITLE
Enable gzip compression

### DIFF
--- a/config/template.config.js
+++ b/config/template.config.js
@@ -1,5 +1,4 @@
 const assetName = ext => `assets/[hash:base32].[name].${ext || '[ext]'}`;
-const path = require('path');
 
 // Patches the given webpack config to allow referencing the govuk_template_jinja
 // template from node_modules
@@ -34,8 +33,7 @@ module.exports = function (cfg) {
       {
         loader: 'css-loader',
         options: {
-          importLoaders: 1,
-          url: false
+          importLoaders: 1
         }
       },
       {
@@ -43,12 +41,6 @@ module.exports = function (cfg) {
         options: {
           ident: 'postcss',
           plugins: () => [
-            require('postcss-url')([{
-              url: 'copy',
-              basePath: path.resolve(__dirname, '../node_modules/govuk_template_jinja/assets/stylesheets/'),
-              assetsPath: 'dist/assets',
-              useHash: true
-            }]),
             require('postcss-url')([{
               url: u => u.url
               .replace(/\?\d+\.\d+\.\d+/, '')

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const CompressionPlugin = require('compression-webpack-plugin');
 const webpack = require('webpack');
 const nodeModules = require('webpack-node-externals');
 const enableTemplate = require('./template.config');
@@ -120,7 +121,12 @@ let cfg = {
   },
 
   plugins: [
-    new webpack.EnvironmentPlugin({NODE_ENV})
+    new webpack.EnvironmentPlugin({NODE_ENV}),
+    new CompressionPlugin({
+      test: /\.(js|svg|css)$/,
+      include: 'assets/',
+      deleteOriginalAssets: true
+    })
   ]
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,6 +2681,43 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
+    "compressible": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "compression": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "2.0.12",
+        "debug": "2.6.9",
+        "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "1.1.2"
+      }
+    },
+    "compression-webpack-plugin": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-1.1.6.tgz",
+      "integrity": "sha512-oNao3kC1JiQC781akjCgm7zu7K1pxDw9sd2oUUbW128cp2OpvOD4xm1s/WDuAdRsOl4m6rsTGAzcdILvA/7nFg==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "cacache": "10.0.2",
+        "find-cache-dir": "1.0.0",
+        "serialize-javascript": "1.4.0",
+        "webpack-sources": "1.1.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4148,6 +4185,15 @@
       "dev": true,
       "requires": {
         "pino-http": "3.1.0"
+      }
+    },
+    "express-static-gzip": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/express-static-gzip/-/express-static-gzip-0.3.2.tgz",
+      "integrity": "sha512-xFOW5Lxrh4xLey5i6gGWHOFznJayGCxazUau0kq7ElUh1t7q2B6IlvWv4d3UJwJej+aXEu9os/VpzPvRchdNiA==",
+      "dev": true,
+      "requires": {
+        "serve-static": "1.13.1"
       }
     },
     "extend": {
@@ -10082,6 +10128,12 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,12 @@
   "license": "MIT",
   "devDependencies": {
     "@govuk-frontend/all": "0.0.22-alpha",
+    "compression": "1.7.1",
+    "compression-webpack-plugin": "1.1.6",
     "css-loader": "0.28.7",
     "express": "4.16.2",
     "express-pino-logger": "3.0.1",
+    "express-static-gzip": "0.3.2",
     "extract-loader": "1.0.1",
     "file-loader": "1.1.6",
     "glob": "7.1.2",

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import helmet from 'helmet';
 import pinoMiddleware from 'express-pino-logger';
+import compression from 'compression';
+import staticGzip from 'express-static-gzip';
 import home from '../home';
 import orgs from '../orgs';
 import {pageNotFoundMiddleware, internalServerErrorMiddleware} from '../errors';
@@ -13,10 +15,11 @@ export default function ({logger} = {}) {
     app.use(pinoMiddleware({logger}));
   }
 
+  app.use('/assets', staticGzip('dist/assets', {immutable: true}));
+  app.use(compression());
+
   app.use(helmet());
   app.use(helmet.contentSecurityPolicy(csp));
-
-  app.use('/assets', express.static('dist/assets', {immutable: true}));
 
   app.use('/orgs', orgs);
   app.use('/', home);

--- a/src/app/app.test.js
+++ b/src/app/app.test.js
@@ -16,6 +16,12 @@ test('should have a Content Security Policy set', async t => {
     .expect('Content-Security-Policy', `default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' www.google-analytics.com 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='; img-src 'self' www.google-analytics.com; connect-src 'self' www.google-analytics.com; frame-src 'self'; font-src 'self' data:; object-src 'self'; media-src 'self'`);
 });
 
+test('should gzip responses', async t => {
+  return request(app)
+    .get('/')
+    .expect('Content-Encoding', /gzip/);
+});
+
 test('should display a 404 page', async t => {
   return request(app)
     .get('/this-should-not-exists')


### PR DESCRIPTION
# What

We should be serving responses with Content-Encoding: gzip to reduce
filesizes where possible.

All static assets are gziped at compile time to remove the need to compress
them on-the-fly during serving them.

All dynamic app responses are compressed on-the-fly. This can be
disabled by setting a `Cache-Control: no-transform` header on the
response.

As part of this change there was a need to process the assets discovered
from the govuk_template css (which were previously being emitted to the
asset dir with the help of the postcss-url helper). This is no longer
required and we can let the main file-loader handle the asset
processing to take advatange of the gzip.

## How to review

Check code
Check it still deploys to cf and renders all the assets
Check there's enough tests (maybe we need a test for asset responses - but it's hard to get know the urls since then contain hashes)

## Who can review

Not @chrisfarms
