### PR TITLE
[#157185422] Fix how the space quota is displayed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
-## What
+What
+----
 
 Describe what you have changed and why.
 
-## How to review
+How to review
+-------------
 
 Describe the steps required to test the changes.
 
-## Who can review
+Who can review
+---------------
 
 Describe who can review the changes. Or more importantly, list the people
 that can't review, because they worked on it.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,35 @@ gorouter's self-signed cert (e.g. on bosh-lite).
 You should be able to edit files in the `./src` directory and the changes will
 automatically be updated.
 
+## Quick local start for review/troubleshooting
+
+Provided you have logged in CF and have AWS credentials
+
+1. Update uaa user:
+
+```
+DEPLOY_ENV=...
+uaac target https://uaa.${DEPLOY_ENV}.dev.cloudpipeline.digital
+uaac token client get admin -s $(aws s3 cp s3://gds-paas-${DEPLOY_ENV}-state/cf-secrets.yml  - | grep secrets_uaa_admin_client_secret | cut -f2 -d " ")
+uaac client update paas-admin --redirect-uri http://localhost:3000/auth/login/callback
+```
+
+2. Get the command to start the server:
+
+```
+cf target -o admin -s public
+cf env paas-admin | awk '/User-Provided/ { printing=1; next} /^$/ { printing=0 ; next} printing  {gsub(": ","=\""); gsub("$", "\" \\"); print; next  } END { print "npm start"}'
+
+```
+
+3. Undo the paas-admin client change once done:
+
+
+```
+uaac client update paas-admin --redirect-uri https://admin.${DEPLOY_ENV}.dev.cloudpipeline.digital/auth/login/callback
+```
+
+
 ## Production builds
 
 The `NODE_ENV` environment variable alters the build process to bundle all
@@ -123,3 +152,4 @@ This project is fairly young and may not be a right fit for different needs yet.
 You may be interested in investigating other tools, such as
 [Stratos](https://github.com/cloudfoundry-incubator/stratos) which may become
 an official tool some day.
+

--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -86,7 +86,7 @@
             <p class="govuk-grid-column-full">
               {{ (space.entity.memory_allocated / 1024) | round(2) }}gb of
               {% if space.entity.quota %}
-                {{ (space.entity.quota.memory_limit / 1024) | round(2) }}gb
+                {{ (space.entity.quota.entity.memory_limit / 1024) | round(2) }}gb
               {% else %}
                 no limit
               {% endif %}


### PR DESCRIPTION
What
----

When displaying the space quota in the list of spaces we
check if there is a space quota to show the space limit. But we
incorrectly refer to the wrong valiable, as the quota attribute
of the space has a `entity` field.

This causes the interface to show a NaNgb from a null/1024 operation.

We update the interface to use the right value.

How to review
----

Reproduce this problem creating some space quota:

```
cf create-org foo
cf target -o foo
cf create-space dev
cf target -s dev
cf create-space-quota foo -m 1gb
cf set-space-quota dev foo
```

You can run this code from your dev environment like:

Provided you have logged in CF and have AWS credentials

1. Update uaa user:

```
DEPLOY_ENV=...
uaac target https://uaa.${DEPLOY_ENV}.dev.cloudpipeline.digital
uaac token client get admin -s $(aws s3 cp s3://gds-paas-${DEPLOY_ENV}-state/cf-secrets.yml  - | grep secrets_uaa_admin_client_secret | cut -f2 -d " ")
uaac client update paas-admin --redirect-uri http://localhost:3000/auth/login/callback
```

2. Get the command to start the server:

```
cf target -o admin -s public
cf env paas-admin | awk '/User-Provided/ { printing=1; next} /^$/ { printing=0 ; next} printing  {gsub(": ","=\""); gsub("$", "\" \\"); print; next  } END { print "npm start"}'

```

3. Undo the paas-admin client change once done:


```
uaac client update paas-admin --redirect-uri https://admin.${DEPLOY_ENV}.dev.cloudpipeline.digital/auth/login/callback
```

Check that the new code displays the right units.


Who can review
----

Anyone but @keymon