### PR TITLE
[#156761419] Less verbose logs

### DIFF
--- a/src/@types/express-pino-logger/index.d.ts
+++ b/src/@types/express-pino-logger/index.d.ts
@@ -1,9 +1,10 @@
 declare module 'express-pino-logger' {
   import express from 'express';
-  import { BaseLogger } from 'pino';
+  import { BaseLogger, SerializerFn } from 'pino';
 
   interface IOptions {
     readonly logger: BaseLogger;
+    serializers?: { [key: string]: SerializerFn };
   }
 
   type MiddlewareFunction = (req: express.Request, res: express.Response, next: express.NextFunction) => void;

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import pinoMiddleware from 'express-pino-logger';
 import staticGzip from 'express-static-gzip';
 import helmet from 'helmet';
+import { IncomingMessage, ServerResponse } from 'http';
 import { BaseLogger } from 'pino';
 
 import auth from '../auth';
@@ -33,7 +34,18 @@ export interface IAppConfig {
 export default function(config: IAppConfig) {
   const app = express();
 
-  app.use(pinoMiddleware({logger: config.logger}));
+  app.use(pinoMiddleware({
+    logger: config.logger,
+    serializers: {
+      req: (req: IncomingMessage) => ({
+        method: req.method,
+        url: req.url,
+      }),
+      res: /* istanbul ignore next */ (res: ServerResponse) => ({
+        status: res.statusCode,
+      }),
+    },
+  }));
 
   app.set('trust proxy', true);
 


### PR DESCRIPTION
## What

Pino by default would provide a lot of information through to the logs.
This may be helpful at some point, but in practice is annoying and
dangerous as a session cookie is printed.

We have a habbit of copying the error log and pasting in places, meaning
it could potentially leak the session. Let's avoid it by serializing the
request and response for the logger to use.

## How to review

- Run application
- Login to the app
- Cause an error, like visit `/organisations/fake` route
- Observe logs - experience lack of headers in the logs

## Who can review

Neither @dcarley nor myself
