### PR TITLE
[#156761419] Only amend permissions on change

### DIFF
--- a/src/users/permissions.njk
+++ b/src/users/permissions.njk
@@ -34,9 +34,10 @@
     <tr class="govuk-c-table__row">
       <th class="govuk-c-table__header" scope="row">{{ organization.entity.name }}</th>
       <td class="govuk-c-table__cell ">
+        <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers | default(0) }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][current]">
         {{ govukCheckboxes({
           id: "org_roles[" + organization.metadata.guid + "][billing_managers]",
-          name: "org_roles[" + organization.metadata.guid + "][billing_managers]",
+          name: "org_roles[" + organization.metadata.guid + "][billing_managers][desired]",
           items: [
             {
               value: "1",
@@ -47,9 +48,10 @@
         }) }}
       </td>
       <td class="govuk-c-table__cell ">
+        <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].managers | default(0) }}" name="org_roles[{{ organization.metadata.guid }}][managers][current]">
         {{ govukCheckboxes({
           id: "org_roles[" + organization.metadata.guid + "][managers]",
-          name: "org_roles[" + organization.metadata.guid + "][managers]",
+          name: "org_roles[" + organization.metadata.guid + "][managers][desired]",
           items: [
             {
               value: "1",
@@ -60,9 +62,10 @@
         }) }}
       </td>
       <td class="govuk-c-table__cell ">
+        <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].auditors | default(0) }}" name="org_roles[{{ organization.metadata.guid }}][auditors][current]">
         {{ govukCheckboxes({
           id: "org_roles[" + organization.metadata.guid + "][auditors]",
-          name: "org_roles[" + organization.metadata.guid + "][auditors]",
+          name: "org_roles[" + organization.metadata.guid + "][auditors][desired]",
           items: [
             {
               value: "1",
@@ -109,9 +112,10 @@
       <tr class="govuk-c-table__row">
         <th class="govuk-c-table__header" scope="row">{{ space.entity.name }}</th>
         <td class="govuk-c-table__cell ">
+          <input type="hidden" value="{{ values.space_roles[space.metadata.guid].managers | default(0) }}" name="space_roles[{{ space.metadata.guid }}][managers][current]">
           {{ govukCheckboxes({
             id: "space_roles[" + space.metadata.guid + "][managers]",
-            name: "space_roles[" + space.metadata.guid + "][managers]",
+            name: "space_roles[" + space.metadata.guid + "][managers][desired]",
             items: [
               {
                 value: "1",
@@ -122,9 +126,10 @@
           }) }}
         </td>
         <td class="govuk-c-table__cell ">
+          <input type="hidden" value="{{ values.space_roles[space.metadata.guid].developers | default(0) }}" name="space_roles[{{ space.metadata.guid }}][developers][current]">
           {{ govukCheckboxes({
             id: "space_roles[" + space.metadata.guid + "][developers]",
-            name: "space_roles[" + space.metadata.guid + "][developers]",
+            name: "space_roles[" + space.metadata.guid + "][developers][desired]",
             items: [
               {
                 value: "1",
@@ -135,9 +140,10 @@
           }) }}
         </td>
         <td class="govuk-c-table__cell ">
+          <input type="hidden" value="{{ values.space_roles[space.metadata.guid].auditors | default(0) }}" name="space_roles[{{ space.metadata.guid }}][auditors][current]">
           {{ govukCheckboxes({
             id: "space_roles[" + space.metadata.guid + "][auditors]",
-            name: "space_roles[" + space.metadata.guid + "][auditors]",
+            name: "space_roles[" + space.metadata.guid + "][auditors][desired]",
             items: [
               {
                 value: "1",

--- a/src/users/users.test.ts
+++ b/src/users/users.test.ts
@@ -14,69 +14,6 @@ import { IContext } from '../app/context';
 
 const tokenKey = 'secret';
 
-// tslint:disable:max-line-length
-nock('https://example.com/api').persist()
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, cfData.organization)
-  .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, cfData.spaces)
-  .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/spaces').reply(200, cfData.spaces)
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').reply(200, cfData.spaces)
-  .get('/v2/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8/organizations').reply(200, `{"resources": []}`)
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, cfData.userRolesForOrg)
-  .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/user_roles').reply(200, cfData.userRolesForSpace)
-  .get('/v2/info').reply(200, cfData.info)
-  .post('/v2/users').reply(200, cfData.user)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/uaa-user-edit-123456').reply(200, `{}`)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/uaa-user-edit-123456').reply(200, `{}`)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/uaa-user-edit-123456').reply(200, `{}`)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
-  .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/uaa-user-edit-123456').reply(200, `{}`)
-  .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/uaa-user-edit-123456').reply(200, `{}`)
-  .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/uaa-user-edit-123456').reply(200, `{}`)
-  .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/uaa-user-edit-123456').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/uaa-user-edit-123456').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/uaa-user-edit-123456').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/uaa-user-edit-123456').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
-  .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
-  .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/uaa-user-edit-123456').reply(200, `{}`)
-  .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/uaa-user-edit-123456').reply(200, `{}`)
-  .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/uaa-user-edit-123456').reply(200, `{}`)
-  .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
-  .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
-  .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users').reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
-  .get('/v2/users/99022be6-feb8-4f78-96f3-7d11f4d476f1/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, {resources: []})
-  .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, {})
-;
-
-nock('https://example.com/uaa').persist()
-  .get('/Users?filter=email+eq+%22imeCkO@test.org%22').reply(200, uaaData.usersByEmail)
-  .get('/Users?filter=email+eq+%22jeff@jeff.com%22').reply(200, uaaData.noFoundUsersByEmail)
-  .post('/invite_users?redirect_uri=https://www.cloud.service.gov.uk/next-steps?success&client_id=user_invitation').reply(200, uaaData.invite)
-  .post('/oauth/token?grant_type=client_credentials').reply(200, `{"access_token": "FAKE_ACCESS_TOKEN"}`)
-;
-
-nock(/api.notifications.service.gov.uk/).persist()
-  .filteringPath(() => '/')
-  .post('/').reply(200, {notify: 'FAKE_NOTIFY_RESPONSE'})
-;
-// tslint:enable:max-line-length
-
 const time = Math.floor(Date.now() / 1000);
 const rawToken = {user_id: 'uaa-id-253', scope: [], exp: (time + (24 * 60 * 60))};
 const accessToken = jwt.sign(rawToken, tokenKey);
@@ -102,286 +39,584 @@ const ctx: IContext = {
   }),
 };
 
-test('should show the users pages', async t => {
-  const response = await users.listUsers(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  });
-
-  t.contains(response.body, 'Team members');
-});
-
-test('should show the invite page', async t => {
-  const response = await users.inviteUserForm(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  });
-
-  t.contains(response.body, 'Invite a new team member');
-});
-
-test('should show error message when email is missing', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {});
-
-  t.contains(response.body, 'a valid email address is required');
-  t.equal(response.status, 400);
-});
-
-test('should show error message when email is invalid according to our regex', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {email: 'x'});
-
-  t.contains(response.body, 'a valid email address is required');
-  t.equal(response.status, 400);
-});
-
-// TODO: implement this when refactoring tests
-// tslint:disable:max-line-length
-// test('should show error message when email is invalid acording to invite_users', async t => {
-//   nock('https://example.com/uaa')
-//     .post('/invite_users?redirect_uri=https://www.cloud.service.gov.uk/next-steps?success&client_id=user_invitation').reply(200, `{new_invites: []}`)
-//     .get('/Users?filter=email+eq+%22bang@thingcom%22').reply(200, uaaData.noFoundUsersByEmail)
-//   ;
-//   const response = await request(app)
-//     .post('/3deb9f04-b449-4f94-b3dd-c73cefe5b275/invite')
-//     .type('form')
-//     .send({
-//       email: 'bang@thingcom',
-//       'org_roles[3deb9f04-b449-4f94-b3dd-c73cefe5b275][billing_managers]': '1'
-//     });
-//   t.equal(response.status, 400);
-//   t.contains(response.text, 'a valid email address is required');
-// });
-// tslint:enable:max-line-length
-
-test('should show error message when invitee is already a member of org', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {
-    email: 'imeCkO@test.org',
-    org_roles: {
-      '3deb9f04-b449-4f94-b3dd-c73cefe5b275': {
-        billing_managers: '1',
-      },
+function composeOrgRoles(setup: object) {
+  const defaultRoles = {
+    billing_managers: {
+      current: '0',
     },
-  });
-
-  t.contains(response.body, 'is already a member of the organisation');
-  t.equal(response.status, 400);
-});
-
-test('should show error when no roles selected', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {email: 'jeff@jeff.com'});
-
-  t.contains(response.body, 'at least one role should be selected');
-  t.equal(response.status, 400);
-});
-
-test('should invite the user, set BillingManager role and show success', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {
-    email: 'jeff@jeff.com',
-    org_roles: {
-      '3deb9f04-b449-4f94-b3dd-c73cefe5b275': {
-        billing_managers: '1',
-      },
+    managers: {
+      current: '0',
     },
-  });
-
-  t.contains(response.body, 'Invited a new team member');
-});
-
-test('should invite the user, set OrgManager role and show success', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {
-    email: 'jeff@jeff.com',
-    org_roles: {
-      '3deb9f04-b449-4f94-b3dd-c73cefe5b275': {
-        managers: '1',
-      },
+    auditors: {
+      current: '0',
     },
-  });
+  };
 
