### PR TITLE
Add sub navigation to all pages that deserve it

### DIFF
--- a/src/applications/overview.njk
+++ b/src/applications/overview.njk
@@ -6,11 +6,7 @@
   {{ application.entity.name }} - Application Overview
 {% endblock %}
 
-{% block main_classes %}with-subnav{% endblock %}
-
 {% block main %}
-  {% include "../organizations/subnav/element.njk" %}
-
   <div class="govuk-o-grid">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
       {{ govukBackLink({

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -33,7 +33,11 @@
       html: 'This is a new service – your <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">feedback</a> will help us to improve it.'
     }) }}
 
-    <main class="govuk-o-main-wrapper {% block main_classes %}{% endblock %}">
+    <main class="govuk-o-main-wrapper {% if organization %} with-subnav {% endif %} {% block main_classes %}{% endblock %}">
+      {% if organization %}
+        {% include "../organizations/subnav/element.njk" %}
+      {% endif %}
+
       {% block main %}
         No content rendered to 'main' block
       {% endblock %}

--- a/src/services/overview.njk
+++ b/src/services/overview.njk
@@ -6,11 +6,7 @@
   {{ service.entity.name }} - Service Overview
 {% endblock %}
 
-{% block main_classes %}with-subnav{% endblock %}
-
 {% block main %}
-  {% include "../organizations/subnav/element.njk" %}
-
   <div class="govuk-o-grid">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
       {{ govukBackLink({

--- a/src/spaces/overview.njk
+++ b/src/spaces/overview.njk
@@ -4,11 +4,7 @@
   {{ space.entity.name }} - Overview
 {% endblock %}
 
-{% block main_classes %}with-subnav{% endblock %}
-
 {% block main %}
-  {% include "../organizations/subnav/element.njk" %}
-
   <h1 class="govuk-heading-xl">
     <span class="govuk-caption-xl">Space</span>
     {{ space.entity.name }}

--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -9,11 +9,7 @@
   Spaces
 {% endblock %}
 
-{% block main_classes %}with-subnav{% endblock %}
-
 {% block main %}
-  {% include "../organizations/subnav/element.njk" %}
-
   <div class="govuk-o-grid">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
       <h1 class="govuk-heading-xl">


### PR DESCRIPTION
## What

Previously, we had to include the sub navigation on every page that
might have required it. The approach quickly proven we will forget about
certain places meaning the sub navigation will not be displayed.

We're now including the if statement in the main layout, checking
whether an `organization` variable has been provided from the controller
and decide on displaying the nav at all times.

## How to review

- Code sanity check
- Optionally, run the application using rafal's env and see if the subnav is displayed on almost every page you can click to except the org listing

### Before

![screen shot 2018-03-27 at 12 07 35](https://user-images.githubusercontent.com/2418945/37963921-acbee342-31b7-11e8-8f09-34326a3d20d9.png)

### After

![screen shot 2018-03-27 at 12 08 39](https://user-images.githubusercontent.com/2418945/37963927-b0257d84-31b7-11e8-8cea-3a276852a3fd.png)

