### PR TITLE
Add logo

### DIFF
--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -1,0 +1,27 @@
+.navigation {
+  float:right;
+  display: block;
+  margin-right: $govuk-spacing-scale-3;
+  margin-top: 7px;
+  padding-top: 0;
+  @include govuk-font-bold-16;
+
+  a {
+    color: $govuk-white;
+    text-decoration: none;
+
+    &:hover {
+     text-decoration: underline;
+    }
+  }
+
+  ul {
+    margin: 0;
+  }
+
+  li {
+    list-style-type: none;
+    display: inline;
+    margin-left: $govuk-spacing-scale-3;
+  }
+}

--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -1,11 +1,4 @@
-.navigation {
-  float:right;
-  display: block;
-  margin-right: $govuk-spacing-scale-3;
-  margin-top: 7px;
-  padding-top: 0;
-  @include govuk-font-bold-16;
-
+.header-wrapper {
   a {
     color: $govuk-white;
     text-decoration: none;
@@ -14,6 +7,28 @@
      text-decoration: underline;
     }
   }
+}
+
+.header-title {
+  color: #fff;
+  @include govuk-font-regular-24;
+  float: left;
+  margin-top: 8px;
+}
+
+#global-header .header-wrapper .header-global .header-logo {
+  @media only screen and (min-width: 769px)  {
+    width: auto;
+  }
+}
+
+.navigation {
+  float:right;
+  display: block;
+  margin-right: $govuk-spacing-scale-3;
+  margin-top: 7px;
+  padding-top: 0;
+  @include govuk-font-bold-16;
 
   ul {
     margin: 0;

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -3,10 +3,6 @@
 
 {% set homepage_url = '/' %}
 
-{% set logo_link_title = 'Go to the GOV.UK PaaS Admin Tool Homepage' %}
-
-{% block inside_header %} <div class="navigation"><ul><li><a href="/organisations">My Organisations</a></li><li><a href="#">Documentation</a></li><li><a href="#">Support</a></li><li><a href="#">Sign out</a></li><ul>{% endblock %}
-
 {% block page_title %}PaaS Administration{% endblock %}
 
 {% block head %}
@@ -14,6 +10,9 @@
 {% endblock %}
 
 {% block inside_header %}
+  <div class="header-title">
+    Platform as a Service
+  </div>
   <div class="navigation">
     <ul>
       <li><a href="/organisations">My Organisations</a></li>

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -5,10 +5,23 @@
 
 {% set logo_link_title = 'Go to the GOV.UK PaaS Admin Tool Homepage' %}
 
+{% block inside_header %} <div class="navigation"><ul><li><a href="/organisations">My Organisations</a></li><li><a href="#">Documentation</a></li><li><a href="#">Support</a></li><li><a href="#">Sign out</a></li><ul>{% endblock %}
+
 {% block page_title %}PaaS Administration{% endblock %}
 
 {% block head %}
   <link href="./govuk.screen.scss" media="screen" rel="stylesheet" type="text/css" />
+{% endblock %}
+
+{% block inside_header %}
+  <div class="navigation">
+    <ul>
+      <li><a href="/organisations">My Organisations</a></li>
+      <li><a href="https://docs.cloud.service.gov.uk/">Documentation</a></li>
+      <li><a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">Support</a></li>
+      <li><a href="/auth/logout">Sign out</a></li>
+    <ul>
+  </div>
 {% endblock %}
 
 {% block cookie_message %}

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -2,6 +2,7 @@
 
 @import 'navigationPanel/_navigationPanel.scss';
 @import 'elements';
+@import 'header';
 
 @import '../organizations/subnav/element';
 


### PR DESCRIPTION
Add logo for Platform as a Service.  This is in a separate div from the GOV.UK logo which isn't ideal as they both point to the same place.  To put them together we would have to take a copy of the template and modify it rather than simply feeding it in from the node-module which would mean that we could miss updates to this module.

Hopefully this template will be deprecated soon and superseded by a new version from the design system, so it's probably better to wait until this new version comes out.  If the two logos causes confusion for users before the new design system version comes out, we may need to revisit this however.

Closes #27

Before: 
<img width="395" alt="screen shot 2018-03-28 at 18 12 08" src="https://user-images.githubusercontent.com/11633362/38045109-9c34a8c0-32b3-11e8-9573-7f9d2308a753.png">

After:
<img width="499" alt="screen shot 2018-03-28 at 18 11 38" src="https://user-images.githubusercontent.com/11633362/38045116-a3e77d0e-32b3-11e8-8997-6456d27f8e9e.png">
