### PR TITLE
[#154558816] Setup API communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ OAUTH_TOKEN_URL="https://uaa.$DEPLOY_ENV.dev.cloudpipeline.digital/oauth/token" 
 OAUTH_CLIENT_ID="my-client-id" \
 OAUTH_CLIENT_SECRET="my-secret" \
 SERVER_ROOT_URL="http://localhost:3000" \
+API_URL="https://api.$DEPLOY_ENV.dev.cloudpipeline.digital/" \
 npm start
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -629,6 +629,16 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -4715,6 +4725,26 @@
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "devDependencies": {
     "@govuk-frontend/all": "0.0.22-alpha",
+    "axios": "0.18.0",
     "compression": "1.7.1",
     "compression-webpack-plugin": "1.1.6",
     "cookie-session": "2.0.0-beta.3",

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -7,6 +7,7 @@ import staticGzip from 'express-static-gzip';
 
 import auth from '../auth';
 import home from '../home';
+import {cfClient} from '../cf';
 import orgs from '../orgs';
 import {pageNotFoundMiddleware, internalServerErrorMiddleware} from '../errors';
 import csp from './app.csp';
@@ -33,6 +34,7 @@ export default function (config) {
 
   // Authenticated endpoints follow
   app.use(auth(config));
+  app.use(cfClient(config));
 
   app.use('/orgs', orgs);
 

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -9,6 +9,7 @@ import auth from '../auth';
 import home from '../home';
 import {cfClient} from '../cf';
 import orgs from '../orgs';
+import spaces from '../spaces';
 import {pageNotFoundMiddleware, internalServerErrorMiddleware} from '../errors';
 import csp from './app.csp';
 
@@ -37,6 +38,7 @@ export default function (config) {
   app.use(cfClient(config));
 
   app.use('/orgs', orgs);
+  app.use('/spaces', spaces);
 
   app.use(pageNotFoundMiddleware);
   app.use(internalServerErrorMiddleware);

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -11,6 +11,7 @@ import {cfClient} from '../cf';
 import orgs from '../orgs';
 import spaces from '../spaces';
 import applications from '../applications';
+import services from '../services';
 import {pageNotFoundMiddleware, internalServerErrorMiddleware} from '../errors';
 import csp from './app.csp';
 
@@ -41,6 +42,7 @@ export default function (config) {
   app.use('/orgs', orgs);
   app.use('/spaces', spaces);
   app.use('/applications', applications);
+  app.use('/services', services);
 
   app.use(pageNotFoundMiddleware);
   app.use(internalServerErrorMiddleware);

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -10,6 +10,7 @@ import home from '../home';
 import {cfClient} from '../cf';
 import orgs from '../orgs';
 import spaces from '../spaces';
+import applications from '../applications';
 import {pageNotFoundMiddleware, internalServerErrorMiddleware} from '../errors';
 import csp from './app.csp';
 
@@ -39,6 +40,7 @@ export default function (config) {
 
   app.use('/orgs', orgs);
   app.use('/spaces', spaces);
+  app.use('/applications', applications);
 
   app.use(pageNotFoundMiddleware);
   app.use(internalServerErrorMiddleware);

--- a/src/app/app.test.js
+++ b/src/app/app.test.js
@@ -2,6 +2,7 @@ import {test} from 'tap';
 import request from 'supertest';
 import pino from 'pino';
 import nock from 'nock';
+import {orgs} from '../cf/client.test.data';
 import init from '.';
 
 const logger = pino({}, Buffer.from([]));
@@ -16,7 +17,8 @@ const app = init({
   oauthTokenURL: 'https://example.com/token',
   oauthClientID: 'key',
   oauthClientSecret: 'secret',
-  serverRootURL: 'http://localhost:3000'
+  serverRootURL: 'http://localhost:3000',
+  cloudFoundryAPI: 'https://example.com/api'
 });
 
 test('should store a session in a signed cookie', async t => {
@@ -77,6 +79,8 @@ test('when authenticated', async t => {
     t.equal(response.status, 302);
     t.contains(response.header['set-cookie'][0], 'pazmin-session');
   });
+
+  nock('https://example.com').get('/api/v2/organizations').times(1).reply(200, orgs);
 
   await t.test('should return orgs', async t => {
     const response = await agent.get('/orgs');

--- a/src/applications/applications.js
+++ b/src/applications/applications.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import applicationsTemplate from './applications.njk';
+
+const app = express();
+
+app.get('/:space', (req, res) => {
+  req.cf.applications(req.params.space)
+    .then(applications => {
+      res.send(applicationsTemplate.render({applications}));
+    })
+    .catch(req.log.error);
+});
+
+export default app;

--- a/src/applications/applications.njk
+++ b/src/applications/applications.njk
@@ -1,0 +1,14 @@
+{% extends "../layouts/govuk.njk" %}
+{% from "@govuk-frontend/input/macro.njk" import govukInput %}
+{% from "@govuk-frontend/button/macro.njk" import govukButton %}
+{% from "@govuk-frontend/panel/macro.njk" import govukPanel %}
+{% from "@govuk-frontend/back-link/macro.njk" import govukBackLink %}
+{% from "@govuk-frontend/details/macro.njk" import govukDetails %}
+
+{% block page_title %}
+  Applications
+{% endblock %}
+
+{% block main %}
+  <pre>{{ applications | dump }}</pre>
+{% endblock %}

--- a/src/applications/applications.test.js
+++ b/src/applications/applications.test.js
@@ -1,0 +1,30 @@
+import {test} from 'tap';
+import express from 'express';
+import nock from 'nock';
+import request from 'supertest';
+import {Client} from '../cf';
+import {apps} from '../cf/client.test.data';
+import applicationsApp from '.';
+
+nock('https://example.com').get('/api/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps').times(1).reply(200, apps);
+
+const app = express();
+
+app.use((req, res, next) => {
+  req.log = console;
+  next();
+});
+
+app.use((req, res, next) => {
+  req.cf = new Client('https://example.com/api', 'qwerty123456');
+  next();
+});
+
+app.use(applicationsApp);
+
+test('should show the orgs pages', async t => {
+  const response = await request(app).get('/be1f9c1d-e629-488e-a560-a35b545f0ad7');
+
+  t.equal(response.status, 200);
+  t.contains(response.text, 'Applications');
+});

--- a/src/applications/index.js
+++ b/src/applications/index.js
@@ -1,0 +1,1 @@
+export {default} from './applications';

--- a/src/cf/client.js
+++ b/src/cf/client.js
@@ -1,0 +1,62 @@
+import axios from 'axios';
+
+export default class Client {
+  constructor(apiURL, accessToken) {
+    this.api = apiURL;
+    this.accessToken = accessToken;
+  }
+
+  request(method, url, data, params) {
+    return axios.request({
+      url,
+      method,
+      baseURL: `${this.api}`,
+      data,
+      params,
+      headers: {Authorization: `Bearer ${this.accessToken}`}
+    });
+  }
+
+  async allResources(response) {
+    const data = response.data.resources;
+
+    if (!response.data.next_url) {
+      return data;
+    }
+
+    const newResponse = await this.request('get', response.data.next_url);
+    const newData = await this.allResources(newResponse);
+
+    return [...data, ...newData];
+  }
+
+  async info() {
+    const response = await this.request('get', '/v2/info');
+    return response.data;
+  }
+
+  async organizations() {
+    const response = await this.request('get', `/v2/organizations`);
+    return this.allResources(response);
+  }
+
+  async spaces(organization) {
+    const response = await this.request('get', `/v2/organizations/${organization}/spaces`);
+    return this.allResources(response);
+  }
+
+  async applications(space) {
+    const response = await this.request('get', `/v2/spaces/${space}/apps`);
+    return this.allResources(response);
+  }
+
+  async services(space) {
+    const response = await this.request('get', `/v2/spaces/${space}/service_instances`);
+    return this.allResources(response);
+  }
+
+  async users(organization) {
+    const response = await this.request('get', `/v2/organizations/${organization}/users`);
+    return this.allResources(response);
+  }
+}

--- a/src/cf/client.test.data.js
+++ b/src/cf/client.test.data.js
@@ -1,0 +1,208 @@
+export const info = `{
+  "name": "vcap",
+  "build": "2222",
+  "support": "http://support.cloudfoundry.com",
+  "version": 2,
+  "description": "Cloud Foundry sponsored by Pivotal",
+  "authorization_endpoint": "http://localhost:8080/uaa",
+  "token_endpoint": "http://localhost:8080/uaa",
+  "min_cli_version": null,
+  "min_recommended_cli_version": null,
+  "api_version": "2.99.0",
+  "app_ssh_endpoint": "ssh.system.domain.example.com:2222",
+  "app_ssh_host_key_fingerprint": "47:0d:d1:c8:c3:3d:0a:36:d1:49:2f:f2:90:27:31:d0",
+  "app_ssh_oauth_client": null,
+  "routing_endpoint": "http://localhost:3000",
+  "logging_endpoint": "ws://loggregator.vcap.me:80"
+}`;
+
+export const orgs = `{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+        "url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+        "created_at": "2016-06-08T16:41:33Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "the-system_domain-org-name",
+        "billing_enabled": false,
+        "quota_definition_guid": "dcb680a9-b190-4838-a3d2-b84aa17517a6",
+        "status": "active",
+        "quota_definition_url": "/v2/quota_definitions/dcb680a9-b190-4838-a3d2-b84aa17517a6",
+        "spaces_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/spaces",
+        "domains_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/domains",
+        "private_domains_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/private_domains",
+        "users_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/users",
+        "managers_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/managers",
+        "billing_managers_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/billing_managers",
+        "auditors_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/auditors",
+        "app_events_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/app_events",
+        "space_quota_definitions_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/space_quota_definitions"
+      }
+    }
+  ]
+}`;
+
+export const spaces = `{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "5489e195-c42b-4e61-bf30-323c331ecc01",
+        "url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01",
+        "created_at": "2016-06-08T16:41:35Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "name-1774",
+        "organization_guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275",
+        "space_quota_definition_guid": null,
+        "allow_ssh": true,
+        "organization_url": "/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275",
+        "developers_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers",
+        "managers_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers",
+        "auditors_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors",
+        "apps_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/apps",
+        "routes_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/routes",
+        "domains_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/domains",
+        "service_instances_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/service_instances",
+        "app_events_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/app_events",
+        "events_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/events",
+        "security_groups_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/security_groups",
+        "staging_security_groups_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/staging_security_groups"
+      }
+    }
+  ]
+}`;
+
+export const apps = `{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "efd23111-72d1-481e-8168-d5395e0ea5f0",
+        "url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0",
+        "created_at": "2016-06-08T16:41:41Z",
+        "updated_at": "2016-06-08T16:41:41Z"
+      },
+      "entity": {
+        "name": "name-2131",
+        "production": false,
+        "space_guid": "be1f9c1d-e629-488e-a560-a35b545f0ad7",
+        "stack_guid": "ab968358-43eb-4a5b-80e7-351f194028f7",
+        "buildpack": null,
+        "detected_buildpack": null,
+        "environment_json": null,
+        "memory": 1024,
+        "instances": 1,
+        "disk_quota": 1024,
+        "state": "STOPPED",
+        "version": "43abf29f-1ad1-46d0-bf08-991946e218fa",
+        "command": null,
+        "console": false,
+        "debug": null,
+        "staging_task_id": null,
+        "package_state": "PENDING",
+        "health_check_type": "port",
+        "health_check_timeout": null,
+        "staging_failed_reason": null,
+        "staging_failed_description": null,
+        "diego": false,
+        "docker_image": null,
+        "docker_credentials": {
+          "username": null,
+          "password": null
+        },
+        "package_updated_at": "2016-06-08T16:41:41Z",
+        "detected_start_command": "",
+        "enable_ssh": true,
+        "ports": null,
+        "space_url": "/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7",
+        "stack_url": "/v2/stacks/ab968358-43eb-4a5b-80e7-351f194028f7",
+        "routes_url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/routes",
+        "events_url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/events",
+        "service_bindings_url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/service_bindings",
+        "route_mappings_url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/route_mappings"
+      }
+    }
+  ]
+}`;
+
+export const services = `{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "9547e9ed-e460-4abe-bda3-7070b9835917",
+        "url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917",
+        "created_at": "2016-06-08T16:41:41Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "name-2104",
+        "credentials": {
+          "creds-key-60": "creds-val-60"
+        },
+        "service_plan_guid": "fcf57f7f-3c51-49b2-b252-dc24e0f7dcab",
+        "space_guid": "f858c6b3-f6b1-4ae8-81dd-8e8747657fbe",
+        "gateway_data": null,
+        "dashboard_url": null,
+        "type": "managed_service_instance",
+        "last_operation": null,
+        "tags": [
+
+        ],
+        "space_url": "/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe",
+        "service_plan_url": "/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab",
+        "service_bindings_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_bindings",
+        "service_keys_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/service_keys",
+        "routes_url": "/v2/service_instances/9547e9ed-e460-4abe-bda3-7070b9835917/routes"
+      }
+    }
+  ]
+}`;
+
+export const users = `{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "uaa-id-245",
+        "url": "/v2/users/uaa-id-245",
+        "created_at": "2016-06-08T16:41:35Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "admin": false,
+        "active": false,
+        "default_space_guid": null,
+        "username": "user@example.com",
+        "spaces_url": "/v2/users/uaa-id-245/spaces",
+        "organizations_url": "/v2/users/uaa-id-245/organizations",
+        "managed_organizations_url": "/v2/users/uaa-id-245/managed_organizations",
+        "billing_managed_organizations_url": "/v2/users/uaa-id-245/billing_managed_organizations",
+        "audited_organizations_url": "/v2/users/uaa-id-245/audited_organizations",
+        "managed_spaces_url": "/v2/users/uaa-id-245/managed_spaces",
+        "audited_spaces_url": "/v2/users/uaa-id-245/audited_spaces"
+      }
+    }
+  ]
+}`;

--- a/src/cf/client.test.js
+++ b/src/cf/client.test.js
@@ -1,0 +1,67 @@
+import {test} from 'tap';
+import nock from 'nock';
+import Client from './client';
+import * as data from './client.test.data';
+
+let client;
+
+test('should create a client correctly', async t => {
+  client = new Client('https://example.com/api', 'qwerty123456');
+
+  nock('https://example.com/api').persist()
+    .get('/v2/info').times(1).reply(200, data.info)
+    .get('/v2/organizations').times(1).reply(200, data.orgs)
+    .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').times(1).reply(200, data.spaces)
+    .get('/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps').times(1).reply(200, data.apps)
+    .get('/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').times(1).reply(200, data.services)
+    .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users').times(1).reply(200, data.users)
+    .get('/v2/test').times(1).reply(200, `{"next_url":"/v2/test?page=2","resources":["a"]}`)
+    .get('/v2/test?page=2').times(1).reply(200, `{"next_url":null,"resources":["b"]}`);
+
+  const info = await client.info();
+
+  t.equal(info.version, 2);
+});
+
+test('should iterate over all pages to gather resources', async t => {
+  const response = await client.request('get', '/v2/test');
+  const data = await client.allResources(response);
+
+  t.equal([...data].length, 2);
+  t.equal(data[1], 'b');
+});
+
+test('should obtain list of organizations', async t => {
+  const orgs = await client.organizations();
+
+  t.ok(orgs.length > 0);
+  t.equal(orgs[0].entity.name, 'the-system_domain-org-name');
+});
+
+test('should obtain list of spaces', async t => {
+  const spaces = await client.spaces('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
+
+  t.ok(spaces.length > 0);
+  t.equal(spaces[0].entity.name, 'name-1774');
+});
+
+test('should obtain list of apps', async t => {
+  const apps = await client.applications('be1f9c1d-e629-488e-a560-a35b545f0ad7');
+
+  t.ok(apps.length > 0);
+  t.equal(apps[0].entity.name, 'name-2131');
+});
+
+test('should obtain list of services', async t => {
+  const services = await client.services('f858c6b3-f6b1-4ae8-81dd-8e8747657fbe');
+
+  t.ok(services.length > 0);
+  t.equal(services[0].entity.name, 'name-2104');
+});
+
+test('should obtain list of users', async t => {
+  const users = await client.users('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
+
+  t.ok(users.length > 0);
+  t.equal(users[0].entity.username, 'user@example.com');
+});

--- a/src/cf/index.js
+++ b/src/cf/index.js
@@ -1,0 +1,2 @@
+export {default as Client} from './client';
+export {default as cfClient} from './middleware';

--- a/src/cf/middleware.js
+++ b/src/cf/middleware.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import Client from './client';
+
+export default function cfClient(config) {
+  const app = express();
+
+  app.use((req, res, next) => {
+    req.cf = new Client(config.cloudFoundryAPI, req.accessToken);
+    next();
+  });
+
+  return app;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -53,7 +53,8 @@ const config = {
   oauthTokenURL: expectEnvVariable('OAUTH_TOKEN_URL'),
   oauthClientID: expectEnvVariable('OAUTH_CLIENT_ID'),
   oauthClientSecret: expectEnvVariable('OAUTH_CLIENT_SECRET'),
-  serverRootURL: process.env.SERVER_ROOT_URL || 'http://localhost:' + (process.env.PORT || '3000')
+  serverRootURL: process.env.SERVER_ROOT_URL || 'http://localhost:' + (process.env.PORT || '3000'),
+  cloudFoundryAPI: expectEnvVariable('API_URL')
 };
 
 main(config).then(onShutdown).catch(onError);

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -8,7 +8,8 @@ const envVars = {
   OAUTH_AUTHORIZATION_URL: 'test',
   OAUTH_TOKEN_URL: 'test',
   OAUTH_CLIENT_ID: 'test',
-  OAUTH_CLIENT_SECRET: 'test'
+  OAUTH_CLIENT_SECRET: 'test',
+  API_URL: 'https://example.com'
 };
 
 t.test('should listen on a random port by default', async t => {

--- a/src/orgs/orgs.js
+++ b/src/orgs/orgs.js
@@ -4,7 +4,11 @@ import orgs from './orgs.njk';
 const app = express();
 
 app.get('/', (req, res) => {
-  res.send(orgs.render({name: req.query.name}));
+  req.cf.organizations()
+    .then(organizations => {
+      res.send(orgs.render({organizations}));
+    })
+    .catch(req.log.error);
 });
 
 export default app;

--- a/src/orgs/orgs.njk
+++ b/src/orgs/orgs.njk
@@ -11,6 +11,7 @@
 
 
 {% block main %}
+  <pre>{{ organizations | dump }}</pre>
   {% if name %}
     {{ govukBackLink({
       "text": "Back",
@@ -18,7 +19,7 @@
     }) }}
     {{ govukPanel({
       "titleText": "Organisation Created!",
-      "text": "Your org is called " + name
+      "text": "Your org is called " + "test"
     }) }}
   {% else %}
     <form action="/orgs" method="get">
@@ -29,7 +30,7 @@
         },
         id: "name-1",
         name: "name",
-        value: name
+        value: "test"
       }) }}
       {{ govukButton({
           "text": "Create org (not really)"

--- a/src/orgs/orgs.test.js
+++ b/src/orgs/orgs.test.js
@@ -1,8 +1,28 @@
 import {test} from 'tap';
+import express from 'express';
+import nock from 'nock';
 import request from 'supertest';
-import app from '.';
+import {Client} from '../cf';
+import {orgs} from '../cf/client.test.data';
+import orgsApp from '.';
 
-test('should show the orgs page', async t => {
+nock('https://example.com').get('/api/v2/organizations').times(1).reply(200, orgs);
+
+const app = express();
+
+app.use((req, res, next) => {
+  req.log = console;
+  next();
+});
+
+app.use((req, res, next) => {
+  req.cf = new Client('https://example.com/api', 'qwerty123456');
+  next();
+});
+
+app.use(orgsApp);
+
+test('should show the orgs pages', async t => {
   const response = await request(app).get('/');
 
   t.equal(response.status, 200);

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,1 @@
+export {default} from './services';

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import servicesTemplate from './services.njk';
+
+const app = express();
+
+app.get('/:space', (req, res) => {
+  req.cf.services(req.params.space)
+    .then(services => {
+      res.send(servicesTemplate.render({services}));
+    })
+    .catch(req.log.error);
+});
+
+export default app;

--- a/src/services/services.njk
+++ b/src/services/services.njk
@@ -1,0 +1,14 @@
+{% extends "../layouts/govuk.njk" %}
+{% from "@govuk-frontend/input/macro.njk" import govukInput %}
+{% from "@govuk-frontend/button/macro.njk" import govukButton %}
+{% from "@govuk-frontend/panel/macro.njk" import govukPanel %}
+{% from "@govuk-frontend/back-link/macro.njk" import govukBackLink %}
+{% from "@govuk-frontend/details/macro.njk" import govukDetails %}
+
+{% block page_title %}
+  Services
+{% endblock %}
+
+{% block main %}
+  <pre>{{ services | dump }}</pre>
+{% endblock %}

--- a/src/services/services.test.js
+++ b/src/services/services.test.js
@@ -1,0 +1,30 @@
+import {test} from 'tap';
+import express from 'express';
+import nock from 'nock';
+import request from 'supertest';
+import {Client} from '../cf';
+import {orgs} from '../cf/client.test.data';
+import orgsApp from '.';
+
+nock('https://example.com').get('/api/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').times(1).reply(200, orgs);
+
+const app = express();
+
+app.use((req, res, next) => {
+  req.log = console;
+  next();
+});
+
+app.use((req, res, next) => {
+  req.cf = new Client('https://example.com/api', 'qwerty123456');
+  next();
+});
+
+app.use(orgsApp);
+
+test('should show the orgs pages', async t => {
+  const response = await request(app).get('/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe');
+
+  t.equal(response.status, 200);
+  t.contains(response.text, 'Services');
+});

--- a/src/spaces/index.js
+++ b/src/spaces/index.js
@@ -1,0 +1,1 @@
+export {default} from './spaces';

--- a/src/spaces/spaces.js
+++ b/src/spaces/spaces.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import spacesTemplate from './spaces.njk';
+
+const app = express();
+
+app.get('/:organization', (req, res) => {
+  req.cf.spaces(req.params.organization)
+    .then(spaces => {
+      res.send(spacesTemplate.render({spaces}));
+    })
+    .catch(req.log.error);
+});
+
+export default app;

--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -1,0 +1,16 @@
+{% extends "../layouts/govuk.njk" %}
+{% from "@govuk-frontend/input/macro.njk" import govukInput %}
+{% from "@govuk-frontend/button/macro.njk" import govukButton %}
+{% from "@govuk-frontend/panel/macro.njk" import govukPanel %}
+{% from "@govuk-frontend/back-link/macro.njk" import govukBackLink %}
+{% from "@govuk-frontend/details/macro.njk" import govukDetails %}
+
+{% block page_title %}
+  Spaces
+{% endblock %}
+
+{% block main %}
+  <pre>{{ spaces | dump }}</pre>
+{% endblock %}
+
+

--- a/src/spaces/spaces.test.js
+++ b/src/spaces/spaces.test.js
@@ -1,0 +1,30 @@
+import {test} from 'tap';
+import express from 'express';
+import nock from 'nock';
+import request from 'supertest';
+import {Client} from '../cf';
+import {spaces} from '../cf/client.test.data';
+import spacesApp from '.';
+
+nock('https://example.com').get('/api/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').times(1).reply(200, spaces);
+
+const app = express();
+
+app.use((req, res, next) => {
+  req.log = console;
+  next();
+});
+
+app.use((req, res, next) => {
+  req.cf = new Client('https://example.com/api', 'qwerty123456');
+  next();
+});
+
+app.use(spacesApp);
+
+test('should show the spaces pages', async t => {
+  const response = await request(app).get('/3deb9f04-b449-4f94-b3dd-c73cefe5b275');
+
+  t.equal(response.status, 200);
+  t.contains(response.text, 'Spaces');
+});


### PR DESCRIPTION
## What


We're going to create our own mini client, that will do all the necessary curl requests for us and return simple values.
The ones available for grabs, are out of date and could go distinct.

We're adding [`axios`](https://github.com/axios/axios) to our dependencies in order to make some requests across the web. We could be using the [`http`](https://nodejs.org/api/http.html) but we'd like to have an ability of promises.

We'd like to test it out by executing a call against the orgs endpoint to gather some data.

We're not doing a templating around it in this story, so these should be purely printing JSON in HTML.

## How to review

- Code review + sanity check
- Decide whether the client is sufficient in the current form
- See if you can obtain orgs under `/orgs` - use Rafal's setup and ask for admin password

## Who can review

Neither @camelpunch nor myself.