### PR TITLE
Add next steps

### DIFF
--- a/src/organizations/_organizations.scss
+++ b/src/organizations/_organizations.scss
@@ -11,6 +11,7 @@
 .paas-sections {
   border-bottom: 1px solid $govuk-border-colour;
   padding-left: 0;
+  margin-bottom: $govuk-spacing-scale-8;
 
   li {
     list-style: none;
@@ -26,4 +27,46 @@
   padding-top: $govuk-spacing-scale-6;
   padding-bottom: $govuk-spacing-scale-6;
   border-top: 1px solid $govuk-border-colour;
+}
+
+.paas-info-section {
+  margin-top: $govuk-spacing-scale-7;
+  @include govuk-font-regular-19;
+
+  h3 {
+    @include govuk-font-bold-19;
+  }
+
+  p {
+    margin-top: $govuk-spacing-scale-1;
+  }
+}
+
+.paas-download-section {
+  margin-bottom: $govuk-spacing-scale-7 + $govuk-spacing-scale-1;
+  margin-top: $govuk-spacing-scale-3;
+  margin-left: 1px;
+  margin-right: 1px;
+  padding-top: $govuk-spacing-scale-5;
+  padding-bottom: $govuk-spacing-scale-5;
+  padding-left: $govuk-spacing-scale-3/2;
+  padding-right: $govuk-spacing-scale-3/2;
+  background-color: $govuk-grey-4;
+  border: 10px $govuk-grey-3 solid;
+  @include govuk-font-regular-19;
+
+  h3 {
+    @include govuk-font-bold-19;
+    margin-bottom: $govuk-spacing-scale-1;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style-position: inside;
+  }
+
+  p {
+    margin-top: 0;
+  }
 }

--- a/src/organizations/organizations.njk
+++ b/src/organizations/organizations.njk
@@ -20,4 +20,60 @@
       </li>
     {% endfor %}
   </ul>
+
+  <div class="govuk-o-grid">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+      <h2 class="paas-heading-lede">Installing the Cloud Foundry command line will let you operate GOV.UK PaaS from your computer terminal.</p>
+    </div>
+  </div>
+
+  <div class="govuk-o-grid paas-download-section">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+      <h3>Download the Cloud Foundry command line tool</h3>
+      <p>You’ll need to do this to operate GOV.UK PaaS from your terminal. You can download the cf command line tool using one of the installation options or by visiting the <a href="#">github page</a>.</p>
+    </div>
+    <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+      <h3>Installation options:</h3>
+      <ul>
+        <li><a href="#">Mac OS X 64 bit</a></li>
+        <li><a href="#">Windows 64 bit</a></li>
+        <li><a href="#">Linux 64 bit</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="govuk-o-grid">
+    <div class="govuk-o-grid__item govuk-o-grid__item--full">
+      <h2>Once you’ve installed the cf CLI</h2>
+    </div>
+  </div>
+
+
+  <div class="paas-info-section">
+    <div class="govuk-o-grid paas-info-section">
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h3><a href="#">Deploy your first application</a></h3>
+        <p>View our quick setup guide on deploying your first app to GOV.UK PaaS.</p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h3><a href="#">View and manage team members</a></h3>
+        <p>If you are an ‘org manager’ you can administer team members. Learn how to do this using the command line too</p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h3><a href="#">View all documentation</a></h3>
+        <p>Our documentation covers all aspects of using GOV.UK PaaS, from managing and scaling your applications to troubleshooting.</p>
+      </div>
+    </div>
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h3><a href="#">See steps to going live</a></h3>
+        <p>See an overview of the steps your service needs to take to go live on GOV.UK PaaS.</p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h3><a href="#">Get a cost estimation</a></h3>
+        <p>Use our calculator to estimate how much it will cost your service to use GOV.UK PaaS.</p>
+      </div>
+    </div>
+  </div>
+
 {% endblock %}

--- a/src/organizations/organizations.njk
+++ b/src/organizations/organizations.njk
@@ -35,9 +35,18 @@
     <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
       <h3>Installation options:</h3>
       <ul>
-        <li><a href="#">Mac OS X 64 bit</a></li>
-        <li><a href="#">Windows 64 bit</a></li>
-        <li><a href="#">Linux 64 bit</a></li>
+        <li>
+          <a href="{{ cfDownloadLinkLocation }}macosx64{{ cfDownloadLinkSource }}">Mac OS X 64 bit</a>
+        </li>
+        <li>
+          <a href="{{ cfDownloadLinkLocation }}windows64{{ cfDownloadLinkSource }}">Windows 64 bit</a>
+        </li>
+        <li>
+          <a href="{{ cfDownloadLinkLocation }}debian64{{ cfDownloadLinkSource }}">Debian 64 bit</a>
+        </li>
+        <li>
+          <a href="{{ cfDownloadLinkLocation }}redhat64{{ cfDownloadLinkSource }}">RedHat 64 bit</a>
+        </li>
       </ul>
     </div>
   </div>
@@ -52,26 +61,22 @@
   <div class="paas-info-section">
     <div class="govuk-o-grid paas-info-section">
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
-        <h3><a href="#">Deploy your first application</a></h3>
-        <p>View our quick setup guide on deploying your first app to GOV.UK PaaS.</p>
+        <h3><a href="{{ documentationLink }}setting-up-the-command-line">Setup and deploy your first app</a></h3>
+        <p>View our guide on logging in and deploying your first app to GOV.UK PaaS.</p>
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
-        <h3><a href="#">View and manage team members</a></h3>
-        <p>If you are an ‘org manager’ you can administer team members. Learn how to do this using the command line too</p>
+        <h3><a href="{{ documentationLink }}organisations-spaces-amp-targets">Learn more about orgs and spaces</a></h3>
+        <p>Get familiar with the basic concepts of Cloud Foundry-based platforms, and what setting up environments looks like.</p>
       </div>
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
-        <h3><a href="#">View all documentation</a></h3>
-        <p>Our documentation covers all aspects of using GOV.UK PaaS, from managing and scaling your applications to troubleshooting.</p>
+        <h3><a href="{{ documentationLink }}managing-users">Manage team members</a></h3>
+        <p>Learn how to manage permission levels for your users using the command line tool (for org managers only).</p>
       </div>
     </div>
     <div class="govuk-o-grid">
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
-        <h3><a href="#">See steps to going live</a></h3>
-        <p>See an overview of the steps your service needs to take to go live on GOV.UK PaaS.</p>
-      </div>
-      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
-        <h3><a href="#">Get a cost estimation</a></h3>
-        <p>Use our calculator to estimate how much it will cost your service to use GOV.UK PaaS.</p>
+        <h3><a href="{{ documentationLink }}system-status-alerts-and-updates">Get GOV.UK PaaS updates</a></h3>
+        <p>Discover how to get system status alerts and updates about new features.</p>
       </div>
     </div>
   </div>

--- a/src/organizations/organizations.ts
+++ b/src/organizations/organizations.ts
@@ -4,13 +4,19 @@ import { IContext } from '../app/context';
 
 import organizationsTemplate from './organizations.njk';
 
-export async function listOrganizations(ctx: IContext, _params: IParameters): Promise<IResponse> {
-  const organizations = await ctx.cf.organizations();
+export async function listOrganizations(context: IContext, _params: IParameters): Promise<IResponse> {
+  const organizations = await context.cf.organizations();
+  const cfDownloadLinkLocation = 'https://packages.cloudfoundry.org/stable?release=';
+  const cfDownloadLinkSource = '&amp;source=github';
+  const documentationLink = 'https://docs.cloud.service.gov.uk/#';
 
   return {
     body: organizationsTemplate.render({
-      routePartOf: ctx.routePartOf,
-      linkTo: ctx.linkTo,
+      routePartOf: context.routePartOf,
+      linkTo: context.linkTo,
+      cfDownloadLinkLocation,
+      cfDownloadLinkSource,
+      documentationLink,
       organizations,
     }),
   };


### PR DESCRIPTION
## What

Add in next steps which now live in Paas Admin rather than the [main product page](https://www.cloud.service.gov.uk/next-steps). This should be more relevant for people who are likely to want to carry out these steps.  Some custom CSS as we don't have a pattern for a download box on administration interfaces.

The content we are using is from the product page as it seems to be more up to date than the content on the prototype.


## How to review

Run the application, make sure it looks okay, fits with Steve's design and it works.

## Who can review

Anyone who isn't me.
