### PR TITLE
[#155508629] Refactor tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4400,16 +4400,6 @@
         "homedir-polyfill": "1.0.1"
       }
     },
-    "expect-cookies": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/expect-cookies/-/expect-cookies-0.1.2.tgz",
-      "integrity": "sha1-Gsc3T+RtiEfcnm4YEUZ3B72U+f4=",
-      "dev": true,
-      "requires": {
-        "cookie-signature": "1.0.6",
-        "should": "7.1.1"
-      }
-    },
     "expect-ct": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.1.0.tgz",
@@ -13600,41 +13590,6 @@
         "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
-    },
-    "should": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-7.1.1.tgz",
-      "integrity": "sha1-ZGTEi298Hh8YrASDV4+i3VXCxuA=",
-      "dev": true,
-      "requires": {
-        "should-equal": "0.5.0",
-        "should-format": "0.3.1",
-        "should-type": "0.2.0"
-      }
-    },
-    "should-equal": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
-      "integrity": "sha1-x5fxNfMGf+tp6+zbMGscP+IbPm8=",
-      "dev": true,
-      "requires": {
-        "should-type": "0.2.0"
-      }
-    },
-    "should-format": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.1.tgz",
-      "integrity": "sha1-LLt4JGFnCs5CkrKx7EaNuM+Z4zA=",
-      "dev": true,
-      "requires": {
-        "should-type": "0.2.0"
-      }
-    },
-    "should-type": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
-      "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
-      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "compression-webpack-plugin": "1.1.6",
     "cookie-session": "2.0.0-beta.3",
     "css-loader": "0.28.7",
-    "expect-cookies": "0.1.2",
     "express": "4.16.2",
     "express-pino-logger": "3.0.1",
     "express-static-gzip": "0.3.2",

--- a/src/app/app.test.js
+++ b/src/app/app.test.js
@@ -2,7 +2,6 @@ import {test} from 'tap';
 import request from 'supertest';
 import pino from 'pino';
 import nock from 'nock';
-import cookies from 'expect-cookies';
 import init from '.';
 
 const logger = pino({}, Buffer.from([]));
@@ -21,54 +20,45 @@ const app = init({
 });
 
 test('should store a session in a signed cookie', async t => {
-  app.get('/something', (req, _res) => {
-    req.session.test = 1;
-  });
+  const response = await request(app).get('/test');
 
-  return request(app)
-    .get('/test')
-    .expect(cookies.set({
-      name: 'pazmin-session'
-    }))
-    .expect(cookies.set({
-      name: 'pazmin-session.sig'
-    }));
+  t.contains(response.header['set-cookie'][1], 'pazmin-session.sig');
 });
 
 test('should render as text/html with utf-8 charset', async t => {
-  return request(app)
-    .get('/')
-    .expect('Content-Type', 'text/html; charset=utf-8');
+  const response = await request(app).get('/');
+
+  t.equal(response.header['content-type'], 'text/html; charset=utf-8');
 });
 
 test('should have a Content Security Policy set', async t => {
-  return request(app)
-    .get('/')
-    .expect('Content-Security-Policy', `default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' www.google-analytics.com 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='; img-src 'self' www.google-analytics.com; connect-src 'self' www.google-analytics.com; frame-src 'self'; font-src 'self' data:; object-src 'self'; media-src 'self'`);
+  const response = await request(app).get('/');
+
+  t.equal(response.header['content-security-policy'], `default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' www.google-analytics.com 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='; img-src 'self' www.google-analytics.com; connect-src 'self' www.google-analytics.com; frame-src 'self'; font-src 'self' data:; object-src 'self'; media-src 'self'`);
 });
 
 test('should gzip responses', async t => {
-  return request(app)
-    .get('/')
-    .expect('Content-Encoding', /gzip/);
+  const response = await request(app).get('/');
+
+  t.contains(response.header['content-encoding'], 'gzip');
 });
 
 test('should redirect to oauth provider for auth', async t => {
-  return request(app)
-    .get('/orgs')
-    .expect(302);
+  const response = await request(app).get('/orgs');
+
+  t.equal(response.status, 302);
 });
 
 test('missing pages should redirect with a 302 if not authenticated', async t => {
-  return request(app)
-    .get('/this-should-not-exists')
-    .expect(302);
+  const response = await request(app).get('/this-should-not-exists');
+
+  t.equal(response.status, 302);
 });
 
 test('when authenticated', async t => {
   const agent = request.agent(app);
 
-  // Requeried for passport to retrieve a token
+  // Capture the request to the given URL and prepare a response.
   nock('https://example.com')
     .post('/token')
     .times(1)
@@ -81,25 +71,23 @@ test('when authenticated', async t => {
       jti: '__jti__'
     });
 
-  await t.resolves(
-    agent
-    .get('/auth/login/callback?code=__fakecode__&state=__fakestate__')
-    .expect(302)
-    .expect(cookies(sessionSecret).set({
-      name: 'pazmin-session'
-    }))
-  );
+  await t.test('should authenticate successfully', async t => {
+    const response = await agent.get('/auth/login/callback?code=__fakecode__&state=__fakestate__');
+
+    t.equal(response.status, 302);
+    t.contains(response.header['set-cookie'][0], 'pazmin-session');
+  });
 
   await t.test('should return orgs', async t => {
-    return agent
-      .get('/orgs')
-      .expect(200);
+    const response = await agent.get('/orgs');
+
+    t.equal(response.status, 200);
   });
 
   await t.test('missing pages should redirect with a 404', async t => {
-    return agent
-      .get('/this-should-not-exists')
-      .expect(404);
+    const response = await agent.get('/this-should-not-exists');
+
+    t.equal(response.status, 404);
   });
 });
 

