### PR TITLE
[#156760174] Stop users from removing the last org manager

### DIFF
--- a/src/users/permissions.njk
+++ b/src/users/permissions.njk
@@ -49,6 +49,11 @@
       </td>
       <td class="govuk-table__cell ">
         <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].managers }}" name="org_roles[{{ organization.metadata.guid }}][managers][current]">
+        {% if  (managers | length < 2) and (values.org_roles[organization.metadata.guid].managers) %}
+          {% set isCheckboxDisabled = true %}
+        {% else %}
+          {% set isCheckboxDisabled = false %}
+        {% endif %}
         {{ govukCheckboxes({
           id: "org_roles[" + organization.metadata.guid + "][managers]",
           name: "org_roles[" + organization.metadata.guid + "][managers][desired]",
@@ -56,7 +61,8 @@
             {
               value: "1",
               html: "<span>Org manager</span>",
-              checked: values.org_roles[organization.metadata.guid].managers
+              checked: values.org_roles[organization.metadata.guid].managers,
+              disabled: isCheckboxDisabled
             }
           ]
         }) }}

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -157,7 +157,6 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
 
   const organization = await cf.organization(params.organizationGUID);
   const users = await cf.usersForOrganization(params.organizationGUID);
-
   await Promise.all(users.map(async (user: IOrganizationUserRoles) => {
     const userWithSpaces = {
       ...user,
@@ -360,6 +359,10 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
 
   const isAdmin = ctx.token.hasScope(CLOUD_CONTROLLER_ADMIN);
   const isManager = await cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'org_manager');
+  const users = await cf.usersForOrganization(params.organizationGUID);
+  const managers = users.filter((manager: IOrganizationUserRoles) =>
+    manager.entity.organization_roles.some(role => role === 'org_manager'),
+  );
 
   /* istanbul ignore next */
   if (!isAdmin && !isManager) {
@@ -405,6 +408,7 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
       errors: [],
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      managers,
       organization,
       spaces,
       user,


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/156760174

## What

Prevent users from removing the last org manager as this means they remove the ability to manager organisations from themselves, which if enable results in an error.  As a follow up it's worth adding copy that we recommend having at least two organisation managers at the very least.

## Disabled for removing the last org manager.

<img width="705" alt="screen shot 2018-06-14 at 17 46 26" src="https://user-images.githubusercontent.com/11633362/41426224-edf16d9a-6ffa-11e8-9783-64144b6a8a91.png">

## How to review

Run the application as a user below admin level, and try to remove all the org managers.

## Who can review

Anyone who isn't me.
