### PR TITLE
[#154558816] Organisation overview

### DIFF
--- a/src/app/sync-handler.js
+++ b/src/app/sync-handler.js
@@ -1,0 +1,7 @@
+import {internalServerErrorMiddleware} from '../errors';
+
+export default function syncHandler(f) {
+  return (req, res) => {
+    f(req, res).catch(err => internalServerErrorMiddleware(err, req, res));
+  };
+}

--- a/src/app/sync-handler.test.js
+++ b/src/app/sync-handler.test.js
@@ -1,0 +1,42 @@
+import {test} from 'tap';
+import express from 'express';
+import request from 'supertest';
+import pino from 'pino';
+import pinoMiddleware from 'express-pino-logger';
+import {internalServerErrorMiddleware} from '../errors';
+import syncHandler from './sync-handler';
+
+const logger = pino({}, Buffer.from([]));
+
+const app = express();
+
+app.use(pinoMiddleware(logger));
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+app.get('/failure', syncHandler(async () => {
+  throw new Error('failure');
+}));
+
+app.get('/success', syncHandler(async (req, res) => {
+  await sleep(10);
+  res.send('success');
+}));
+
+app.use(internalServerErrorMiddleware);
+
+test('should fail to resolve async function for route', async t => {
+  const response = await request(app).get('/failure');
+
+  t.equal(response.status, 500);
+  t.contains(response.text, 'Internal Server Error');
+});
+
+test('should resolve async function correctly', async t => {
+  const response = await request(app).get('/success');
+
+  t.equal(response.status, 200);
+  t.contains(response.text, 'success');
+});

--- a/src/cf/client.js
+++ b/src/cf/client.js
@@ -51,9 +51,29 @@ export default class Client {
     return this.allResources(response);
   }
 
-  async spaces(organization) {
-    const response = await this.request('get', `/v2/organizations/${organization}/spaces`);
+  async organization(organizationGUID) {
+    const response = await this.request('get', `/v2/organizations/${organizationGUID}`);
+    return response.data;
+  }
+
+  async organizationQuota(quotaGUID) {
+    const response = await this.request('get', `/v2/quota_definitions/${quotaGUID}`);
+    return response.data;
+  }
+
+  async spaces(organizationGUID) {
+    const response = await this.request('get', `/v2/organizations/${organizationGUID}/spaces`);
     return this.allResources(response);
+  }
+
+  async space(spaceGUID) {
+    const response = await this.request('get', `/v2/spaces/${spaceGUID}/summary`);
+    return response.data;
+  }
+
+  async spaceQuota(quotaGUID) {
+    const response = await this.request('get', `/v2/space_quota_definitions/${quotaGUID}`);
+    return response.data;
   }
 
   async spacesForUserInOrganization(user, organization) {

--- a/src/cf/client.js
+++ b/src/cf/client.js
@@ -22,7 +22,7 @@ export default class Client {
       return await this._request(method, url, data, params);
     } catch (err) {
       if (err.response && err.response.data && err.response.data.description) {
-        throw new Error(err.response.data.description);
+        throw new Error(`${url}: ${err.response.data.description}`);
       }
       throw err;
     }
@@ -67,6 +67,11 @@ export default class Client {
   }
 
   async space(spaceGUID) {
+    const response = await this.request('get', `/v2/spaces/${spaceGUID}`);
+    return response.data;
+  }
+
+  async spaceSummary(spaceGUID) {
     const response = await this.request('get', `/v2/spaces/${spaceGUID}/summary`);
     return response.data;
   }
@@ -81,9 +86,14 @@ export default class Client {
     return this.allResources(response);
   }
 
-  async applications(space) {
-    const response = await this.request('get', `/v2/spaces/${space}/apps`);
+  async applications(spaceGUID) {
+    const response = await this.request('get', `/v2/spaces/${spaceGUID}/apps`);
     return this.allResources(response);
+  }
+
+  async applicationSummary(applicationGUID) {
+    const response = await this.request('get', `/v2/apps/${applicationGUID}/summary`);
+    return response.data;
   }
 
   async services(space) {

--- a/src/cf/client.js
+++ b/src/cf/client.js
@@ -6,7 +6,7 @@ export default class Client {
     this.accessToken = accessToken;
   }
 
-  request(method, url, data, params) {
+  _request(method, url, data, params) {
     return axios.request({
       url,
       method,
@@ -15,6 +15,17 @@ export default class Client {
       params,
       headers: {Authorization: `Bearer ${this.accessToken}`}
     });
+  }
+
+  async request(method, url, data, params) {
+    try {
+      return await this._request(method, url, data, params);
+    } catch (err) {
+      if (err.response && err.response.data && err.response.data.description) {
+        throw new Error(err.response.data.description);
+      }
+      throw err;
+    }
   }
 
   async allResources(response) {

--- a/src/cf/client.test.data.js
+++ b/src/cf/client.test.data.js
@@ -159,6 +159,33 @@ export const spaces = `{
 }`;
 
 export const space = `{
+  "metadata": {
+    "guid": "bc8d3381-390d-4bd7-8c71-25309900a2e3",
+    "url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3",
+    "created_at": "2016-06-08T16:41:40Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "name-2064",
+    "organization_guid": "6e1ca5aa-55f1-4110-a97f-1f3473e771b9",
+    "space_quota_definition_guid": null,
+    "allow_ssh": true,
+    "organization_url": "/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9",
+    "developers_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/developers",
+    "managers_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/managers",
+    "auditors_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/auditors",
+    "apps_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/apps",
+    "routes_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/routes",
+    "domains_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/domains",
+    "service_instances_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/service_instances",
+    "app_events_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/app_events",
+    "events_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/events",
+    "security_groups_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/security_groups",
+    "staging_security_groups_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/staging_security_groups"
+  }
+}`;
+
+export const spaceSummary = `{
   "guid": "50ae42f6-346d-4eca-9e97-f8c9e04d5fbe",
   "name": "name-1382",
   "apps": [
@@ -328,6 +355,94 @@ export const apps = `{
       }
     }
   ]
+}`;
+
+export const appSummary = `{
+  "guid": "cd897c8c-3171-456d-b5d7-3c87feeabbd1",
+  "name": "name-79",
+  "routes": [
+    {
+      "guid": "2d642293-7448-45c6-a864-937c77b9c09a",
+      "host": "host-1",
+      "port": null,
+      "path": "",
+      "domain": {
+        "guid": "02e200d3-5b18-497b-aafd-17fc3bece05f",
+        "name": "domain-1.example.com"
+      }
+    }
+  ],
+  "running_instances": 0,
+  "services": [
+    {
+      "guid": "307f8c47-7796-4d90-bd40-6a56764e37b3",
+      "name": "name-82",
+      "bound_app_count": 1,
+      "last_operation": null,
+      "dashboard_url": null,
+      "service_plan": {
+        "guid": "a7229730-4c4a-418c-a449-9d9f1f2fb3c2",
+        "name": "name-83",
+        "service": {
+          "guid": "724a9245-900e-47cb-b924-0a7a98dea977",
+          "label": "label-1",
+          "provider": null,
+          "version": null
+        }
+      }
+    }
+  ],
+  "available_domains": [
+    {
+      "guid": "02e200d3-5b18-497b-aafd-17fc3bece05f",
+      "name": "domain-1.example.com",
+      "owning_organization_guid": "58a46adc-2e73-4f9c-b7ba-5e72e875cd18"
+    },
+    {
+      "guid": "f067af33-4141-4e69-bbd5-d7b3e01140fa",
+      "name": "customer-app-domain1.com",
+      "router_group_guid": null,
+      "router_group_type": null
+    },
+    {
+      "guid": "ccdb1696-d3e3-4786-a9c1-11bc64b2090a",
+      "name": "customer-app-domain2.com",
+      "router_group_guid": null,
+      "router_group_type": null
+    }
+  ],
+  "production": false,
+  "space_guid": "1053174d-eb79-4f16-bf82-9f83a52d6e84",
+  "stack_guid": "aff73b55-7767-4928-b0ce-502cca863be0",
+  "buildpack": null,
+  "detected_buildpack": null,
+  "detected_buildpack_guid": null,
+  "environment_json": null,
+  "memory": 1024,
+  "instances": 1,
+  "disk_quota": 1024,
+  "state": "STOPPED",
+  "version": "d457b51a-d7cb-494d-b39e-3171ec75bd60",
+  "command": null,
+  "console": false,
+  "debug": null,
+  "staging_task_id": null,
+  "package_state": "PENDING",
+  "health_check_http_endpoint": "",
+  "health_check_type": "port",
+  "health_check_timeout": null,
+  "staging_failed_reason": null,
+  "staging_failed_description": null,
+  "diego": false,
+  "docker_image": null,
+  "docker_credentials": {
+   "username": null,
+   "password": null
+  },
+  "package_updated_at": "2016-06-08T16:41:22Z",
+  "detected_start_command": "",
+  "enable_ssh": true,
+  "ports": null
 }`;
 
 export const services = `{

--- a/src/cf/client.test.data.js
+++ b/src/cf/client.test.data.js
@@ -49,12 +49,86 @@ export const organizations = `{
   ]
 }`;
 
+export const organization = `{
+  "metadata": {
+    "guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+    "url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+    "created_at": "2016-06-08T16:41:33Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "the-system_domain-org-name",
+    "billing_enabled": false,
+    "quota_definition_guid": "dcb680a9-b190-4838-a3d2-b84aa17517a6",
+    "status": "active",
+    "quota_definition_url": "/v2/quota_definitions/dcb680a9-b190-4838-a3d2-b84aa17517a6",
+    "spaces_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/spaces",
+    "domains_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/domains",
+    "private_domains_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/private_domains",
+    "users_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/users",
+    "managers_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/managers",
+    "billing_managers_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/billing_managers",
+    "auditors_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/auditors",
+    "app_events_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/app_events",
+    "space_quota_definitions_url": "/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/space_quota_definitions"
+  }
+}`;
+
+export const organizationQuota = `{
+  "metadata": {
+    "guid": "80f3e539-a8c0-4c43-9c72-649df53da8cb",
+    "url": "/v2/quota_definitions/80f3e539-a8c0-4c43-9c72-649df53da8cb",
+    "created_at": "2016-06-08T16:41:39Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "name-1996",
+    "non_basic_services_allowed": true,
+    "total_services": 60,
+    "total_routes": 1000,
+    "total_private_domains": -1,
+    "memory_limit": 20480,
+    "trial_db_allowed": false,
+    "instance_memory_limit": -1,
+    "app_instance_limit": -1,
+    "app_task_limit": -1,
+    "total_service_keys": -1,
+    "total_reserved_route_ports": 5
+  }
+}`;
+
 export const spaces = `{
   "total_results": 1,
   "total_pages": 1,
   "prev_url": null,
   "next_url": null,
   "resources": [
+    {
+      "metadata": {
+        "guid": "5489e195-c42b-4e61-bf30-323c331ecc01",
+        "url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01",
+        "created_at": "2016-06-08T16:41:35Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "name-1774",
+        "organization_guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275",
+        "space_quota_definition_guid": "a9097bc8-c6cf-4a8f-bc47-623fa22e8019",
+        "allow_ssh": true,
+        "organization_url": "/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275",
+        "developers_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers",
+        "managers_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers",
+        "auditors_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors",
+        "apps_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/apps",
+        "routes_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/routes",
+        "domains_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/domains",
+        "service_instances_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/service_instances",
+        "app_events_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/app_events",
+        "events_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/events",
+        "security_groups_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/security_groups",
+        "staging_security_groups_url": "/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/staging_security_groups"
+      }
+    },
     {
       "metadata": {
         "guid": "5489e195-c42b-4e61-bf30-323c331ecc01",
@@ -82,6 +156,122 @@ export const spaces = `{
       }
     }
   ]
+}`;
+
+export const space = `{
+  "guid": "50ae42f6-346d-4eca-9e97-f8c9e04d5fbe",
+  "name": "name-1382",
+  "apps": [
+    {
+      "guid": "c49aac23-e26c-4564-ba1a-0b0bdcff1387",
+      "urls": [
+        "host-7.domain-7.example.com"
+      ],
+      "routes": [
+        {
+          "guid": "9b593acf-f617-4713-b9cf-c959aa2e3276",
+          "host": "host-7",
+          "port": null,
+          "path": "",
+          "domain": {
+            "guid": "97b03bcb-db5d-4923-8b02-662c490fc2ac",
+            "name": "domain-7.example.com"
+          }
+        }
+      ],
+      "service_count": 1,
+      "service_names": [
+        "name-1385"
+      ],
+      "running_instances": 0,
+      "name": "name-1388",
+      "production": false,
+      "space_guid": "50ae42f6-346d-4eca-9e97-f8c9e04d5fbe",
+      "stack_guid": "8d4152c3-d2bb-44ac-9036-b2a8c95f24ef",
+      "buildpack": null,
+      "detected_buildpack": null,
+      "detected_buildpack_guid": null,
+      "environment_json": null,
+      "memory": 1024,
+      "instances": 1,
+      "disk_quota": 1024,
+      "state": "STOPPED",
+      "version": "a93316d0-dcd0-43c2-9569-624af35a61bd",
+      "command": null,
+      "console": false,
+      "debug": null,
+      "staging_task_id": null,
+      "package_state": "PENDING",
+      "health_check_type": "port",
+      "health_check_timeout": null,
+      "staging_failed_reason": null,
+      "staging_failed_description": null,
+      "diego": false,
+      "docker_image": null,
+      "docker_credentials": {
+        "username": null,
+        "password": null
+      },
+      "package_updated_at": "2016-06-08T16:41:28Z",
+      "detected_start_command": "",
+      "enable_ssh": true,
+      "ports": null
+    }
+  ],
+  "services": [
+    {
+      "guid": "5cf08d8b-848c-4f27-bd92-8080fa021783",
+      "name": "name-1385",
+      "bound_app_count": 1,
+      "shared_from": {
+        "space_guid": "c4861ea6-fc27-4a20-ad21-461743ce8921",
+        "space_name": "source-space",
+        "organization_name": "source-org"
+      },
+      "last_operation": {
+        "type": "create",
+        "state": "succeeded",
+        "description": "description goes here",
+        "updated_at": "2016-06-08T16:41:28Z",
+        "created_at": "2016-06-08T16:41:28Z"
+      },
+      "dashboard_url": null,
+      "service_plan": {
+        "guid": "0f8ad3ee-ca65-4849-ae52-d6539392fae2",
+        "name": "name-1386",
+        "service": {
+          "guid": "17752c54-ac25-46fb-9989-3f69017d0dbe",
+          "label": "label-27",
+          "provider": null,
+          "version": null
+        }
+      }
+    }
+  ]
+}`;
+
+export const spaceQuota = `{
+  "metadata": {
+    "guid": "a9097bc8-c6cf-4a8f-bc47-623fa22e8019",
+    "url": "/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "name-1491",
+    "organization_guid": "a065dfc7-3aed-4438-a6af-b1f42d9a4ed4",
+    "non_basic_services_allowed": true,
+    "total_services": 60,
+    "total_routes": 1000,
+    "memory_limit": 20480,
+    "instance_memory_limit": -1,
+    "app_instance_limit": -1,
+    "app_task_limit": 5,
+    "total_service_keys": 600,
+    "total_reserved_route_ports": -1,
+    "organization_url": "/v2/organizations/a065dfc7-3aed-4438-a6af-b1f42d9a4ed4",
+    "spaces_url": "/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019/spaces"
+  }
 }`;
 
 export const apps = `{

--- a/src/cf/client.test.js
+++ b/src/cf/client.test.js
@@ -15,7 +15,9 @@ test('should create a client correctly', async t => {
     .get('/v2/quota_definitions/80f3e539-a8c0-4c43-9c72-649df53da8cb').times(1).reply(200, data.organizationQuota)
     .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').times(1).reply(200, data.spaces)
     .get('/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps').times(1).reply(200, data.apps)
-    .get('/v2/spaces/50ae42f6-346d-4eca-9e97-f8c9e04d5fbe/summary').times(1).reply(200, data.space)
+    .get('/v2/apps/cd897c8c-3171-456d-b5d7-3c87feeabbd1/summary').times(1).reply(200, data.appSummary)
+    .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3').times(1).reply(200, data.space)
+    .get('/v2/spaces/50ae42f6-346d-4eca-9e97-f8c9e04d5fbe/summary').times(1).reply(200, data.spaceSummary)
     .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').times(1).reply(200, data.spaceQuota)
     .get('/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').times(1).reply(200, data.services)
     .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').times(1).reply(200, data.spaces)
@@ -42,7 +44,7 @@ test('should throw an error when receiving 404', async t => {
   try {
     await client.request('get', '/v2/failure');
   } catch (err) {
-    t.equal(err.message, 'TEST');
+    t.contains(err.message, 'TEST');
   }
 });
 
@@ -81,7 +83,13 @@ test('should obtain list of spaces', async t => {
 });
 
 test('should obtain single space', async t => {
-  const space = await client.space('50ae42f6-346d-4eca-9e97-f8c9e04d5fbe');
+  const space = await client.space('bc8d3381-390d-4bd7-8c71-25309900a2e3');
+
+  t.equal(space.entity.name, 'name-2064');
+});
+
+test('should obtain single space', async t => {
+  const space = await client.spaceSummary('50ae42f6-346d-4eca-9e97-f8c9e04d5fbe');
 
   t.equal(space.name, 'name-1382');
 });
@@ -104,6 +112,12 @@ test('should obtain list of apps', async t => {
 
   t.ok(apps.length > 0);
   t.equal(apps[0].entity.name, 'name-2131');
+});
+
+test('should obtain app summary', async t => {
+  const app = await client.applicationSummary('cd897c8c-3171-456d-b5d7-3c87feeabbd1');
+
+  t.equal(app.name, 'name-79');
 });
 
 test('should obtain list of services', async t => {

--- a/src/cf/client.test.js
+++ b/src/cf/client.test.js
@@ -11,11 +11,17 @@ test('should create a client correctly', async t => {
   nock('https://example.com/api').persist()
     .get('/v2/info').times(1).reply(200, data.info)
     .get('/v2/organizations').times(1).reply(200, data.organizations)
+    .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20').times(1).reply(200, data.organization)
+    .get('/v2/quota_definitions/80f3e539-a8c0-4c43-9c72-649df53da8cb').times(1).reply(200, data.organizationQuota)
     .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').times(1).reply(200, data.spaces)
     .get('/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps').times(1).reply(200, data.apps)
+    .get('/v2/spaces/50ae42f6-346d-4eca-9e97-f8c9e04d5fbe/summary').times(1).reply(200, data.space)
+    .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').times(1).reply(200, data.spaceQuota)
     .get('/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').times(1).reply(200, data.services)
     .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').times(1).reply(200, data.spaces)
     .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').times(1).reply(200, data.users)
+    .get('/v2/failure').times(1).reply(404, {description: 'TEST'})
+    .get('/v2/failure/500').times(1).reply(500, {})
     .get('/v2/test').times(1).reply(200, `{"next_url":"/v2/test?page=2","resources":["a"]}`)
     .get('/v2/test?page=2').times(1).reply(200, `{"next_url":null,"resources":["b"]}`);
 
@@ -32,6 +38,22 @@ test('should iterate over all pages to gather resources', async t => {
   t.equal(data[1], 'b');
 });
 
+test('should throw an error when receiving 404', async t => {
+  try {
+    await client.request('get', '/v2/failure');
+  } catch (err) {
+    t.equal(err.message, 'TEST');
+  }
+});
+
+test('should throw an error when unrecognised error', async t => {
+  try {
+    await client.request('get', '/v2/failure/500');
+  } catch (err) {
+    t.equal(err.message, 'Request failed with status code 500');
+  }
+});
+
 test('should obtain list of organisations', async t => {
   const organizations = await client.organizations();
 
@@ -39,11 +61,35 @@ test('should obtain list of organisations', async t => {
   t.equal(organizations[0].entity.name, 'the-system_domain-org-name');
 });
 
+test('should obtain single organisation', async t => {
+  const organization = await client.organization('a7aff246-5f5b-4cf8-87d8-f316053e4a20');
+
+  t.equal(organization.entity.name, 'the-system_domain-org-name');
+});
+
+test('should obtain organisation quota', async t => {
+  const quota = await client.organizationQuota('80f3e539-a8c0-4c43-9c72-649df53da8cb');
+
+  t.equal(quota.entity.name, 'name-1996');
+});
+
 test('should obtain list of spaces', async t => {
   const spaces = await client.spaces('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
 
   t.ok(spaces.length > 0);
   t.equal(spaces[0].entity.name, 'name-1774');
+});
+
+test('should obtain single space', async t => {
+  const space = await client.space('50ae42f6-346d-4eca-9e97-f8c9e04d5fbe');
+
+  t.equal(space.name, 'name-1382');
+});
+
+test('should obtain space quota', async t => {
+  const quota = await client.spaceQuota('a9097bc8-c6cf-4a8f-bc47-623fa22e8019');
+
+  t.equal(quota.entity.name, 'name-1491');
 });
 
 test('should obtain list of spaces for specific user in given org', async t => {

--- a/src/errors/error.500.njk
+++ b/src/errors/error.500.njk
@@ -7,4 +7,5 @@
 {% block main %}
   <h1 class="govuk-heading-xl">Sorry an error occurred</h1>
   <p class="govuk-body">Something went wrong while processing the request.</p>
+  <pre><code>{{ message.stack }}</code></pre>
 {% endblock %}

--- a/src/errors/error.js
+++ b/src/errors/error.js
@@ -4,7 +4,7 @@ import pageNotFound from './error.404.njk';
 export function internalServerErrorMiddleware(err, req, res, _next) {
   req.log.error(err);
   res.status(500);
-  res.send(internalServerError.render({message: err.toString()}));
+  res.send(internalServerError.render({message: err}));
 }
 
 export function pageNotFoundMiddleware(req, res, _next) {

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -33,11 +33,7 @@
       html: 'This is a new service – your <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">feedback</a> will help us to improve it.'
     }) }}
 
-    <main class="govuk-o-main-wrapper">
-    <h1 class="govuk-heading-l">
-      {% block title %}
-      {% endblock %}
-    </h1>
+    <main class="govuk-o-main-wrapper {% block main_classes %}{% endblock %}">
       {% block main %}
         No content rendered to 'main' block
       {% endblock %}

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -1,2 +1,6 @@
 @import '~@govuk-frontend/all/all';
+
 @import 'navigationPanel/_navigationPanel.scss';
+@import '../organizations/subnav/element';
+
+@import '../spaces/spaces';

--- a/src/organizations/organizations.njk
+++ b/src/organizations/organizations.njk
@@ -9,11 +9,13 @@
   Organisations
 {% endblock %}
 
-{% block title %}
-  Welcome to GOV.UK PaaS
-{% endblock %}
 {% block main %}
+  <h1 class="govuk-heading-l">
+    Welcome to GOV.UK PaaS
+  </h1>
+  
   <h2 class="govuk-heading-m">Choose an organisation</h2>
+  
   <div class="govuk-o-grid">
     {% for organization in organizations %}
       <div class="govuk-o-grid__item govuk-o-grid__item--one-half">

--- a/src/organizations/subnav/_element.scss
+++ b/src/organizations/subnav/_element.scss
@@ -1,0 +1,43 @@
+main.with-subnav {
+  padding-top: 0;
+
+  .subnav {
+    border-bottom: 1px solid $govuk-grey-2;
+    margin: 0;
+    margin-bottom: $govuk-spacing-scale-6;
+
+    div:first-of-type {
+      padding-left: 0;
+    }
+
+    strong {
+      display: inline-block;
+      padding-bottom: $govuk-spacing-scale-2;
+      padding-top: $govuk-spacing-scale-2;
+    }
+
+    nav {
+      margin: 0;
+      padding-right: 0;
+      text-align: right;
+
+      a {
+        border-bottom: $govuk-spacing-scale-1 solid transparent;
+        display: inline-block;
+        margin-left: $govuk-spacing-scale-2;
+        padding-bottom: $govuk-spacing-scale-2;
+        padding-top: $govuk-spacing-scale-2;
+        text-decoration: none;
+        transition: border-bottom .1s ease;
+
+        &:last-of-type {
+          padding-right: 0;
+        }
+
+        &.active {
+          border-bottom: $govuk-spacing-scale-1 solid $govuk-black;
+        }
+      }
+    }
+  }
+}

--- a/src/organizations/subnav/element.njk
+++ b/src/organizations/subnav/element.njk
@@ -1,0 +1,16 @@
+<div class="govuk-o-grid subnav">
+  <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+    <strong>{{ organization.entity.name }}</strong>
+  </div>
+
+  <nav class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+    <a href="/spaces/{{ organization.metadata.guid }}" class="govuk-link active">
+      Org overview
+    </a>
+
+    <a href="/users/{{ organization.metadata.guid }}" class="govuk-link">
+      Team members
+    </a>
+  </nav>
+</div>
+  

--- a/src/spaces/_spaces.scss
+++ b/src/spaces/_spaces.scss
@@ -38,3 +38,10 @@
     margin-top: $govuk-spacing-scale-6 * 3;
   }
 }
+
+table.space-overview {
+  th.name {
+    min-width: 280px;
+    width: 35%;
+  }
+}

--- a/src/spaces/_spaces.scss
+++ b/src/spaces/_spaces.scss
@@ -1,0 +1,40 @@
+.space {
+  background-color: $govuk-grey-4;
+  border: $govuk-spacing-scale-2 solid $govuk-border-colour;
+  margin: $govuk-spacing-scale-2 0;
+  padding: $govuk-spacing-scale-2 0;
+  transition: background-color .1s ease;
+
+  &:hover {
+    background-color: #fff;
+  }
+
+  h3 {
+    margin: 0;
+  }
+
+  a {
+    text-decoration: none;
+  }
+
+  .running::before, .stopped::before {
+    content: "";
+    border-radius: 100%;
+    display: inline-block;
+    height: $govuk-spacing-scale-2;
+    margin-right: $govuk-spacing-scale-1;
+    width: $govuk-spacing-scale-2;
+  }
+
+  .running::before {
+    background-color: $govuk-green;
+  }
+
+  .stopped::before {
+    background-color: $govuk-grey-1;
+  }
+
+  & + h2 {
+    margin-top: $govuk-spacing-scale-6 * 3;
+  }
+}

--- a/src/spaces/overview.njk
+++ b/src/spaces/overview.njk
@@ -1,0 +1,101 @@
+{% extends "../layouts/govuk.njk" %}
+{% from "@govuk-frontend/input/macro.njk" import govukInput %}
+{% from "@govuk-frontend/button/macro.njk" import govukButton %}
+{% from "@govuk-frontend/panel/macro.njk" import govukPanel %}
+{% from "@govuk-frontend/back-link/macro.njk" import govukBackLink %}
+{% from "@govuk-frontend/details/macro.njk" import govukDetails %}
+
+{% block page_title %}
+  {{ space.entity.name }} - Overview
+{% endblock %}
+
+{% block main_classes %}with-subnav{% endblock %}
+
+{% block main %}
+  {% include "../organizations/subnav/element.njk" %}
+
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl">Space</span>
+    {{ space.entity.name }}
+  </h1>
+
+  <h2 class="govuk-heading-l">
+    This space has {{ applications | length }} applications
+  </h2>
+
+  {% if applications.length > 0 %}
+    <table class="govuk-c-table space-overview">
+      <thead class="govuk-c-table__head">
+        <tr class="govuk-c-table__row">
+          <th class="govuk-c-table__header name" scope="col">Application name</th>
+          <th class="govuk-c-table__header" scope="col">Instances</th>
+          <th class="govuk-c-table__header" scope="col">Memory</th>
+          <th class="govuk-c-table__header" scope="col">Disk</th>
+          <th class="govuk-c-table__header" scope="col">Status</th>
+          <th class="govuk-c-table__header" scope="col">URLs</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-c-table__body">
+        {% for application in applications %}
+          <tr class="govuk-c-table__row">
+            <th class="govuk-c-table__header" scope="row">
+              <a href="#" class="govuk-link">{{ application.entity.name }}</a>
+            </th>
+            <td class="govuk-c-table__cell ">
+              {{ application.entity.running_instances }}/{{ application.entity.instances }}
+            </td>
+            <td class="govuk-c-table__cell ">
+              {{ (application.entity.memory / 1024) | round(2) }}gb
+            </td>
+            <td class="govuk-c-table__cell ">
+              {{ (application.entity.disk_quota / 1024) | round(2) }}gb
+            </td>
+            <td class="govuk-c-table__cell ">
+              {{ application.entity.state }}
+            </td>
+            <td class="govuk-c-table__cell ">
+              <small>{{ application.entity.urls | join(", ") }}</small>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+
+  <h2 class="govuk-heading-l govuk-!-mt-r9">
+    This space has {{ space.entity.services | length }} services
+  </h2>
+
+  {% if space.entity.services > 0 %}
+    <table class="govuk-c-table space-overview">
+      <thead class="govuk-c-table__head">
+        <tr class="govuk-c-table__row">
+          <th class="govuk-c-table__header name" scope="col">Service name</th>
+          <th class="govuk-c-table__header" scope="col">Type</th>
+          <th class="govuk-c-table__header" scope="col">Plan</th>
+          <th class="govuk-c-table__header" scope="col">State</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-c-table__body">
+        {% for service in space.entity.services %}
+          <tr class="govuk-c-table__row">
+            <th class="govuk-c-table__header" scope="row">
+              <a href="#" class="govuk-link">{{ service.name }}</a>
+            </th>
+            <td class="govuk-c-table__cell ">
+              {{ service.service_plan.service.label }}
+            </td>
+            <td class="govuk-c-table__cell ">
+              {{ service.service_plan.name }}
+            </td>
+            <td class="govuk-c-table__cell ">
+              {{ service.last_operation.state }}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+{% endblock %}
+
+

--- a/src/spaces/spaces.js
+++ b/src/spaces/spaces.js
@@ -1,14 +1,42 @@
 import express from 'express';
+import syncHandler from '../app/sync-handler';
 import spacesTemplate from './spaces.njk';
 
 const app = express();
 
-app.get('/:organization', (req, res) => {
-  req.cf.spaces(req.params.organization)
-    .then(spaces => {
-      res.send(spacesTemplate.render({spaces}));
-    })
-    .catch(req.log.error);
-});
+async function listSpaces(client, organizationGUID) {
+  const spaces = await client.spaces(organizationGUID);
+  const organization = await client.organization(organizationGUID);
+  const users = await client.usersInOrganization(organizationGUID);
+  const managers = users.filter(user =>
+    user.entity.organization_roles.some(role => role === 'org_manager')
+  );
+
+  organization.entity.quota = await client.organizationQuota(organization.entity.quota_definition_guid); // eslint-disable-line camelcase
+
+  await Promise.all(spaces.map(async space => {
+    space.entity = {...space.entity, ...await client.space(space.metadata.guid)};
+
+    space.entity.quota = null;
+    if ((space.entity.space_quota_definition_guid)) { // eslint-disable-line camelcase
+      space.entity.quota = await client.spaceQuota(space.entity.space_quota_definition_guid); // eslint-disable-line camelcase
+    }
+  }));
+
+  for (const space of spaces) {
+    space.entity.running_apps = space.entity.apps.filter(app => app.running_instances > 0); // eslint-disable-line camelcase
+    space.entity.stopped_apps = space.entity.apps.filter(app => app.running_instances === 0); // eslint-disable-line camelcase
+    space.entity.memory_allocated = space.entity.apps.reduce((allocated, app) => allocated + app.memory, 0); // eslint-disable-line camelcase
+  }
+
+  organization.entity.memory_allocated = spaces.reduce((allocated, space) => allocated + space.entity.memory_allocated, 0); // eslint-disable-line camelcase
+
+  return {spaces, organization, users, managers};
+}
+
+app.get('/:organization', syncHandler(async (req, res) => {
+  const data = await listSpaces(req.cf, req.params.organization);
+  res.send(spacesTemplate.render(data));
+}));
 
 export default app;

--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -9,8 +9,156 @@
   Spaces
 {% endblock %}
 
+{% block main_classes %}with-subnav{% endblock %}
+
 {% block main %}
-  <pre>{{ spaces | dump }}</pre>
+  {% include "../organizations/subnav/element.njk" %}
+
+  <div class="govuk-o-grid">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">Organisation</span>
+        {{ organization.entity.name }}
+      </h1>
+    </div>
+
+    <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+      <table class="govuk-c-table">
+        <tbody class="govuk-c-table__body">
+          <tr class="govuk-c-table__row">
+            <th class="govuk-c-table__header" scope="row">
+              Memory:
+            </th>
+            <td class="govuk-c-table__cell govuk-c-table__cell--numeric">
+              {{ (organization.entity.memory_allocated / 1024) | round(2) }}gb
+              of {{ (organization.entity.quota.entity.memory_limit / 1024) | round(2) }}gb
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <h2 class="govuk-heading-l">
+    This organisation has {{ spaces | length }} spaces
+  </h2>
+
+  <details class="govuk-c-details" role="group">
+    <summary class="govuk-c-details__summary" role="button" aria-controls="details-content-0" aria-expanded="false">
+      <span class="govuk-c-details__summary-text">
+        What are spaces?
+      </span>
+    </summary>
+
+    <div class="govuk-c-details__text" aria-hidden="true">
+      <p>
+        Each organisation is divided into one or more spaces, which are used to organise app development, deployment, and maintenance.
+      </p>
+
+      <a href="https://docs.cloud.service.gov.uk/#organisations-spaces-amp-targets" class="govuk-link">
+        Read more about Spaces
+      </a>
+    </div>
+  </details>
+
+  {% for space in spaces %}
+    <div class="govuk-o-grid space">
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h3 class="govuk-heading-m">
+          <span class="govuk-caption-m">
+            Space:
+          </span>
+
+          <a href="#" id="space-{{ space.metadata.guid }}" class="govuk-link govuk-!-w-bold">
+            {{ space.entity.name }}
+          </a>
+        </h3>
+      </div>
+      
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-o-grid">
+        <div class="govuk-o-grid__item govuk-o-grid__item--full">
+          The space has {{ space.entity.apps | length }} apps:
+        </div>
+
+        <div class="govuk-o-grid__item govuk-o-grid__item--one-half running">
+          {{ space.entity.running_apps | length }} running
+        </div>
+
+        <div class="govuk-o-grid__item govuk-o-grid__item--one-half stopped">
+          {{ space.entity.stopped_apps | length }} stopped
+        </div>
+      </div>
+
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third govuk-o-grid">
+        <div class="govuk-o-grid__item govuk-o-grid__item--full">
+          Space memory allocated:
+        </div>
+
+        <div class="govuk-o-grid__item govuk-o-grid__item--full">
+          {{ (space.entity.memory_allocated / 1024) | round(2) }}gb of 
+          {% if space.entity.quota %}
+            {{ (space.entity.quota.memory_limit / 1024) | round(2) }}gb
+          {% else %}
+            no limit
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+
+  <h2 class="govuk-heading-l">
+    This organisation has {{ users | length }} team members
+  </h2>
+
+  <div class="govuk-o-grid">
+    <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
+      <a href="/users/{{ organization.metadata.guid }}" class="govuk-link">
+        View and manage team members
+      </a>
+
+      <p>
+        As an ‘org manager’ you can manage team members in your organiation.
+      </p>
+    </div>
+
+    <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
+      <table class="govuk-c-table">
+        <caption class="govuk-c-table__caption">
+          There are {{ managers | length }} Org managers:
+        </caption>
+
+        <tbody class="govuk-c-table__body">
+          {% for user in managers %}
+            <tr class="govuk-c-table__row">
+              <td class="govuk-c-table__cell">
+                <a href="#">
+                  {{ user.entity.username }}
+                </a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <details class="govuk-c-details" role="group">
+        <summary class="govuk-c-details__summary" role="button" aria-controls="details-content-0" aria-expanded="false">
+          <span class="govuk-c-details__summary-text">
+            What are org managers?
+          </span>
+        </summary>
+
+        <div class="govuk-c-details__text" aria-hidden="true">
+          <p>
+            An org manager administers user roles.
+          </p>
+
+          <a href="https://docs.cloud.service.gov.uk/#user-roles" class="govuk-link">
+            Read more about different roles
+          </a>
+        </div>
+      </details>
+    </div>
+  </div>
 {% endblock %}
 
 

--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -69,7 +69,7 @@
             Space:
           </span>
 
-          <a href="#" id="space-{{ space.metadata.guid }}" class="govuk-link govuk-!-w-bold">
+          <a href="/spaces/{{ space.metadata.guid }}/overview" id="space-{{ space.metadata.guid }}" class="govuk-link govuk-!-w-bold">
             {{ space.entity.name }}
           </a>
         </h3>

--- a/src/spaces/spaces.test.js
+++ b/src/spaces/spaces.test.js
@@ -3,10 +3,16 @@ import express from 'express';
 import nock from 'nock';
 import request from 'supertest';
 import {Client} from '../cf';
-import {spaces} from '../cf/client.test.data';
+import * as data from '../cf/client.test.data';
 import spacesApp from '.';
 
-nock('https://example.com').get('/api/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').times(1).reply(200, spaces);
+nock('https://example.com/api')
+  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275').times(1).reply(200, data.organization)
+  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').times(1).reply(200, data.spaces)
+  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').times(1).reply(200, data.users)
+  .get('/v2/quota_definitions/dcb680a9-b190-4838-a3d2-b84aa17517a6').times(1).reply(200, data.organizationQuota)
+  .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/summary').times(2).reply(200, data.space)
+  .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').times(1).reply(200, data.spaceQuota);
 
 const app = express();
 

--- a/src/spaces/spaces.test.js
+++ b/src/spaces/spaces.test.js
@@ -11,7 +11,13 @@ nock('https://example.com/api')
   .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').times(1).reply(200, data.spaces)
   .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').times(1).reply(200, data.users)
   .get('/v2/quota_definitions/dcb680a9-b190-4838-a3d2-b84aa17517a6').times(1).reply(200, data.organizationQuota)
-  .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/summary').times(2).reply(200, data.space)
+  .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/summary').times(2).reply(200, data.spaceSummary)
+  .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/summary').times(2).reply(200, data.spaceSummary)
+  .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9').times(1).reply(200, data.organization)
+  .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/apps').times(1).reply(200, data.apps)
+  .get('/v2/apps/cd897c8c-3171-456d-b5d7-3c87feeabbd1/summary').times(1).reply(200, data.appSummary)
+  .get('/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/summary').times(1).reply(200, data.appSummary)
+  .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3').times(1).reply(200, data.space)
   .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').times(1).reply(200, data.spaceQuota);
 
 const app = express();
@@ -33,4 +39,11 @@ test('should show the spaces pages', async t => {
 
   t.equal(response.status, 200);
   t.contains(response.text, 'Spaces');
+});
+
+test('should space overview', async t => {
+  const response = await request(app).get('/bc8d3381-390d-4bd7-8c71-25309900a2e3/overview');
+
+  t.equal(response.status, 200);
+  t.contains(response.text, 'name-1382 - Overview');
 });


### PR DESCRIPTION
## What

It wasn't clear what was wrong when it came to the request errors in
axios. We can capture that by try and catch and then throw a specific
error message from the request.

We cannot justify the use of synchronous approach express enforces. It
may be confusing to some people on the team as to why and when we use
async/await or promises.

We're creating a simple handler, that will take care of that for us.
It's a matter of including it when needed. Refactor to come later.

It's time to glue things together for spaces. We're adding some extra
functionality in order to download different pieces from API and put
them together in a new template parsed to end user.

We'd like to cover the spaces module as much as possible. We think these
should go in a separate commit in order to keep a bing chunk of code
separated.

There is no need for the layout to automatically include the h1 on every
page. Instead, we're moving it to the organisation page as it will be
the only one with this kind of layout.

## How to review

- Code review
- Run tests `npm test` (travis should do that)
- Run the application (You may want to use Rafal's environment. 
  No need to setup your own...)
  ```
  OAUTH_AUTHORIZATION_URL="https://uaa.rafalp.dev.cloudpipeline.digital/oauth/authorize" OAUTH_TOKEN_URL="https://uaa.rafalp.dev.cloudpipeline.digital/oauth/token" OAUTH_CLIENT_ID="rafal-login" OAUTH_CLIENT_SECRET="secret" SERVER_ROOT_URL="http://localhost:3000" API_URL=https://api.rafalp.dev.cloudpipeline.digital npm start
  ```
- Click through to single organisation
- Experience the overview of your organisation

Worth to mention, we compromised on some design details for different 
reasons. Happy to provide more details if interested.

## Who can review

Neither @chrisfarms nor myself.