### PR TITLE
[#155121562] Remove duplicate govuk_template fonts

### DIFF
--- a/config/template.config.js
+++ b/config/template.config.js
@@ -56,6 +56,17 @@ module.exports = function (cfg) {
   for (let i = 0; i < cfg.module.rules.length; i++) {
     const r = cfg.module.rules[i];
     if (r.test.test('x.html')) {
+      // Remove govuk_template fonts that already come from govuk_frontend
+      r.use.push({
+        loader: 'regexp-replace-loader',
+        options: {
+          match: {
+            pattern: '.+govuk_template_jinja/assets/stylesheets/fonts.+',
+            flags: 'g'
+          },
+          replaceWith: ''
+        }
+      });
       // This strips the ?x.x.x version query string which breaks loaders
       r.use.push({
         loader: 'regexp-replace-loader',


### PR DESCRIPTION
## What

We were loading fonts from both govuk_template and govuk_frontend which
doubled (2*200KB) the amount of CSS that needed to be downloaded before
the first paint of the page.

govuk_template should be replaced in the future by something more
compatible with govuk_frontend. In the meantime we'll continue to make
modifications in a slightly hacky way by using webpack loaders.

This regexp is specific enough that it should only match the following
two lines, to prevent them appearing in the rendered HTML and the
referenced CSS files no longer being built:

    <!--[if IE 8]><link rel="stylesheet" media="all" href="../../../../node_modules/govuk_template_jinja/assets/stylesheets/fonts-ie8.css"/><![endif]-->
    <!--[if gte IE 9]><!--><link rel="stylesheet" media="all" href="/assets/6e7r9n3wmvk8mre72skqzw5pdn.fonts.css"/><!--<![endif]-->

This was checked with [lighthouse][0]. Results before and after:

     dcarley@air  ~/p/p/paas-admin   bugfix/155121562-improve_loading  jq '.audits."first-meaningful-paint" | {score: .score, value: .displayValue}' lighthouse.{before,after}
    {
      "score": 56,
      "value": "3,690 ms"
    }
    {
      "score": 80,
      "value": "2,620 ms"
    }

[0]: https://developers.google.com/web/tools/lighthouse/

## How to review

1. Run the app from the `master` branch using the instructions in the README.
1. Run [Lighthouse from Chrome DevTools](https://developers.google.com/web/tools/lighthouse/#devtools) and confirm that the "Opportunities" section shows "Reduce render-blocking stylesheets" with:
    - a time of over 2secs
    - 2x CSS files of ~200KB
1. Run the app from this branch.
1. Run Lighthouse again and confirm that the same section now shows:
    - a time of under 2secs
    - 1x CSS file of ~200KB

## Who can review

Anyone.