### PR TITLE
[#157111626] Add resend invite functionality

### DIFF
--- a/src/app/router.ts
+++ b/src/app/router.ts
@@ -86,6 +86,12 @@ const router = new Router([
     path: '/organisations/:organizationGUID/users/:userGUID/delete',
   },
   {
+    action: users.resendInvitation,
+    method: 'post',
+    name: 'admin.organizations.users.invite.resend',
+    path: '/organisations/:organizationGUID/users/:userGUID/invite',
+  },
+  {
     action: statement.viewStatement,
     name: 'admin.statement.view',
     path: '/organisations/:organizationGUID/statements/:rangeStart',

--- a/src/users/edit.njk
+++ b/src/users/edit.njk
@@ -45,6 +45,12 @@
       }) }}
     {% endif %}
 
+    <form method="post" action="{{ linkTo('admin.organizations.users.invite.resend', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-!-mt-r6">
+      {{ govukButton({
+        text: "Resend user invite"
+      }) }}
+    </form>
+
     <form method="post" class="govuk-!-mt-r6">
       {% include "./permissions.njk" %}
 

--- a/src/users/users.test.ts
+++ b/src/users/users.test.ts
@@ -116,6 +116,7 @@ test('ordinary set of tests', async suit => {
 
   nock(config.uaaAPI).persist()
     .get('/Users?filter=email+eq+%22imeCkO@test.org%22').reply(200, uaaData.usersByEmail)
+    .get('/Users?filter=email+eq+%22user@example.com%22').reply(200, uaaData.usersByEmail)
     .get('/Users?filter=email+eq+%22jeff@jeff.com%22').reply(200, uaaData.noFoundUsersByEmail)
     .post('/invite_users?redirect_uri=https://www.cloud.service.gov.uk/next-steps?success&client_id=user_invitation').reply(200, uaaData.invite)
     .post('/oauth/token?grant_type=client_credentials').reply(200, `{"access_token": "FAKE_ACCESS_TOKEN"}`)
@@ -330,6 +331,22 @@ test('ordinary set of tests', async suit => {
         }),
       },
     });
+
+    t.contains(response.body, 'Invited a new team member');
+  });
+
+  suit.test('should fail if the user does not exist in org', async t => {
+    t.rejects(users.resendInvitation(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'not-existing-user',
+    }, {}), /user not found/);
+  });
+
+  suit.test('should resend user invite', async t => {
+    const response = await users.resendInvitation(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-id-253',
+    }, {});
 
     t.contains(response.body, 'Invited a new team member');
   });

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -351,6 +351,84 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
   }
 }
 
+export async function resendInvitation(ctx: IContext, params: IParameters, _: object): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+  });
+
+  const isAdmin = ctx.token.hasScope(CLOUD_CONTROLLER_ADMIN);
+  const isManager = await cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'org_manager');
+
+  /* istanbul ignore next */
+  if (!isAdmin && !isManager) {
+    throw new NotFoundError('not found');
+  }
+
+  const organization = await cf.organization(params.organizationGUID);
+  const users = await cf.usersForOrganization(params.organizationGUID);
+  const user = users.find((u: IOrganizationUserRoles) => u.metadata.guid === params.userGUID);
+
+  if (!user) {
+    throw new NotFoundError('user not found within the organisation');
+  }
+
+  /* istanbul ignore next */
+  if (!VALID_EMAIL.test(user.entity.username)) {
+    throw new Error('a valid email address is required');
+  }
+
+  const uaa = new UAAClient({
+    apiEndpoint: ctx.app.uaaAPI,
+    clientCredentials: {
+      clientID: ctx.app.oauthClientID,
+      clientSecret: ctx.app.oauthClientSecret,
+    },
+  });
+
+  const uaaUser = await uaa.findUser(user.entity.username);
+  let userGUID = uaaUser && uaaUser.id;
+
+  /* istanbul ignore next */
+  if (!userGUID) {
+    throw new Error('the user does not exist');
+  }
+
+  const invitation = await uaa.inviteUser(
+    user.entity.username,
+    'user_invitation',
+    'https://www.cloud.service.gov.uk/next-steps?success',
+  );
+
+  /* istanbul ignore next */
+  if (!invitation) { // TODO: test me
+    throw new ValidationError([{field: 'email', message: 'a valid email address is required'}]);
+  }
+
+  userGUID = invitation.userId;
+
+  const notify = new NotificationClient({
+    apiKey: ctx.app.notifyAPIKey,
+    templates: {
+      welcome: ctx.app.notifyWelcomeTemplateID,
+    },
+  });
+
+  await notify.sendWelcomeEmail(user.entity.username, {
+    organisation: organization.entity.name,
+    url: invitation.inviteLink,
+  });
+
+  return {
+    body: inviteSuccessTemplate.render({
+      errors: [],
+      routePartOf: ctx.routePartOf,
+      linkTo: ctx.linkTo,
+      organization,
+    }),
+  };
+}
+
 export async function editUser(ctx: IContext, params: IParameters): Promise<IResponse> {
   const cf = new CloudFoundryClient({
     accessToken: ctx.token.accessToken,


### PR DESCRIPTION
## What

We'd like to allow our tenants to resend user invites, when they know
a link has expired or a user has been unable to log into the platform.

Unfortunately, the `active` flag on CF has not been updated when the
user finishes up setting their account, meaning we have to display it at
all times. That's not a bug, it's a feature - Org manager can reset
user's password :D

## How to review

- Code review
- Run application
- Navigate to a user (preferably the one you have email access)
- Attempt to resend invite

## Dependencies

Needs to be merged before alphagov/paas-cf#1399