### PR TITLE
Fix jumping on space hover

### DIFF
--- a/src/spaces/_spaces.scss
+++ b/src/spaces/_spaces.scss
@@ -16,12 +16,16 @@
   margin-right: $govuk-spacing-scale-3;
   margin-left: $govuk-spacing-scale-3;
   margin-bottom: $govuk-spacing-scale-2;
-  transition: background-color .1s ease;
+  transition: background-color .1s ease, border-color .1s ease;
   text-align: left;
   @include govuk-font-regular-16;
 
   &:hover {
     border: 2px solid $govuk-blue;
+    padding-top: $govuk-spacing-scale-5 - 1px;
+    padding-bottom: $govuk-spacing-scale-4 - 1px;
+    padding-right: $govuk-spacing-scale-3 - 1px;
+    padding-left: $govuk-spacing-scale-3 - 1px;
   }
 
   h4 {


### PR DESCRIPTION
## What

Currently, when one would hover over the space box, all of the boxes
below would jump down by 2px. This is not really nice to look at or
experience and the solution may be relatively simple.

We're reducing the padding inside the box on hover, forcing the box size
to remain the same. This eliminates the issue.

## How to review

- Run the application
- Navigate to organisation view
- Hover over spaces
- Experience no jumping around (may want to do the same on master to see the difference)