### PR TITLE
Fix lack of default permissions

### DIFF
--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -204,6 +204,28 @@ export async function inviteUserForm(ctx: IContext, params: IParameters): Promis
   const organization = await cf.organization(params.organizationGUID);
   const spaces = await cf.spaces(params.organizationGUID);
 
+  /* istanbul ignore next */
+  const values: IRoleValues = {
+    org_roles: {
+      [params.organizationGUID]: {
+        billing_managers: 0,
+        managers: 0,
+        auditors: 0,
+      },
+    },
+    space_roles: await spaces.reduce(async (next: Promise<any>, space: ISpace) => {
+      const spaceRoles = await next;
+
+      spaceRoles[space.metadata.guid] = {
+        managers: 0,
+        developers: 0,
+        auditors: 0,
+      };
+
+      return spaceRoles;
+    }, Promise.resolve({})),
+  };
+
   return {
     body: inviteTemplate.render({
       errors: [],
@@ -211,7 +233,7 @@ export async function inviteUserForm(ctx: IContext, params: IParameters): Promis
       linkTo: ctx.linkTo,
       organization,
       spaces,
-      values: {},
+      values,
     }),
   };
 }


### PR DESCRIPTION
## What

We've introduced a bug in the df91f55, where we got rid of the default
values in favour of 1/0 setup. This was a good decision and fixed
another issue, however causes the invite page, to not set the default
values, due to missing logic.

That has a reaction of attempting to delete roles from non-existing
user causing the application to 500 and not setting the desired
permissions.

It also had a bug where the state would be set to all boxes ticket,
which on save would have the user granted all permissions.

## How to review

- Run application from `master`
- Attempt to invite user
- Experience error - ALSO refresh at the error page to see weirdness.
---
- Run application from this branch
- Invite user
- Experience no error
---

There are two commits. We need to decide on either or both of them to be pushed. Let me know what you think and I'll remove/squash the commits as necessary.

## Who can review

@chrisfarms - has context and we've introduced the bug together in the first place.