-  t.contains(response.body, 'Invited a new team member');
-});
+  return {
+    ...defaultRoles,
+    ...setup,
+  };
+}
 
-test('should invite the user, set OrgAuditor role and show success', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {
-    email: 'jeff@jeff.com',
-    org_roles: {
-      '3deb9f04-b449-4f94-b3dd-c73cefe5b275': {
-        auditors: '1',
-      },
+function composeSpaceRoles(setup: object) {
+  const defaultRoles = {
+    developers: {
+      current: '0',
     },
-  });
-
-  t.contains(response.body, 'Invited a new team member');
-});
-
-test('should invite the user, set SpaceManager role and show success', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {
-    email: 'jeff@jeff.com',
-    space_roles: {
-      '5489e195-c42b-4e61-bf30-323c331ecc01': {
-        managers: '1',
-      },
+    managers: {
+      current: '0',
     },
-  });
-
-  t.contains(response.body, 'Invited a new team member');
-});
-
-test('should invite the user, set SpaceDeveloper role and show success', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {
-    email: 'jeff@jeff.com',
-    space_roles: {
-      '5489e195-c42b-4e61-bf30-323c331ecc01': {
-        developers: '1',
-      },
+    auditors: {
+      current: '0',
     },
+  };
+
+  return {
+    ...defaultRoles,
+    ...setup,
+  };
+}
+
+test('ordinary set of tests', async _t => {
+  // tslint:disable:max-line-length
+  nock('https://example.com/api').persist()
+    .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, cfData.organization)
+    .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, cfData.spaces)
+    .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/spaces').reply(200, cfData.spaces)
+    .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').reply(200, cfData.spaces)
+    .get('/v2/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8/organizations').reply(200, `{"resources": []}`)
+    .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, cfData.userRolesForOrg)
+    .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/user_roles').reply(200, cfData.userRolesForSpace)
+    .get('/v2/info').reply(200, cfData.info)
+    .post('/v2/users').reply(200, cfData.user)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/uaa-user-edit-123456').reply(200, `{}`)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/uaa-user-edit-123456').reply(200, `{}`)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/uaa-user-edit-123456').reply(200, `{}`)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
+    .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/uaa-user-edit-123456').reply(200, `{}`)
+    .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/uaa-user-edit-123456').reply(200, `{}`)
+    .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/uaa-user-edit-123456').reply(200, `{}`)
+    .delete('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/uaa-user-edit-123456').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/uaa-user-edit-123456').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/uaa-user-edit-123456').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/uaa-user-edit-123456').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
+    .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, `{}`)
+    .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/uaa-user-edit-123456').reply(200, `{}`)
+    .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/uaa-user-edit-123456').reply(200, `{}`)
+    .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/uaa-user-edit-123456').reply(200, `{}`)
+    .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
+    .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/99022be6-feb8-4f78-96f3-7d11f4d476f1').reply(200, `{}`)
+    .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users').reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
+    .get('/v2/users/99022be6-feb8-4f78-96f3-7d11f4d476f1/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, {resources: []})
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8').reply(200, {})
+  ;
+
+  nock('https://example.com/uaa').persist()
+    .get('/Users?filter=email+eq+%22imeCkO@test.org%22').reply(200, uaaData.usersByEmail)
+    .get('/Users?filter=email+eq+%22jeff@jeff.com%22').reply(200, uaaData.noFoundUsersByEmail)
+    .post('/invite_users?redirect_uri=https://www.cloud.service.gov.uk/next-steps?success&client_id=user_invitation').reply(200, uaaData.invite)
+    .post('/oauth/token?grant_type=client_credentials').reply(200, `{"access_token": "FAKE_ACCESS_TOKEN"}`)
+  ;
+
+  nock(/api.notifications.service.gov.uk/).persist()
+    .filteringPath(() => '/')
+    .post('/').reply(200, {notify: 'FAKE_NOTIFY_RESPONSE'})
+  ;
+  // tslint:enable:max-line-length
+
+  test('should show the users pages', async t => {
+    const response = await users.listUsers(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    });
+
+    t.contains(response.body, 'Team members');
   });
 
