### PR TITLE
[#156760174] Disable checkbox for last billing manager

### DIFF
--- a/src/users/permissions.njk
+++ b/src/users/permissions.njk
@@ -35,6 +35,11 @@
       <th class="govuk-table__header" scope="row">{{ organization.entity.name }}</th>
       <td class="govuk-table__cell ">
         <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][current]">
+        {% if  (billingManagers | length < 2) and (values.org_roles[organization.metadata.guid].billing_managers) %}
+          {% set isCheckboxDisabled = true %}
+        {% else %}
+          {% set isCheckboxDisabled = false %}
+        {% endif %}
         {{ govukCheckboxes({
           id: "org_roles[" + organization.metadata.guid + "][billing_managers]",
           name: "org_roles[" + organization.metadata.guid + "][billing_managers][desired]",
@@ -42,7 +47,8 @@
             {
               value: "1",
               html: "<span>Billing manager</span>",
-              checked: values.org_roles[organization.metadata.guid].billing_managers
+              checked: values.org_roles[organization.metadata.guid].billing_managers,
+              disabled: isCheckboxDisabled
             }
           ]
         }) }}

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -363,6 +363,9 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
   const managers = users.filter((manager: IOrganizationUserRoles) =>
     manager.entity.organization_roles.some(role => role === 'org_manager'),
   );
+  const billingManagers = users.filter((manager: IOrganizationUserRoles) =>
+    manager.entity.organization_roles.some(role => role === 'billing_manager'),
+  );
 
   /* istanbul ignore next */
   if (!isAdmin && !isManager) {
@@ -409,6 +412,7 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
       managers,
+      billingManagers,
       organization,
       spaces,
       user,


### PR DESCRIPTION
## What

As a follow up to #62, we'd like to disable the option to unset the last
billing manager as this too, brings the application to an error when
unknowingly used.

## How to review

- Attempt to remove last billing manager as non admin user
- Get blocked by the app to do so
- See #62 for screenshots or further instructions if needed