### PR TITLE
[#156888176] Support multiple JWT signing keys

### DIFF
--- a/src/auth/has-role.test.ts
+++ b/src/auth/has-role.test.ts
@@ -3,7 +3,7 @@ import { test } from 'tap';
 
 import { Token } from '.';
 
-const tokenKeys: ReadonlyArray<string> = ['secret'];
+const tokenKeys: ReadonlyArray<string> = ['secret', 'old-secret'];
 const time = Math.floor(Date.now() / 1000);
 
 test('should throw error if unverifiable accessToken', async t => {
@@ -56,4 +56,10 @@ test('should have scopes', async t => {
   const accessToken = jwt.sign({exp: (time + (24 * 60 * 60)), scope: ['read-write']}, tokenKeys[0]);
   const token = new Token(accessToken, tokenKeys);
   t.ok(token.hasScope('read-write'));
+});
+
+test('should succeed when verifying with older key', async t => {
+  const accessToken = jwt.sign({exp: (time + (24 * 60 * 60)), scope: ['read-write']}, tokenKeys[1]);
+  const token = new Token(accessToken, tokenKeys);
+  t.ok(token.expiry);
 });

--- a/src/auth/has-role.ts
+++ b/src/auth/has-role.ts
@@ -29,7 +29,23 @@ export class Token {
 }
 
 function verify(accessToken: string, signingKeys: ReadonlyArray<string>): IToken {
-  const rawToken: any = jwt.verify(accessToken, signingKeys[0]);
+  let rawToken: any;
+  let jwtError;
+
+  for (const key of signingKeys) {
+    try {
+      rawToken = jwt.verify(accessToken, key);
+      break; // Break out of the for loop, in order not to continue testing remaining keys.
+    } catch (err) {
+      // We're iterating over each key, in attempt to verify the JWT token.
+      // Throwing an error would prevent the next key to be tried.
+      jwtError = err;
+    }
+  }
+
+  if (typeof rawToken === 'undefined') {
+    throw jwtError;
+  }
 
   if (typeof rawToken !== 'object') {
     throw new Error('jwt: could not verify the token as no object has been verified');


### PR DESCRIPTION
## What

It is possible the UAA would return with more than one signing key. This
is due to rotation of secrets and prevention of old keys being disabled
after that happens.

We'd like the paas-admin, to validate against any found key, to be 100%
sure the keys are(n't) valid.

I'm not the big fan of the implementation, so I'm happy to hear other
ideas :)

## How to review

- Run tests (done with travis)
- Run application
- Follow [Dan's steps](https://www.pivotaltracker.com/story/show/156888176/comments/188574135) to replicate issue
- Expect no error

## Who can review

Neither @carolinegreen nor myself.