-  t.contains(response.body, 'Invited a new team member');
-});
+  test('should show the invite page', async t => {
+    const response = await users.inviteUserForm(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    });
 
-test('should invite the user, set SpaceAuditor role and show success', async t => {
-  const response = await users.inviteUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-  }, {
-    email: 'jeff@jeff.com',
-    space_roles: {
-      '5489e195-c42b-4e61-bf30-323c331ecc01': {
-        auditors: '1',
+    t.contains(response.body, 'Invite a new team member');
+  });
+
+  test('should show error message when email is missing', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {});
+
+    t.contains(response.body, 'a valid email address is required');
+    t.equal(response.status, 400);
+  });
+
+  test('should show error message when email is invalid according to our regex', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {email: 'x'});
+
+    t.contains(response.body, 'a valid email address is required');
+    t.equal(response.status, 400);
+  });
+
+  // TODO: implement this when refactoring tests
+  // tslint:disable:max-line-length
+  // test('should show error message when email is invalid acording to invite_users', async t => {
+  //   nock('https://example.com/uaa')
+  //     .post('/invite_users?redirect_uri=https://www.cloud.service.gov.uk/next-steps?success&client_id=user_invitation').reply(200, `{new_invites: []}`)
+  //     .get('/Users?filter=email+eq+%22bang@thingcom%22').reply(200, uaaData.noFoundUsersByEmail)
+  //   ;
+  //   const response = await request(app)
+  //     .post('/3deb9f04-b449-4f94-b3dd-c73cefe5b275/invite')
+  //     .type('form')
+  //     .send({
+  //       email: 'bang@thingcom',
+  //       'org_roles[3deb9f04-b449-4f94-b3dd-c73cefe5b275][billing_managers]': '1'
+  //     });
+  //   t.equal(response.status, 400);
+  //   t.contains(response.text, 'a valid email address is required');
+  // });
+  // tslint:enable:max-line-length
+
+  test('should show error message when invitee is already a member of org', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {
+      email: 'imeCkO@test.org',
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          billing_managers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
       },
-    },
+    });
+
+    t.contains(response.body, 'is already a member of the organisation');
+    t.equal(response.status, 400);
   });
 
