### PR TITLE
Remove Superfluous Link

### DIFF
--- a/src/organizations/subnav/element.njk
+++ b/src/organizations/subnav/element.njk
@@ -4,7 +4,6 @@
   </div>
 
   <nav class="govuk-grid-column-two-thirds">
-    <a href="/spaces/{{ organization.metadata.guid }}" class="govuk-link active">
     <a href="{{ linkTo('admin.organizations.view', {organizationGUID: organization.metadata.guid}) }}" class="govuk-link {% if not routePartOf('admin.organizations.users') %} active {% endif %}">
       Overview
     </a>


### PR DESCRIPTION
## What

Voiceover on mac was picking up an extra link(below) that wasn't visible.  The cause was a redundant link that not been fully removed.

## Extra Link

<img width="1280" alt="screen shot 2018-04-25 at 15 56 39" src="https://user-images.githubusercontent.com/11633362/41158806-381a46ae-6b22-11e8-9997-5c8fd9ec166a.png">

## How to review

Ideally check with a screenreader such as mac voiceover that the link is no longer there.  However, it is also picked up if you just tab through.  Make sure everything still works.

## Who can review

Anyone who isn't me.