### PR TITLE
Fix whitespace and swap organisation managers and managing team members

### DIFF
--- a/src/spaces/_spaces.scss
+++ b/src/spaces/_spaces.scss
@@ -102,3 +102,24 @@
 .space-information {
   color: $govuk-text-colour;
 }
+
+.organisation-overview  {
+  a {
+    @include govuk-font-bold-19;
+    text-decoration: underline;
+  }
+
+  table a {
+    @include govuk-font-regular-16;
+    text-decoration: none;
+  }
+
+  p {
+    @include govuk-font-regular-19;
+    margin-top: $govuk-spacing-scale-1;
+  }
+
+  h2 {
+    margin-bottom: $govuk-spacing-scale-7;
+  }
+}

--- a/src/spaces/_spaces.scss
+++ b/src/spaces/_spaces.scss
@@ -2,6 +2,8 @@
   a {
     display: block;
   }
+
+  margin-bottom: $govuk-spacing-scale-8;
 }
 
 .space {

--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -103,7 +103,7 @@
   {% endfor %}
   </div>
 
-  <div class="govuk-o-grid">
+  <div class="govuk-o-grid organisation-overview">
     <div class="govuk-o-grid__item govuk-o-grid__item--full">
       <h2 class="govuk-heading-l">
         This organisation has {{ users | length }} team members
@@ -111,17 +111,7 @@
     </div>
 
     <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
-      <a href="{{ linkTo('admin.organizations.users', {organizationGUID: organization.metadata.guid}) }}" class="govuk-link">
-        View and manage team members
-      </a>
-
-      <p>
-        As an ‘org manager’ you can manage team members in your organiation.
-      </p>
-    </div>
-
-    <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
-      <table class="govuk-c-table">
+      <table class="govuk-c-table organisation-managers">
         <caption class="govuk-c-table__caption">
           There are {{ managers | length }} Org managers:
         </caption>
@@ -130,7 +120,7 @@
           {% for user in managers %}
             <tr class="govuk-c-table__row">
               <td class="govuk-c-table__cell">
-                <a href="{{ linkTo('admin.organizations.users.edit', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-link">
+                <a href="{{ linkTo('admin.organizations.users.edit', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}">
                   {{ user.entity.username }}
                 </a>
               </td>
@@ -156,6 +146,16 @@
           </a>
         </div>
       </details>
+    </div>
+
+    <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
+      <a href="{{ linkTo('admin.organizations.users', {organizationGUID: organization.metadata.guid}) }}">
+        View and manage team members
+      </a>
+
+      <p>
+        As an ‘org manager’ you can manage team members in your organiation.
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -101,13 +101,15 @@
       </section>
     </a>
   {% endfor %}
-  <div>
-
-  <h2 class="govuk-heading-l">
-    This organisation has {{ users | length }} team members
-  </h2>
+  </div>
 
   <div class="govuk-o-grid">
+    <div class="govuk-o-grid__item govuk-o-grid__item--full">
+      <h2 class="govuk-heading-l">
+        This organisation has {{ users | length }} team members
+      </h2>
+    </div>
+
     <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
       <a href="{{ linkTo('admin.organizations.users', {organizationGUID: organization.metadata.guid}) }}" class="govuk-link">
         View and manage team members


### PR DESCRIPTION
## What

Swap organisation managers and managing team members from left to right and fix some of the font sizing, underlines and whitespace to match Steve's design.  Also fix spacing between spaces and organisation section.

Before:
<img width="1025" alt="screen shot 2018-04-26 at 18 04 22" src="https://user-images.githubusercontent.com/11633362/39320531-52707702-497c-11e8-83c0-38ee168fa1e7.png">

After:
<img width="980" alt="screen shot 2018-04-26 at 18 03 05" src="https://user-images.githubusercontent.com/11633362/39320549-5bc574ba-497c-11e8-8a9a-eeef23b0caec.png">


## How to review

Check against Steve's design, make sure it still works.

## Who can review

Anyone who isn't me.
