### PR TITLE
[#154558816] Add organisation templates

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -8,7 +8,7 @@ import staticGzip from 'express-static-gzip';
 import auth from '../auth';
 import home from '../home';
 import {cfClient} from '../cf';
-import orgs from '../orgs';
+import organizations from '../organizations';
 import spaces from '../spaces';
 import applications from '../applications';
 import services from '../services';
@@ -40,7 +40,7 @@ export default function (config) {
   app.use(auth(config));
   app.use(cfClient(config));
 
-  app.use('/orgs', orgs);
+  app.use('/organisations', organizations);
   app.use('/spaces', spaces);
   app.use('/applications', applications);
   app.use('/services', services);

--- a/src/app/app.test.js
+++ b/src/app/app.test.js
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken';
 import request from 'supertest';
 import pino from 'pino';
 import nock from 'nock';
-import {orgs} from '../cf/client.test.data';
+import {organizations} from '../cf/client.test.data';
 import init from '.';
 
 const logger = pino({}, Buffer.from([]));
@@ -47,7 +47,7 @@ test('should gzip responses', async t => {
 });
 
 test('should redirect to oauth provider for auth', async t => {
-  const response = await request(app).get('/orgs');
+  const response = await request(app).get('/organisations');
 
   t.equal(response.status, 302);
 });
@@ -83,10 +83,10 @@ test('when authenticated', async t => {
     t.contains(response.header['set-cookie'][0], 'pazmin-session');
   });
 
-  nock('https://example.com').get('/api/v2/organizations').times(1).reply(200, orgs);
+  nock('https://example.com').get('/api/v2/organizations').times(1).reply(200, organizations);
 
-  await t.test('should return orgs', async t => {
-    const response = await agent.get('/orgs');
+  await t.test('should return organisations', async t => {
+    const response = await agent.get('/organisations');
 
     t.equal(response.status, 200);
   });
@@ -124,7 +124,7 @@ test('when token expires', async t => {
   });
 
   await t.test('should be redirected to login due to expired token', async t => {
-    const response = await agent.get('/orgs');
+    const response = await agent.get('/organisations');
 
     t.equal(response.status, 302);
   });

--- a/src/applications/applications.test.js
+++ b/src/applications/applications.test.js
@@ -22,7 +22,7 @@ app.use((req, res, next) => {
 
 app.use(applicationsApp);
 
-test('should show the orgs pages', async t => {
+test('should show the organisations pages', async t => {
   const response = await request(app).get('/be1f9c1d-e629-488e-a560-a35b545f0ad7');
 
   t.equal(response.status, 200);

--- a/src/cf/client.test.data.js
+++ b/src/cf/client.test.data.js
@@ -16,7 +16,7 @@ export const info = `{
   "logging_endpoint": "ws://loggregator.vcap.me:80"
 }`;
 
-export const orgs = `{
+export const organizations = `{
   "total_results": 1,
   "total_pages": 1,
   "prev_url": null,

--- a/src/cf/client.test.js
+++ b/src/cf/client.test.js
@@ -10,7 +10,7 @@ test('should create a client correctly', async t => {
 
   nock('https://example.com/api').persist()
     .get('/v2/info').times(1).reply(200, data.info)
-    .get('/v2/organizations').times(1).reply(200, data.orgs)
+    .get('/v2/organizations').times(1).reply(200, data.organizations)
     .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').times(1).reply(200, data.spaces)
     .get('/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps').times(1).reply(200, data.apps)
     .get('/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').times(1).reply(200, data.services)
@@ -32,11 +32,11 @@ test('should iterate over all pages to gather resources', async t => {
   t.equal(data[1], 'b');
 });
 
-test('should obtain list of organizations', async t => {
-  const orgs = await client.organizations();
+test('should obtain list of organisations', async t => {
+  const organizations = await client.organizations();
 
-  t.ok(orgs.length > 0);
-  t.equal(orgs[0].entity.name, 'the-system_domain-org-name');
+  t.ok(organizations.length > 0);
+  t.equal(organizations[0].entity.name, 'the-system_domain-org-name');
 });
 
 test('should obtain list of spaces', async t => {

--- a/src/home/home.njk
+++ b/src/home/home.njk
@@ -18,16 +18,16 @@
   </h3>
   <ul class="govuk-list">
     <li>
-      <a class="govuk-link" href="/orgs">View your organisations</a>
+      <a class="govuk-link" href="/organisations">View your organisations</a>
     </li>
     <li>
-      <a class="govuk-link" href="/orgs">View your spaces</a>
+      <a class="govuk-link" href="/organisations">View your spaces</a>
     </li>
     <li>
-      <a class="govuk-link" href="/orgs">Reset your password</a>
+      <a class="govuk-link" href="/organisations">Reset your password</a>
     </li>
     <li>
-      <a class="govuk-link" href="/orgs">Add a user</a>
+      <a class="govuk-link" href="/organisations">Add a user</a>
     </li>
   </ul>
 {% endblock %}

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -4,7 +4,7 @@
 
 {% set logo_link_title = 'Go to the GOV.UK PaaS Admin Tool Homepage' %}
 
-{% block page_title %}GDS Node.js boilerplate{% endblock %}
+{% block page_title %}PaaS Administration{% endblock %}
 
 {% block head %}
   <link href="./govuk.screen.scss" media="screen" rel="stylesheet" type="text/css" />
@@ -26,6 +26,10 @@
 {% block content %}
   <div class="govuk-o-width-container">
     <main class="govuk-o-main-wrapper">
+    <h1 class="govuk-heading-l">
+      {% block title %}
+      {% endblock %}
+    </h1>
       {% block main %}
         No content rendered to 'main' block
       {% endblock %}

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -1,2 +1,2 @@
 @import '~@govuk-frontend/all/all';
-
+@import 'navigationPanel/_navigationPanel.scss';

--- a/src/layouts/navigationPanel/_navigationPanel.scss
+++ b/src/layouts/navigationPanel/_navigationPanel.scss
@@ -1,0 +1,36 @@
+.admin-c-panel--link {
+	text-decoration: none;
+}
+
+.admin-c-panel {
+    @include govuk-font-regular-16;
+
+    -webkit-box-sizing: border-box;
+
+            box-sizing: border-box;
+
+    margin-bottom: $govuk-spacing-scale-3;
+    padding: $govuk-spacing-scale-4 - $govuk-border-width;
+
+    border: $govuk-border-width solid transparent;
+
+    @include mq($until: tablet) {
+      padding: $govuk-spacing-scale-6 - $govuk-border-width;
+    }
+  }
+
+  .admin-c-panel--navigation {
+    color: $govuk-white;
+    background: $govuk-blue;
+  }
+
+  .admin-c-panel__title {
+    margin-top: 0;
+    margin-bottom: $govuk-spacing-scale-6;
+
+    @include govuk-font-bold-24;
+  }
+
+  .admin-c-panel__body {
+    @include govuk-font-regular-16;
+  }

--- a/src/layouts/navigationPanel/macro.njk
+++ b/src/layouts/navigationPanel/macro.njk
@@ -1,0 +1,3 @@
+{% macro navigationPanel(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/layouts/navigationPanel/template.njk
+++ b/src/layouts/navigationPanel/template.njk
@@ -1,0 +1,13 @@
+<a class="admin-c-panel__link" href="{{ params.link }}">
+  <div class="admin-c-panel admin-c-panel--navigation">
+    <h2 class="admin-c-panel__title">
+      {{ params.titleText }}
+    </h2>
+    <ul class="admin-c-panel__body">
+    	<li>View spaces in the org</li>
+    	<li>View apps within spaces</li>
+    	<li>View org and space memory quotas</li>
+    	<li>Manage team members</li>
+    </ul>
+  </div>
+</a>

--- a/src/organizations/index.js
+++ b/src/organizations/index.js
@@ -1,0 +1,1 @@
+export {default} from './organizations';

--- a/src/organizations/organizations.js
+++ b/src/organizations/organizations.js
@@ -1,12 +1,12 @@
 import express from 'express';
-import orgs from './orgs.njk';
+import organizationsTemplate from './organizations.njk';
 
 const app = express();
 
 app.get('/', (req, res) => {
   req.cf.organizations()
     .then(organizations => {
-      res.send(orgs.render({organizations}));
+      res.send(organizationsTemplate.render({organizations}));
     })
     .catch(req.log.error);
 });

--- a/src/organizations/organizations.njk
+++ b/src/organizations/organizations.njk
@@ -6,7 +6,7 @@
 {% from "../layouts/navigationPanel/macro.njk" import navigationPanel %}
 
 {% block page_title %}
-  Orgs
+  Organisations
 {% endblock %}
 
 {% block title %}

--- a/src/organizations/organizations.test.js
+++ b/src/organizations/organizations.test.js
@@ -3,10 +3,10 @@ import express from 'express';
 import nock from 'nock';
 import request from 'supertest';
 import {Client} from '../cf';
-import {orgs} from '../cf/client.test.data';
-import orgsApp from '.';
+import {organizations} from '../cf/client.test.data';
+import organizationsApp from '.';
 
-nock('https://example.com').get('/api/v2/organizations').times(1).reply(200, orgs);
+nock('https://example.com').get('/api/v2/organizations').times(1).reply(200, organizations);
 
 const app = express();
 
@@ -20,9 +20,9 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use(orgsApp);
+app.use(organizationsApp);
 
-test('should show the orgs pages', async t => {
+test('should show the organisation pages', async t => {
   const response = await request(app).get('/');
 
   t.equal(response.status, 200);

--- a/src/orgs/index.js
+++ b/src/orgs/index.js
@@ -1,1 +1,0 @@
-export {default} from './orgs';

--- a/src/orgs/orgs.njk
+++ b/src/orgs/orgs.njk
@@ -3,44 +3,25 @@
 {% from "@govuk-frontend/button/macro.njk" import govukButton %}
 {% from "@govuk-frontend/panel/macro.njk" import govukPanel %}
 {% from "@govuk-frontend/back-link/macro.njk" import govukBackLink %}
-{% from "@govuk-frontend/details/macro.njk" import govukDetails %}
+{% from "../layouts/navigationPanel/macro.njk" import navigationPanel %}
 
 {% block page_title %}
   Orgs
 {% endblock %}
 
-
-{% block main %}
-  <pre>{{ organizations | dump }}</pre>
-  {% if name %}
-    {{ govukBackLink({
-      "text": "Back",
-      "href": "/orgs"
-    }) }}
-    {{ govukPanel({
-      "titleText": "Organisation Created!",
-      "text": "Your org is called " + "test"
-    }) }}
-  {% else %}
-    <form action="/orgs" method="get">
-      {{ govukInput({
-        label: {
-          "text": "Organisation Name",
-          "hintText": "It should probably be something cool"
-        },
-        id: "name-1",
-        name: "name",
-        value: "test"
-      }) }}
-      {{ govukButton({
-          "text": "Create org (not really)"
-      }) }}
-      {{ govukDetails({
-        "summaryText": "Help with ducks",
-        "text": "We need to know your favourite duck name so we can work out which duck benefits you’re entitled to. If you can’t provide your duck name, you’ll have to send copies of duck identity documents through the post."
-      }) }}
-    </form>
-  {% endif %}
+{% block title %}
+  Welcome to GOV.UK PaaS
 {% endblock %}
-
-
+{% block main %}
+  <h2 class="govuk-heading-m">Choose an organisation</h2>
+  <div class="govuk-o-grid">
+    {% for organization in organizations %}
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
+        {{ navigationPanel({
+          titleText: organization.entity.name,
+          link: "/spaces/" + organization.metadata.guid
+        }) }}
+      </div>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/src/orgs/orgs.test.js
+++ b/src/orgs/orgs.test.js
@@ -26,5 +26,5 @@ test('should show the orgs pages', async t => {
   const response = await request(app).get('/');
 
   t.equal(response.status, 200);
-  t.contains(response.text, 'Create org');
+  t.contains(response.text, 'Choose an organisation');
 });

--- a/src/services/services.test.js
+++ b/src/services/services.test.js
@@ -3,10 +3,10 @@ import express from 'express';
 import nock from 'nock';
 import request from 'supertest';
 import {Client} from '../cf';
-import {orgs} from '../cf/client.test.data';
-import orgsApp from '.';
+import {organizations} from '../cf/client.test.data';
+import organizationsApp from '.';
 
-nock('https://example.com').get('/api/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').times(1).reply(200, orgs);
+nock('https://example.com').get('/api/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').times(1).reply(200, organizations);
 
 const app = express();
 
@@ -20,9 +20,9 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use(orgsApp);
+app.use(organizationsApp);
 
-test('should show the orgs pages', async t => {
+test('should show the organisations pages', async t => {
   const response = await request(app).get('/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe');
 
   t.equal(response.status, 200);


### PR DESCRIPTION
## What

Add template for showing organisations using the GOV.UK design system.  Use design system for title and fonts.

We may want a path for having no organisations and will probably want to look at this later.

First pass at creating new component for navigation panel on this page as it does not exist in the design system.  As this is specific to our app we will keep it here for now.  Roughly following the pattern of the design system for this component.  However some more work needs to be done on it to ensure that it's accessible and that the structure of it is reasonable.  It also needs a readme to describe more thoroughly what it is.  We might want to write tests around this as well.

Usually on frontend pull requests it's useful to put a before and after to see what the changes are.  There is no before for this page so putting in a screenshot of how it looks now.

<img width="980" alt="screen shot 2018-03-08 at 15 18 07" src="https://user-images.githubusercontent.com/11633362/37159011-a403c1aa-22e4-11e8-91e6-841c8a83e9fd.png">


## How to review

Code review, run the application, look at it.

## Who can review

Anyone but me, @paroxp, @camelpunch 