-  t.contains(response.body, 'Invited a new team member');
-});
+  test('should show error when no roles selected', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {email: 'jeff@jeff.com'});
 
-test('should show the user edit page', async t => {
-  const response = await users.editUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'uaa-user-edit-123456',
+    t.contains(response.body, 'at least one role should be selected');
+    t.equal(response.status, 400);
   });
 
-  t.contains(response.body, 'Update a team member');
-});
-
-test('should fail to show the user edit page due to not existing user', async t => {
-  t.rejects(users.editUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'not-existing-user',
-  }), /user not found/);
-});
-
-test('should show error when no roles selected - User Edit', async t => {
-  const response = await users.updateUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'uaa-user-edit-123456',
-  }, {test: 'qwerty123456'});
-
-  t.contains(response.body, 'at least one role should be selected');
-  t.equal(response.status, 400);
-});
-
-test('should update the user, set BillingManager role and show success - User Edit', async t => {
-  const response = await users.updateUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'uaa-user-edit-123456',
-  }, {
-    org_roles: {
-      '3deb9f04-b449-4f94-b3dd-c73cefe5b275': {
-        billing_managers: '1',
+  test('should invite the user, set BillingManager role and show success', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {
+      email: 'jeff@jeff.com',
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          billing_managers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
       },
-    },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+
+    t.contains(response.body, 'Invited a new team member');
   });
 
-  t.contains(response.body, 'Updated a team member');
+  test('should invite the user, set OrgManager role and show success', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {
+      email: 'jeff@jeff.com',
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          managers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+
+    t.contains(response.body, 'Invited a new team member');
+  });
+
+  test('should invite the user, set OrgAuditor role and show success', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {
+      email: 'jeff@jeff.com',
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          auditors: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+
+    t.contains(response.body, 'Invited a new team member');
+  });
+
+  test('should invite the user, set SpaceManager role and show success', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {
+      email: 'jeff@jeff.com',
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({}),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          managers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+    });
+
+    t.contains(response.body, 'Invited a new team member');
+  });
+
+  test('should invite the user, set SpaceDeveloper role and show success', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {
+      email: 'jeff@jeff.com',
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({}),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          developers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+    });
+
+    t.contains(response.body, 'Invited a new team member');
+  });
+
+  test('should invite the user, set SpaceAuditor role and show success', async t => {
+    const response = await users.inviteUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+    }, {
+      email: 'jeff@jeff.com',
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({}),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          auditors: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+    });
+
+    t.contains(response.body, 'Invited a new team member');
+  });
+
+  test('should show the user edit page', async t => {
+    const response = await users.editUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    });
+
+    t.contains(response.body, 'Update a team member');
+  });
+
+  test('should fail to show the user edit page due to not existing user', async t => {
+    t.rejects(users.editUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'not-existing-user',
+    }), /user not found/);
+  });
+
+  test('should show error when no roles selected - User Edit', async t => {
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {test: 'qwerty123456'});
+
+    t.contains(response.body, 'at least one role should be selected');
+    t.equal(response.status, 400);
+  });
+
+  test('should update the user, set BillingManager role and show success - User Edit', async t => {
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          billing_managers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+
+    t.contains(response.body, 'Updated a team member');
+  });
+
+  test('should update the user, set OrgManager role and show success - User Edit', async t => {
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          managers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+
+    t.contains(response.body, 'Updated a team member');
+  });
+
+  test('should update the user, set OrgAuditor role and show success - User Edit', async t => {
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          auditors: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+
+    t.contains(response.body, 'Updated a team member');
+  });
+
+  test('should update the user, set SpaceManager role and show success - User Edit', async t => {
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({}),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          managers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+    });
+
+    t.contains(response.body, 'Updated a team member');
+  });
+
+  test('should update the user, set SpaceDeveloper role and show success - User Edit', async t => {
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({}),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          developers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+    });
+
+    t.contains(response.body, 'Updated a team member');
+  });
+
+  test('should update the user, set SpaceAuditor role and show success - User Edit', async t => {
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({}),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          auditors: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+    });
+
+    t.contains(response.body, 'Updated a team member');
+  });
 });
 
