### PR TITLE
Make the Auth middleware check for expired token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,6 +1545,12 @@
       "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
       "dev": true
     },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -1791,6 +1797,12 @@
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -3822,6 +3834,16 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
+      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "dev": true,
+      "requires": {
+        "base64url": "2.0.0",
+        "safe-buffer": "5.1.1"
       }
     },
     "editions": {
@@ -7373,6 +7395,32 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.0.tgz",
+      "integrity": "sha512-1Wxh8ADP3cNyPl8tZ95WtraHXCAyXupgc0AhMHjU9er98BV+UcKsO7OJUjfhIu0Uba9A40n1oSx8dbJYrm+EoQ==",
+      "dev": true,
+      "requires": {
+        "jws": "3.1.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -7391,6 +7439,29 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
+      }
+    },
+    "jwa": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "dev": true,
+      "requires": {
+        "base64url": "2.0.0",
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.9",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "dev": true,
+      "requires": {
+        "base64url": "2.0.0",
+        "jwa": "1.1.5",
+        "safe-buffer": "5.1.1"
       }
     },
     "keygrip": {
@@ -7812,10 +7883,46 @@
       "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
     "lodash.kebabcase": {
@@ -7834,6 +7941,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
+      "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
     "lodash.reduce": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "helmet": "3.10.0",
     "html-loader": "0.5.5",
     "istanbul-instrumenter-loader": "3.0.0",
+    "jsonwebtoken": "8.2.0",
     "loader-utils": "1.1.0",
     "nock": "9.1.6",
     "node-sass": "4.7.2",

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -32,13 +32,7 @@ export default function authentication(config) {
   app.get('/auth/login', passport.authenticate('oauth2'));
 
   app.get('/auth/login/callback', passport.authenticate('oauth2'), (req, res) => {
-    const redirection = req.session.returnTo;
-    delete req.session.returnTo;
-
-    res.redirect(redirection || '/');
-    req.log.info({
-      returnTo: redirection
-    }, `Authentication successful, redirecting back to ${redirection}`);
+    res.redirect('/');
   });
 
   app.get('/auth/logout', (req, res) => {
@@ -68,10 +62,7 @@ export default function authentication(config) {
       next();
     } else {
       req.session = null;
-      const fullUrl = req.protocol + '://' + req.get('host') + req.path;
-      req.session.returnTo = fullUrl;
       res.redirect('/auth/login');
-      req.log.info(`Performing authentication for ${fullUrl}.`);
     }
   });
 

--- a/src/auth/auth.test.js
+++ b/src/auth/auth.test.js
@@ -72,7 +72,7 @@ test('can login with a code', async t => {
     const response = await agent.get('/auth/login/callback?code=__fakecode&state=__fakestate');
 
     t.equal(response.status, 302);
-    t.contains(response.header.location, '/test');
+    t.contains(response.header.location, '/');
   });
 
   await t.test('can reach an endpoint behind authentication', async t => {

--- a/src/auth/auth.test.js
+++ b/src/auth/auth.test.js
@@ -1,5 +1,6 @@
 import {test} from 'tap';
 import express from 'express';
+import jwt from 'jsonwebtoken';
 import cookieSession from 'cookie-session';
 import request from 'supertest';
 import pino from 'pino';
@@ -43,15 +44,18 @@ test('the login page redirects to the authorize endpoint of the IDP', async t =>
 });
 
 test('can login with a code', async t => {
+  const time = Math.floor(Date.now() / 1000);
+  const token = jwt.sign({foo: 'bar', exp: (time + (24 * 60 * 60))}, 'shhhhh');
+
   // Capture the request to the given URL and prepare a response.
   nock('https://example.com')
     .post('/token')
     .times(1)
     .reply(200, {
-      access_token: '__access_token__', // eslint-disable-line camelcase
+      access_token: token, // eslint-disable-line camelcase
       token_type: 'bearer', // eslint-disable-line camelcase
       refresh_token: '__refresh_token__', // eslint-disable-line camelcase
-      expires_in: 43199, // eslint-disable-line camelcase
+      expires_in: (24 * 60 * 60), // eslint-disable-line camelcase
       scope: 'openid oauth.approvals',
       jti: '__jti__'
     });
@@ -89,5 +93,34 @@ test('can login with a code', async t => {
 
     t.equal(response.status, 302);
     t.equal(response.header.location, '/auth/login');
+  });
+});
+
+test('when faulty token is returned', async t => {
+  const agent = request.agent(app);
+
+  // Capture the request to the given URL and prepare a response.
+  nock('https://example.com')
+    .post('/token')
+    .times(1)
+    .reply(200, {
+      access_token: '__access_token__', // eslint-disable-line camelcase
+      token_type: 'bearer', // eslint-disable-line camelcase
+      refresh_token: '__refresh_token__', // eslint-disable-line camelcase
+      expires_in: (24 * 60 * 60), // eslint-disable-line camelcase
+      scope: 'openid oauth.approvals',
+      jti: '__jti__'
+    });
+
+  await t.test('should authenticate successfully', async t => {
+    const response = await agent.get('/auth/login/callback?code=__fakecode__&state=__fakestate__');
+
+    t.equal(response.status, 302);
+  });
+
+  await t.test('should be redirected to login due to faulty token', async t => {
+    const response = await agent.get('/test');
+
+    t.equal(response.status, 302);
   });
 });


### PR DESCRIPTION
## What

It turns out Passport has no idea we're dealing with JWT, meaning we
have to handle checking the expiration ourselves.

We're adding `jsonwebtoken` as a dependency for quick and easy decoding
of a token on a fly. It doesn't unfortunately allow us to validate the
token as it requires a secret to be fully verified.

Instead, we're decoding the Token and manually comparing the timestamp
with the current one to see if we've expired or good to go.

If the token has expired, we're going to kick the user back to the login
page for re-authentication.

## How to review

- Code sanity check
- Run tests (should be run by travis)
- Optionally log in to the app and wait (whatever it is) for the token to expire and see the action
