### PR TITLE
Fix link styling

### DIFF
--- a/src/layouts/navigationPanel/_navigationPanel.scss
+++ b/src/layouts/navigationPanel/_navigationPanel.scss
@@ -1,4 +1,4 @@
-.admin-c-panel--link {
+.admin-c-panel__link {
 	text-decoration: none;
 }
 
@@ -22,6 +22,11 @@
   .admin-c-panel--navigation {
     color: $govuk-white;
     background: $govuk-blue;
+
+    &:hover {
+      background: $govuk-light-blue;
+    }
+
   }
 
   .admin-c-panel__title {


### PR DESCRIPTION
Very small commit.  Fix typo, put in dashes instead of underscores for link scss so that the style is applied.  Add hover state so that background shows that element has been hovered over.

Before:

<img width="496" alt="screen shot 2018-03-13 at 15 56 52" src="https://user-images.githubusercontent.com/11633362/37353522-6adde42c-26d7-11e8-8bf4-9bb300d44986.png">

After:

<img width="503" alt="screen shot 2018-03-13 at 15 58 13" src="https://user-images.githubusercontent.com/11633362/37353538-73a80984-26d7-11e8-9b1f-a15e2554ca46.png">

