### PR TITLE
[#157080422] Fix user provided service overview

### DIFF
--- a/src/cf/cf.test.data.ts
+++ b/src/cf/cf.test.data.ts
@@ -866,4 +866,61 @@ export const userRolesForSpace = `{
     }
   ]
 }`;
+
+export const userServiceInstance = `{
+  "metadata": {
+    "guid": "e9358711-0ad9-4f2a-b3dc-289d47c17c87",
+    "url": "/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87",
+    "created_at": "2016-06-08T16:41:29Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "name-1700",
+    "credentials": {
+      "creds-key-58": "creds-val-58"
+    },
+    "space_guid": "22236d1a-d9c7-44b7-bdad-2bb079a6c4a1",
+    "type": "user_provided_service_instance",
+    "syslog_drain_url": "https://foo.com/url-104",
+    "route_service_url": null,
+    "tags": [
+      "accounting",
+      "mongodb"
+    ],
+    "space_url": "/v2/spaces/22236d1a-d9c7-44b7-bdad-2bb079a6c4a1",
+    "service_bindings_url": "/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87/service_bindings",
+    "routes_url": "/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87/routes"
+  }
+}`;
+
+export const userServices = `{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "54e4c645-7d20-4271-8c27-8cc904e1e7ee",
+        "url": "/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee",
+        "created_at": "2016-06-08T16:41:33Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "name-1696",
+        "credentials": {
+          "creds-key-57": "creds-val-57"
+        },
+        "space_guid": "87d14ac2-f396-460e-a523-dc1d77aba35a",
+        "type": "user_provided_service_instance",
+        "syslog_drain_url": "https://foo.com/url-103",
+        "route_service_url": null,
+        "tags": ["accounting", "mongodb"],
+        "space_url": "/v2/spaces/87d14ac2-f396-460e-a523-dc1d77aba35a",
+        "service_bindings_url": "/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee/service_bindings",
+        "routes_url": "/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee/routes"
+      }
+    }
+  ]
+}`;
 // tslint:enable:max-line-length

--- a/src/cf/cf.test.ts
+++ b/src/cf/cf.test.ts
@@ -10,6 +10,7 @@ const config = {
   accessToken: 'qwerty123456',
 };
 
+// tslint:disable:max-line-length
 nock('https://example.com/api').persist()
   .get('/v2/info').reply(200, data.info)
   .get('/v2/organizations').reply(200, data.organizations)
@@ -26,6 +27,8 @@ nock('https://example.com/api').persist()
   .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92').times(1).reply(200, data.serviceInstance)
   .get('/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332').times(1).reply(200, data.servicePlan)
   .get('/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5').times(1).reply(200, data.service)
+  .get('/v2/user_provided_service_instances').times(1).reply(200, data.userServices)
+  .get('/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87').times(1).reply(200, data.userServiceInstance)
   .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, data.spaces)
   .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, data.userRolesForOrg)
   .get('/v2/spaces/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, data.userRolesForSpace)
@@ -46,6 +49,7 @@ nock('https://example.com/api').persist()
 nock('https://example.com/uaa').persist()
   .post('/oauth/token?grant_type=client_credentials').reply(200, `{"access_token": "TOKEN_FROM_ENDPOINT"}`)
 ;
+// tslint:enable:max-line-length
 
 test('should fail to get token client without accessToken or clientCredentials', async t => {
   const client = new CloudFoundryClient({apiEndpoint: 'https://example.com/api'});
@@ -270,4 +274,19 @@ test('should obtain list of user roles for organisation and not find logged in u
   );
 
   t.notOk(hasRole);
+});
+
+test('should obtain list of user provided services', async t => {
+  const client = new CloudFoundryClient(config);
+  const services = await client.userServices();
+
+  t.ok(services.length > 0);
+  t.equal(services[0].entity.name, 'name-1696');
+});
+
+test('should obtain user provided service', async t => {
+  const client = new CloudFoundryClient(config);
+  const service = await client.userServiceInstance('e9358711-0ad9-4f2a-b3dc-289d47c17c87');
+
+  t.equal(service.entity.name, 'name-1700');
 });

--- a/src/cf/cf.ts
+++ b/src/cf/cf.ts
@@ -178,6 +178,16 @@ export default class CloudFoundryClient {
     return this.allResources(response);
   }
 
+  public async userServices(): Promise<cf.IUserServices[]> {
+    const response = await this.request('get', `/v2/user_provided_service_instances`);
+    return this.allResources(response);
+  }
+
+  public async userServiceInstance(instanceGUID: string): Promise<cf.IServiceInstance> {
+    const response = await this.request('get', `/v2/user_provided_service_instances/${instanceGUID}`);
+    return response.data;
+  }
+
   public async setOrganizationRole(
     organizationGUID: string,
     userGUID: string,

--- a/src/cf/types.ts
+++ b/src/cf/types.ts
@@ -307,3 +307,19 @@ export interface ISpaceSummary {
   readonly name: string;
   readonly services: ReadonlyArray<IServiceSummary>;
 }
+
+export interface IUserServices {
+  readonly entity: {
+    readonly credentials: {[i: string]: string};
+    readonly name: string;
+    readonly route_service_url: string | null;
+    readonly routes_url: string;
+    readonly service_bindings_url: string;
+    readonly space_guid: string;
+    readonly space_url: string;
+    readonly syslog_drain_url: string;
+    readonly tags: ReadonlyArray<string>;
+    readonly type: string; // tslint:disable-line:no-reserved-keywords
+  };
+  readonly metadata: IMetadata;
+}

--- a/src/services/overview.njk
+++ b/src/services/overview.njk
@@ -36,7 +36,7 @@
               text: 'Type'
             },
             {
-              text: service.service_plan.service.entity.label
+              text: service.service_plan.service.entity.label | default('User Provided Service')
             }
           ],
           [
@@ -44,7 +44,7 @@
               text: 'Plan'
             },
             {
-              text: service.service_plan.entity.name
+              text: service.service_plan.entity.name | default('N/A')
             }
           ],
           [
@@ -52,7 +52,7 @@
               text: 'State'
             },
             {
-              text: service.entity.last_operation.state
+              text: service.entity.last_operation.state | default('N/A')
             }
           ],
           [

--- a/src/services/services.test.ts
+++ b/src/services/services.test.ts
@@ -10,12 +10,16 @@ import * as data from '../cf/cf.test.data';
 
 import { viewService } from '.';
 
+// tslint:disable:max-line-length
 nock('https://example.com/api')
   .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92').times(1).reply(200, data.serviceInstance)
   .get('/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1').times(1).reply(200, data.servicePlan)
   .get('/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450').times(1).reply(200, data.service)
-  .get('/v2/spaces/38511660-89d9-4a6e-a889-c32c7e94f139').times(1).reply(200, data.space)
-  .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9').times(1).reply(200, data.organization);
+  .get('/v2/spaces/38511660-89d9-4a6e-a889-c32c7e94f139').times(2).reply(200, data.space)
+  .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9').times(2).reply(200, data.organization)
+  .get('/v2/user_provided_service_instances').times(2).reply(200, data.userServices)
+  .get('/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee').times(1).reply(200, data.userServiceInstance);
+// tslint:enable:max-line-length
 
 const tokenKey = 'secret';
 const token = jwt.sign({
@@ -39,4 +43,14 @@ test('should show the service overview page', async t => {
   });
 
   t.contains(response.body, 'name-1508 - Service Overview');
+});
+
+test('should show the user provided service overview page', async t => {
+  const response = await viewService(ctx, {
+    organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+    serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+    spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+  });
+
+  t.contains(response.body, 'name-1700 - Service Overview');
 });

--- a/src/spaces/backing-services.njk
+++ b/src/spaces/backing-services.njk
@@ -34,13 +34,13 @@
               <a href="{{ linkTo('admin.organizations.spaces.services.view', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.guid}) }}" class="govuk-link">{{ service.name }}</a>
             </th>
             <td class="govuk-table__cell ">
-              {{ service.service_plan.service.label }}
+              {{ service.service_plan.service.label | default('User Provided Service') }}
             </td>
             <td class="govuk-table__cell ">
-              {{ service.service_plan.name }}
+              {{ service.service_plan.name | default('N/A') }}
             </td>
             <td class="govuk-table__cell ">
-              {{ service.last_operation.state }}
+              {{ service.last_operation.state | default('N/A') }}
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
## What

There is a little API inconvenience, where the call listing all the
services in the space, will return mixed results for both user and
system provided instances. The endpoint however, to summarise each is
not working in a mixed manner, meaning we need to make a different call
for each of these.

API being inconvenient, there is no way to differentiate these services,
therefore we need to make additional call, to get all CUPS only, and
then doing a quick loop through them to see if the requested GUID
matches one of them. Based on that, we're making a targeted call to the
API.

## How to review

- Create yourself some services and CUPS (`cf cups my-cups -p '{"username":"admin","password":"pa55woRD"}'`)
- Run the application
- Navigate to org and space
- See listed both backing services and cups
- Attempt to enter both

## Who can review

Neither @LeePorte nor myself.