-test('should update the user, set OrgManager role and show success - User Edit', async t => {
-  const response = await users.updateUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'uaa-user-edit-123456',
-  }, {
-    org_roles: {
-      '3deb9f04-b449-4f94-b3dd-c73cefe5b275': {
-        managers: '1',
+test('permissions calling cc api', async _t => {
+  nock.cleanAll();
+
+  test('should make a single request due to permission update', async t => {
+    nock.cleanAll();
+
+    const scope = nock('https://example.com/api').persist()
+      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/uaa-user-edit-123456')
+      .reply(200, `{}`)
+      .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/uaa-user-edit-123456')
+      .reply(200, `{}`)
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .reply(200, cfData.userRolesForOrg)
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
+      .reply(200, cfData.organization)
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
+      .reply(200, cfData.spaces)
+    ;
+
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          managers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
       },
-    },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          developers: {
+            current: '0',
+            desired: '1',
+          },
+        }),
+      },
+    });
+
+    t.ok(scope.isDone());
+    t.contains(response.body, 'Updated a team member');
   });
 
-  t.contains(response.body, 'Updated a team member');
-});
+  test('should make no requests when permission is previously and is still set', async t => {
+    nock.cleanAll();
 
-test('should update the user, set OrgAuditor role and show success - User Edit', async t => {
-  const response = await users.updateUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'uaa-user-edit-123456',
-  }, {
-    org_roles: {
-      '3deb9f04-b449-4f94-b3dd-c73cefe5b275': {
-        auditors: '1',
+    const scope = nock('https://example.com/api').persist()
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .reply(200, cfData.userRolesForOrg)
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
+      .reply(200, cfData.organization)
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
+      .reply(200, cfData.spaces)
+    ;
+
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          managers: {
+            current: '1',
+            desired: '1',
+          },
+        }),
       },
-    },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          developers: {
+            current: '1',
+            desired: '1',
+          },
+        }),
+      },
+    });
+
+    t.ok(scope.isDone());
+    t.contains(response.body, 'Updated a team member');
   });
 
