### PR TITLE
[#158425813] Remove 404ing links from permissions page and fix view spaces in users list 

### DIFF
--- a/src/spaces/spaces.njk
+++ b/src/spaces/spaces.njk
@@ -115,9 +115,13 @@
           {% for user in managers %}
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
-                <a href="{{ linkTo('admin.organizations.users.edit', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}">
+                {% if isAdmin or isManager %}
+                  <a href="{{ linkTo('admin.organizations.users.edit', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}">
+                    {{ user.entity.username }}
+                  </a>
+                {% else %}
                   {{ user.entity.username }}
-                </a>
+                {% endif %}
               </td>
             </tr>
           {% endfor %}

--- a/src/users/users.njk
+++ b/src/users/users.njk
@@ -94,7 +94,7 @@
       </td>
       <td class="govuk-table__cell">
         {% for space in user.spaces %}
-          <a href="linkTo('admin.organizations.spaces.applications.list', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid})" class="govuk-link">{{ space.entity.name }}</a>
+          <a href="{{ linkTo('admin.organizations.spaces.applications.list', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid}) }}" class="govuk-link">{{ space.entity.name }}</a>
         {% endfor %}
       </td>
     </tr>

--- a/src/users/users.njk
+++ b/src/users/users.njk
@@ -73,9 +73,13 @@
     {% for user in users %}
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
-        <a href="{{ linkTo('admin.organizations.users.edit', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-link">
+        {% if isAdmin or isManager %}
+          <a href="{{ linkTo('admin.organizations.users.edit', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-link">
+            {{ user.entity.username }}
+          </a>
+        {% else %}
           {{ user.entity.username }}
-        </a>
+        {% endif%}
       </td>
       <td class="govuk-table__cell">
         {% if 'billing_manager' in user.entity.organization_roles %}

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -157,7 +157,7 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
 
   const organization = await cf.organization(params.organizationGUID);
   const users = await cf.usersForOrganization(params.organizationGUID);
-  await Promise.all(users.map(async (user: IOrganizationUserRoles) => {
+  const usersWithSpaces = await Promise.all(users.map(async (user: IOrganizationUserRoles) => {
     const userWithSpaces = {
       ...user,
       spaces: new Array(),
@@ -172,7 +172,7 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
       ); // TODO: permissions issue here
     }
 
-    return user;
+    return userWithSpaces;
   }));
 
   return {
@@ -181,7 +181,7 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
       isAdmin,
       isManager,
       linkTo: ctx.linkTo,
-      users,
+      users: usersWithSpaces,
       organization,
     }),
   };


### PR DESCRIPTION
What?
------

Users that are not org-managers or admin should not be able to go to the "edit user" view. We need to remove the corresponding link.

Also fixed other bug where we were not listing spaces in the list of users view

How to review
-------------

Deploy it locally as described in https://github.com/alphagov/paas-admin/pull/68

 1. Login as admin or/and org manager
   - check you can still edit users and the links are there in the org
     view and in the manage users.
   - check you see the spaces when clicking on "View and manage team members"
   - check the link to the space works

 2. Login as a normal user.

   - Check that there are no links in the org view or in view members.
   - check that you see YOUR own space but not others.
   - check the link to the space works


Who can review
--------------

Not me