### PR TITLE
Fix logout so that it goes to sign in page

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -81,6 +81,7 @@ export default function(config: IAppConfig) {
     authorizationURL: `${config.authorizationAPI}/oauth/authorize`,
     clientID: config.oauthClientID,
     clientSecret: config.oauthClientSecret,
+    logoutURL: `${config.authorizationAPI}/logout.do`,
     tokenURL: `${config.uaaAPI}/oauth/token`,
     uaaAPI: config.uaaAPI,
   }));

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -40,6 +40,7 @@ app.use(auth({
   authorizationURL: 'https://example.com/login/oauth/authorize',
   clientID: 'key',
   clientSecret: 'secret',
+  logoutURL: 'https://example.com/login/logout.do',
   tokenURL: 'https://example.com/uaa/oauth/token',
   uaaAPI: 'https://example.com/uaa',
 }));
@@ -109,7 +110,7 @@ test('can login with a code', async t => {
     const response = await agent.get('/auth/logout');
 
     ts.equal(response.status, 302);
-    ts.equal(response.header.location, '/');
+    ts.equal(response.header.location, 'https://example.com/login/logout.do');
   });
 
   await t.test('can not reach an endpoint behind authentication', async ts => {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -15,6 +15,7 @@ interface IConfig {
   readonly authorizationURL: string;
   readonly tokenURL: string;
   readonly uaaAPI: string;
+  readonly logoutURL: string;
 }
 
 /* istanbul ignore next */
@@ -58,7 +59,7 @@ export default function authentication(config: IConfig) {
 
   app.get('/auth/logout', (req: {logout: () => void}, res) => {
     req.logout();
-    res.redirect('/');
+    res.redirect(config.logoutURL);
   });
 
   app.use(syncMiddleware(async (req: any, res, next) => {


### PR DESCRIPTION
## What

Previous journey was confusing for people, as the redirect made it appear that they hadn't logged out, so go to sign in page when they are logged out to make it clear.

## How to review

Run the application.  Make sure you go to the sign in page when you logout.

## Who can review

Not me or @paroxp 
