### PR TITLE
[#157092603] Remove the large heading

### DIFF
--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -10,11 +10,10 @@
 {% endblock %}
 
 {% block main %}
-  <div class="govuk-o-grid">
+  <div class="govuk-o-grid govuk-!-mb-r8 govuk-!-mt-r5">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">Organisation</span>
-        {{ organization.entity.name }}
+      <h1 class="govuk-heading-l">
+        This organisation has {{ spaces | length }} spaces
       </h1>
     </div>
 
@@ -34,10 +33,6 @@
       </table>
     </div>
   </div>
-
-  <h2 class="govuk-heading-l">
-    This organisation has {{ spaces | length }} spaces
-  </h2>
 
   <details class="govuk-c-details" role="group">
     <summary class="govuk-c-details__summary" role="button" aria-controls="details-content-0" aria-expanded="false">


### PR DESCRIPTION
## What

We'd like to clutter the page less. We've decided the organisation title
doesn't need to be repeated throughout, as it's already used in the nav.

Re juggling things around.

## How to review

- Run the application
- Visit single organisation
- See that the heading is no longer a duplicate

### Before

![screen shot 2018-05-03 at 13 59 06](https://user-images.githubusercontent.com/2418945/39577849-59856db4-4eda-11e8-8d6a-5c66da0c626a.png)

### After

![screen shot 2018-05-03 at 14 00 18](https://user-images.githubusercontent.com/2418945/39577858-5e2dba38-4eda-11e8-908c-77dbf6da9743.png)
