### PR TITLE
Fix the dead URL on next steps

### DIFF
--- a/src/organizations/organizations.njk
+++ b/src/organizations/organizations.njk
@@ -30,7 +30,7 @@
   <div class="govuk-o-grid paas-download-section">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
       <h3>Download the Cloud Foundry command line tool</h3>
-      <p>You’ll need to do this to operate GOV.UK PaaS from your terminal. You can download the cf command line tool using one of the installation options or by visiting the <a href="#">github page</a>.</p>
+      <p>You’ll need to do this to operate GOV.UK PaaS from your terminal. You can download the cf command line tool using one of the installation options or by visiting the <a href="https://github.com/cloudfoundry/cli#downloads">github page</a>.</p>
     </div>
     <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
       <h3>Installation options:</h3>


### PR DESCRIPTION
## What

We'd like to point the users to the general instructions of setting up their
CLI with different methods. Currently it's pointing at `#`, meaning the user
would rather be taken to the top of the page instead.

## How to review

See if the we're pointing to the right place.