### PR TITLE
Add navigation

### DIFF
--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -1,0 +1,27 @@
+.navigation {
+  float:right;
+  display: block;
+  margin-right: $govuk-spacing-scale-3;
+  margin-top: 7px;
+  padding-top: 0;
+  @include govuk-font-bold-16;
+
+  a {
+    color: $govuk-white;
+    text-decoration: none;
+
+    &:hover {
+     text-decoration: underline;
+    }
+  }
+
+  ul {
+    margin: 0;
+  }
+
+  li {
+    list-style-type: none;
+    display: inline;
+    margin-left: $govuk-spacing-scale-3;
+  }
+}

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -11,6 +11,17 @@
   <link href="./govuk.screen.scss" media="screen" rel="stylesheet" type="text/css" />
 {% endblock %}
 
+{% block inside_header %}
+  <div class="navigation">
+    <ul>
+      <li><a href="/organisations">My Organisations</a></li>
+      <li><a href="https://docs.cloud.service.gov.uk/">Documentation</a></li>
+      <li><a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">Support</a></li>
+      <li><a href="/auth/logout">Sign out</a></li>
+    <ul>
+  </div>
+{% endblock %}
+
 {% block cookie_message %}
   <p>GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a></p>
 {% endblock %}

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -2,6 +2,7 @@
 
 @import 'navigationPanel/_navigationPanel.scss';
 @import 'elements';
+@import 'header';
 
 @import '../organizations/subnav/element';
 


### PR DESCRIPTION
Add basic navigation for PAAS admin.  We need this to navigate between pages at a top level.  This is part of the main govuk template but should probably be separated out into a separate template later on.

Todo
-  Make navigation mobile friendly
-  Indicate which section user is on
-  Connect routing to templates rather than having urls hardcoded.  I think this needs to be addressed in another story as we are about to rewrite our routing completely.

Before:

<img width="989" alt="screen shot 2018-03-27 at 11 24 07" src="https://user-images.githubusercontent.com/11633362/37962109-07abfae8-31b2-11e8-994e-44338723b4fe.png">

After:

<img width="1026" alt="screen shot 2018-03-27 at 11 27 54" src="https://user-images.githubusercontent.com/11633362/37962127-1432113a-31b2-11e8-8a93-8d7e7ac570f3.png">


This can be reviewed by running the application and making sure the links are there.  The only link that links to anything currently is organisations as I don't think the other sections yet exist.

Anyone can review this who isn't me.