-  t.contains(response.body, 'Updated a team member');
-});
+  test('should make no requests when permission was previously unset and is still unset', async t => {
+    nock.cleanAll();
 
-test('should update the user, set SpaceManager role and show success - User Edit', async t => {
-  const response = await users.updateUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'uaa-user-edit-123456',
-  }, {
-    space_roles: {
-      '5489e195-c42b-4e61-bf30-323c331ecc01': {
-        managers: '1',
+    const scope = nock('https://example.com/api').persist()
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .reply(200, cfData.userRolesForOrg)
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
+      .reply(200, cfData.organization)
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
+      .reply(200, cfData.spaces)
+    ;
+
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-edit-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          billing_managers: {
+            current: '0',
+          },
+        }),
       },
-    },
-  });
-
-  t.contains(response.body, 'Updated a team member');
-});
-
-test('should update the user, set SpaceDeveloper role and show success - User Edit', async t => {
-  const response = await users.updateUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'uaa-user-edit-123456',
-  }, {
-    space_roles: {
-      '5489e195-c42b-4e61-bf30-323c331ecc01': {
-        developers: '1',
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({
+          developers: {
+            current: '0',
+          },
+        }),
       },
-    },
+    });
+
+    t.ok(scope.isDone());
+    t.contains(response.body, 'Updated a team member');
   });
-
-  t.contains(response.body, 'Updated a team member');
-});
-
-test('should update the user, set SpaceAuditor role and show success - User Edit', async t => {
-  const response = await users.updateUser(ctx, {
-    organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    userGUID: 'uaa-user-edit-123456',
-  }, {
-    space_roles: {
-      '5489e195-c42b-4e61-bf30-323c331ecc01': {
-        auditors: '1',
-      },
-    },
-  });
-
-  t.contains(response.body, 'Updated a team member');
 });


### PR DESCRIPTION
## What

We were making a lot of calls each time a single permission would change.
Meaning we have likely hit the problem with API responding with errors
when "unsetting" permission that has not been previously set.

We decided to record current and desired permission in HTML for later
comparison in the handlers and preparing the call that matters to end
user.

## How to review

1. Sign in as a user with only OrgManager role
1. Attempt to update the roles of another user
1. Be successful

OR 

1. Sign in as a user with only OrgManager role
1. Attempt to invite a user
1. Be successful

## Who can review

Neither @dcarley nor myself.
