### PR TITLE
Change the default logging level to warning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import Server from './server';
 sourceMapSupport.install();
 
 const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
+  level: process.env.LOG_LEVEL || 'warn',
 });
 
 function expectEnvVariable(variableName: string): string {


### PR DESCRIPTION
## What

As we run the application now, it is becoming more annoying to look at
the noise the logs are generating. The access logs are gathered by the
user, meaning we can switch the node access logging off entirely.

It also could have been a security concern as session cookies have been
logged out...

## How to review

- Run/Push the application
- Monitor the logs
- Experience the silence
