### PR TITLE
[#154558854] Add service overview section

### DIFF
--- a/src/cf/cf.js
+++ b/src/cf/cf.js
@@ -123,9 +123,24 @@ export default class CloudFoundryClient {
     return response.data;
   }
 
-  async services(space) {
-    const response = await this.request('get', `/v2/spaces/${space}/service_instances`);
+  async services(spaceGUID) {
+    const response = await this.request('get', `/v2/spaces/${spaceGUID}/service_instances`);
     return this.allResources(response);
+  }
+
+  async serviceInstance(instanceGUID) {
+    const response = await this.request('get', `/v2/service_instances/${instanceGUID}`);
+    return response.data;
+  }
+
+  async service(serviceGUID) {
+    const response = await this.request('get', `/v2/services/${serviceGUID}`);
+    return response.data;
+  }
+
+  async servicePlan(planGUID) {
+    const response = await this.request('get', `/v2/service_plans/${planGUID}`);
+    return response.data;
   }
 
   async usersForOrganization(organizationGUID) {

--- a/src/cf/cf.test.data.js
+++ b/src/cf/cf.test.data.js
@@ -532,6 +532,107 @@ export const services = `{
   ]
 }`;
 
+export const serviceInstance = `{
+  "metadata": {
+    "guid": "0d632575-bb06-4ea5-bb19-a451a9644d92",
+    "url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "name-1508",
+    "credentials": {
+      "creds-key-38": "creds-val-38"
+    },
+    "service_guid": "a14baddf-1ccc-5299-0152-ab9s49de4422",
+    "service_plan_guid": "779d2df0-9cdd-48e8-9781-ea05301cedb1",
+    "space_guid": "38511660-89d9-4a6e-a889-c32c7e94f139",
+    "gateway_data": null,
+    "dashboard_url": null,
+    "type": "managed_service_instance",
+    "last_operation": {
+      "type": "create",
+      "state": "succeeded",
+      "description": "service broker-provided description",
+      "updated_at": "2016-06-08T16:41:29Z",
+      "created_at": "2016-06-08T16:41:29Z"
+    },
+    "tags": [
+      "accounting",
+      "mongodb"
+    ],
+    "space_url": "/v2/spaces/38511660-89d9-4a6e-a889-c32c7e94f139",
+    "service_url": "/v2/services/a14baddf-1ccc-5299-0152-ab9s49de4422",
+    "service_plan_url": "/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1",
+    "service_bindings_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/service_bindings",
+    "service_keys_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/service_keys",
+    "routes_url": "/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/routes"
+  }
+}`;
+
+export const servicePlan = `{
+  "metadata": {
+    "guid": "775d0046-7505-40a4-bfad-ca472485e332",
+    "url": "/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332",
+    "created_at": "2016-06-08T16:41:30Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "name-1573",
+    "free": false,
+    "description": "desc-107",
+    "service_guid": "a00cacc0-0ca6-422e-91d3-6b22bcd33450",
+    "extra": null,
+    "unique_id": "35c56e06-f0c6-4abe-b158-b7c24c889905",
+    "public": true,
+    "active": true,
+    "bindable": true,
+    "service_url": "/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450",
+    "service_instances_url": "/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332/service_instances",
+    "schemas": {
+      "service_instance": {
+        "create": {},
+        "update": {}
+      },
+      "service_binding": {
+        "create": {}
+      }
+    }
+  }
+}`;
+
+export const service = `{
+  "metadata": {
+    "guid": "53f52780-e93c-4af7-a96c-6958311c40e5",
+    "url": "/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5",
+    "created_at": "2016-06-08T16:41:32Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "label": "label-58",
+    "provider": null,
+    "url": null,
+    "description": "desc-135",
+    "long_description": null,
+    "version": null,
+    "info_url": null,
+    "active": true,
+    "bindable": true,
+    "unique_id": "c181996b-f233-43d1-8901-3a43eafcaacf",
+    "extra": null,
+    "tags": [
+
+    ],
+    "requires": [
+
+    ],
+    "documentation_url": null,
+    "service_broker_guid": "0e7250aa-364f-42c2-8fd2-808b0224376f",
+    "plan_updateable": false,
+    "service_plans_url": "/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5/service_plans"
+  }
+}`;
+
 export const users = `{
   "total_results": 1,
   "total_pages": 1,

--- a/src/cf/cf.test.js
+++ b/src/cf/cf.test.js
@@ -21,6 +21,9 @@ nock('https://example.com/api').persist()
   .get('/v2/spaces/50ae42f6-346d-4eca-9e97-f8c9e04d5fbe/summary').reply(200, data.spaceSummary)
   .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').reply(200, data.spaceQuota)
   .get('/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').reply(200, data.services)
+  .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92').times(1).reply(200, data.serviceInstance)
+  .get('/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332').times(1).reply(200, data.servicePlan)
+  .get('/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5').times(1).reply(200, data.service)
   .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, data.spaces)
   .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, data.users)
   .post('/v2/users').reply(200, data.user)
@@ -178,6 +181,27 @@ test('should obtain list of services', async t => {
 
   t.ok(services.length > 0);
   t.equal(services[0].entity.name, 'name-2104');
+});
+
+test('should obtain particular service instance', async t => {
+  const client = new CloudFoundryClient(config);
+  const serviceInstance = await client.serviceInstance('0d632575-bb06-4ea5-bb19-a451a9644d92');
+
+  t.equal(serviceInstance.entity.name, 'name-1508');
+});
+
+test('should obtain particular service plan', async t => {
+  const client = new CloudFoundryClient(config);
+  const servicePlan = await client.servicePlan('775d0046-7505-40a4-bfad-ca472485e332');
+
+  t.equal(servicePlan.entity.name, 'name-1573');
+});
+
+test('should obtain particular service', async t => {
+  const client = new CloudFoundryClient(config);
+  const service = await client.service('53f52780-e93c-4af7-a96c-6958311c40e5');
+
+  t.equal(service.entity.label, 'label-58');
 });
 
 test('should obtain list of user roles', async t => {

--- a/src/services/overview.njk
+++ b/src/services/overview.njk
@@ -1,0 +1,86 @@
+{% extends "../layouts/govuk.njk" %}
+{% from "@govuk-frontend/table/macro.njk" import govukTable %}
+{% from "@govuk-frontend/back-link/macro.njk" import govukBackLink %}
+
+{% block page_title %}
+  {{ service.entity.name }} - Service Overview
+{% endblock %}
+
+{% block main_classes %}with-subnav{% endblock %}
+
+{% block main %}
+  {% include "../organizations/subnav/element.njk" %}
+
+  <div class="govuk-o-grid">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+      {{ govukBackLink({
+        text: 'Space: ' + space.entity.name,
+        href: '/spaces/' + space.metadata.guid + '/overview'
+      }) }}
+
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">Service</span>
+        {{ service.entity.name }}
+      </h1>
+
+      {{ govukTable({
+        caption: 'Service details',
+        firstCellIsHeader: false,
+        rows: [
+          [
+            {
+              text: 'Name'
+            },
+            {
+              text: service.entity.name
+            }
+          ],
+          [
+            {
+              text: 'Type'
+            },
+            {
+              text: service.service_plan.service.entity.label
+            }
+          ],
+          [
+            {
+              text: 'Plan'
+            },
+            {
+              text: service.service_plan.entity.name
+            }
+          ],
+          [
+            {
+              text: 'State'
+            },
+            {
+              text: service.entity.last_operation.state
+            }
+          ],
+          [
+            {
+              text: 'Tags'
+            },
+            {
+              text: service.entity.tags | join(', ')
+            }
+          ]
+        ]
+      }) }}
+
+      <h4 class="govuk-heading-s">On the commandline</h4>
+
+      <p>You can also view the same information on the commandline, to see details for all of your services use:</p>
+
+      <p>
+        <code>cf services</code>
+      </p>
+
+      <a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line" class="govuk-link">
+        Read more about using PaaS on the commandline.
+      </a>
+    </div>
+  </div>
+{% endblock %}

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -1,14 +1,18 @@
 import express from 'express';
-import servicesTemplate from './services.njk';
+import syncHandler from '../app/sync-handler';
+import serviceOverviewTemplate from './overview.njk';
 
 const app = express();
 
-app.get('/:space', (req, res) => {
-  req.cf.services(req.params.space)
-    .then(services => {
-      res.send(servicesTemplate.render({services}));
-    })
-    .catch(req.log.error);
-});
+app.get('/:serviceGUID/overview', syncHandler(async (req, res) => {
+  const service = await req.cf.serviceInstance(req.params.serviceGUID);
+  service.service_plan = await req.cf.servicePlan(service.entity.service_plan_guid); // eslint-disable-line camelcase
+  service.service_plan.service = await req.cf.service(service.service_plan.entity.service_guid); // eslint-disable-line camelcase
+
+  const space = await req.cf.space(service.entity.space_guid);
+  const organization = await req.cf.organization(space.entity.organization_guid);
+
+  res.send(serviceOverviewTemplate.render({service, space, organization}));
+}));
 
 export default app;

--- a/src/services/services.test.js
+++ b/src/services/services.test.js
@@ -3,10 +3,15 @@ import express from 'express';
 import nock from 'nock';
 import request from 'supertest';
 import {CloudFoundryClient} from '../cf';
-import {organizations} from '../cf/cf.test.data';
+import * as data from '../cf/cf.test.data';
 import organizationsApp from '.';
 
-nock('https://example.com').get('/api/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').times(1).reply(200, organizations);
+nock('https://example.com/api')
+  .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92').times(1).reply(200, data.serviceInstance)
+  .get('/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1').times(1).reply(200, data.servicePlan)
+  .get('/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450').times(1).reply(200, data.service)
+  .get('/v2/spaces/38511660-89d9-4a6e-a889-c32c7e94f139').times(1).reply(200, data.space)
+  .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9').times(1).reply(200, data.organization);
 
 const app = express();
 
@@ -25,9 +30,8 @@ app.use((req, res, next) => {
 
 app.use(organizationsApp);
 
-test('should show the organisations pages', async t => {
-  const response = await request(app).get('/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe');
+test('should show the service overview page', async t => {
+  const response = await request(app).get('/0d632575-bb06-4ea5-bb19-a451a9644d92/overview');
 
-  t.equal(response.status, 200);
-  t.contains(response.text, 'Services');
+  t.contains(response.text, 'name-1508 - Service Overview');
 });

--- a/src/spaces/overview.njk
+++ b/src/spaces/overview.njk
@@ -66,7 +66,7 @@
     This space has {{ space.entity.services | length }} services
   </h2>
 
-  {% if space.entity.services > 0 %}
+  {% if space.entity.services.length > 0 %}
     <table class="govuk-c-table space-overview">
       <thead class="govuk-c-table__head">
         <tr class="govuk-c-table__row">


### PR DESCRIPTION
## What

We'd like to allow our tenants to look into basic information of their
services.

This is fairly simplistic view and may be extended over time.

## How to review

- Code review
- Run tests (should be done by travis)
- Run the application against rafal's environment
  ```
  OAUTH_AUTHORIZATION_URL="https://login.rafalp.dev.cloudpipeline.digital/oauth/authorize" OAUTH_TOKEN_URL="https://uaa.rafalp.dev.cloudpipeline.digital/oauth/token" OAUTH_CLIENT_ID="rafal-login" OAUTH_CLIENT_SECRET="secret" API_URL="https://api.rafalp.dev.cloudpipeline.digital" UAA_URL="https://uaa.rafalp.dev.cloudpipeline.digital" NOTIFY_API_KEY="not-important-for-that-story" npm start
  ```
- Navigate through orgs and spaces (want to target the `healthchecks` space)
- Preview `mysqldb` service instance summary

🐝 ~~This PR is based on the #21 which ideally should be merged first.~~