--- a/src/errors/error.test.js
+++ b/src/errors/error.test.js
@@ -15,16 +15,16 @@ test('should display an internal-server-error 500 error page for errors', async 
     throw new Error('bang');
   });
   app.use(internalServerErrorMiddleware);
-  return request(app)
-    .get('/bang')
-    .expect(/Sorry an error occurred/i)
-    .expect(500);
+  const response = await request(app).get('/bang');
+
+  t.equal(response.status, 500);
+  t.contains(response.text, 'Sorry an error occurred');
 });
 
 test('should display an not-found 404 error page for missing pages', async t => {
   app.use(pageNotFoundMiddleware);
-  return request(app)
-    .get('/not-to-exist')
-    .expect(/Page not found/i)
-    .expect(404);
+  const response = await request(app).get('/not-to-exist');
+
+  t.equal(response.status, 404);
+  t.contains(response.text, 'Page not found');
 });

--- a/src/home/home.test.js
+++ b/src/home/home.test.js
@@ -3,9 +3,9 @@ import request from 'supertest';
 import app from '.';
 
 test('should render home page', async t => {
-  return request(app)
-    .get('/')
-    .expect(/congratulations/i)
-    .expect(200);
+  const response = await request(app).get('/');
+
+  t.equal(response.status, 200);
+  t.contains(response.text, 'Congratulations');
 });
 

--- a/src/orgs/orgs.test.js
+++ b/src/orgs/orgs.test.js
@@ -3,8 +3,8 @@ import request from 'supertest';
 import app from '.';
 
 test('should show the orgs page', async t => {
-  return request(app)
-    .get('/')
-    .expect(/Create org/i)
-    .expect(200);
+  const response = await request(app).get('/');
+
+  t.equal(response.status, 200);
+  t.contains(response.text, 'Create org');
 });


### PR DESCRIPTION
## What

With the current use of `supertest` we can experience some unclear
issues which result in hanging the tests without any notification as to
what went wrong. For instance, the following code:

```js
request(app)
  .get('/')
  .expect(nonExsistingVariable);
```

Should in fact throw an exception and stop the tests. The reality, is
that the exceptions are being caught and could then be handled with
`.catch()` method.

We thought it's unreasonable for us to add that after every `.except()`,
therefore we decided to go with different approach.

It proved difficult to replace `supertest` with another solution, due to
the goodness it provides when setting up and tearing down the
application on the go. We decided to refactor it in a way to get the
best of both worlds. Keep the `supertest` magic and not use the bugged
`.except()` function.

We're forcing the request to finish, by prefixing it with the `await`
key word and then taking the response to be used with the default tap
functionality.

!!! This does not get rid of the issue... It should however discourage
people from using or knowing of the faulty functionality.

## How to review

- Code review - The code should be clear. You should know what's going on.
- Run the tests - `npm test` - also run by travis
- Advice perhaps if you think it's insufficient

## Who can review

Neither @carolinegreen nor myself.
