### PR TITLE
[#158454773] Display resend link only when applicable

### DIFF
--- a/src/uaa/uaa.test.data.ts
+++ b/src/uaa/uaa.test.data.ts
@@ -14,6 +14,108 @@ export const usersByEmail = `{
   "schemas" : [ "urn:scim:schemas:core:1.0" ]
 }`;
 
+export const user = `{
+  "id" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+  "externalId" : "test-user",
+  "meta" : {
+    "version" : 0,
+    "created" : "2018-05-22T23:45:25.621Z",
+    "lastModified" : "2018-05-22T23:45:25.621Z"
+  },
+  "userName" : "zGLifk@test.org",
+  "name" : {
+    "familyName" : "family name",
+    "givenName" : "given name"
+  },
+  "emails" : [ {
+    "value" : "zGLifk@test.org",
+    "primary" : false
+  } ],
+  "groups" : [ {
+    "value" : "6e4ee08e-1318-44cf-b4cb-9c88a983aefc",
+    "display" : "profile",
+    "type" : "DIRECT"
+  }, {
+    "value" : "589f428b-7375-4be7-b805-8ecfa2911692",
+    "display" : "user_attributes",
+    "type" : "DIRECT"
+  }, {
+    "value" : "a8478fb8-46e6-473a-b788-53223f77fcd8",
+    "display" : "password.write",
+    "type" : "DIRECT"
+  }, {
+    "value" : "01d6be0c-2bbd-46a2-b46d-cef08fdc4ca8",
+    "display" : "scim.me",
+    "type" : "DIRECT"
+  }, {
+    "value" : "d49949c7-be6e-4008-be38-b6ec76d82ce8",
+    "display" : "openid",
+    "type" : "DIRECT"
+  }, {
+    "value" : "0d89798f-7327-4e9b-ace1-95751def91d6",
+    "display" : "scim.userids",
+    "type" : "DIRECT"
+  }, {
+    "value" : "8737f07c-3365-44dd-8d1c-8efd535a4b79",
+    "display" : "cloud_controller.read",
+    "type" : "DIRECT"
+  }, {
+    "value" : "93c713d2-6f88-4faf-9ab4-c2e992bbae31",
+    "display" : "cloud_controller.write",
+    "type" : "DIRECT"
+  }, {
+    "value" : "07723467-2fbd-4d76-8bf1-3e14449a2f45",
+    "display" : "approvals.me",
+    "type" : "DIRECT"
+  }, {
+    "value" : "6253cc94-fec4-4951-8467-00c8fb26abcc",
+    "display" : "cloud_controller_service_permissions.read",
+    "type" : "DIRECT"
+  }, {
+    "value" : "3bc97cf0-125a-41b1-8ff5-35b221fa4732",
+    "display" : "oauth.approvals",
+    "type" : "DIRECT"
+  }, {
+    "value" : "f96bdc88-b553-419b-9801-41427b4ec489",
+    "display" : "uaa.offline_token",
+    "type" : "DIRECT"
+  }, {
+    "value" : "44daaaa0-0df4-4d87-b230-cda36f148490",
+    "display" : "uaa.user",
+    "type" : "DIRECT"
+  }, {
+    "value" : "fc742b38-3446-4a9f-8267-1293f8d06261",
+    "display" : "roles",
+    "type" : "DIRECT"
+  } ],
+  "approvals" : [ {
+    "userId" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+    "clientId" : "client id",
+    "scope" : "scim.read",
+    "status" : "APPROVED",
+    "lastUpdatedAt" : "2018-05-22T23:45:25.643Z",
+    "expiresAt" : "2018-05-22T23:45:35.643Z"
+  }, {
+    "userId" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+    "clientId" : "identity",
+    "scope" : "uaa.user",
+    "status" : "APPROVED",
+    "lastUpdatedAt" : "2018-05-22T23:45:55.650Z",
+    "expiresAt" : "2018-05-22T23:45:55.650Z"
+  } ],
+  "phoneNumbers" : [ {
+    "value" : "5555555555"
+  } ],
+  "active" : true,
+  "verified" : true,
+  "origin" : "uaa",
+  "zoneId" : "uaa",
+  "passwordLastModified" : "2018-05-22T23:45:25.000Z",
+  "previousLogonTime" : 1527032725655,
+  "lastLogonTime" : 1527032725657,
+  "schemas" : [ "urn:scim:schemas:core:1.0" ]
+}`;
+
 export const noFoundUsersByEmail = `{
   "resources" : [],
   "startIndex" : 0,

--- a/src/uaa/uaa.test.ts
+++ b/src/uaa/uaa.test.ts
@@ -81,3 +81,15 @@ test('should fail retrieve signing keys due to UAA being politely hacked...', as
 
   t.rejects(async () => client.getSigningKeys(), /status 400/);
 });
+
+test('should retrieve particular user successfully', async t => {
+  const client = new UAAClient(config);
+  const id = 'uaa-id-123';
+
+  await nock(config.apiEndpoint)
+    .get(`/Users/${id}`).times(1).reply(200, {id});
+
+  const user = await client.getUser(id);
+
+  t.equal(user.id, id);
+});

--- a/src/uaa/uaa.ts
+++ b/src/uaa/uaa.ts
@@ -83,6 +83,11 @@ export default class UAAClient {
     });
   }
 
+  public async getUser(userGUID: string) {
+    const response = await this.request('get', `/Users/${userGUID}`);
+    return response.data;
+  }
+
   public async findUser(email: string) {
     const params = {filter: `email eq ${JSON.stringify(email)}`};
     const response = await this.request('get', '/Users', {params});

--- a/src/users/edit.njk
+++ b/src/users/edit.njk
@@ -60,7 +60,7 @@
     </form>
 
     <a href="{{ linkTo('admin.organizations.users.delete', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-link">
-      Remove user
+      Remove user from Organisation
     </a>
   </div>
 </div>

--- a/src/users/edit.njk
+++ b/src/users/edit.njk
@@ -45,11 +45,14 @@
       }) }}
     {% endif %}
 
-    <form method="post" action="{{ linkTo('admin.organizations.users.invite.resend', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-!-mt-r6">
-      {{ govukButton({
-        text: "Resend user invite"
-      }) }}
-    </form>
+    {% if not isActive %}
+      <form method="post" action="{{ linkTo('admin.organizations.users.invite.resend', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-!-mt-r6">
+        <p>It would appear the user did not setup their account yet.</p>
+        {{ govukButton({
+          text: "Resend user invite"
+        }) }}
+      </form>
+    {% endif %}
 
     <form method="post" class="govuk-!-mt-r6">
       {% include "./permissions.njk" %}

--- a/src/users/users.test.ts
+++ b/src/users/users.test.ts
@@ -115,6 +115,7 @@ test('ordinary set of tests', async suit => {
   ;
 
   nock(config.uaaAPI).persist()
+    .get('/Users/uaa-user-edit-123456').reply(200, uaaData.usersByEmail)
     .get('/Users?filter=email+eq+%22imeCkO@test.org%22').reply(200, uaaData.usersByEmail)
     .get('/Users?filter=email+eq+%22user@example.com%22').reply(200, uaaData.usersByEmail)
     .get('/Users?filter=email+eq+%22jeff@jeff.com%22').reply(200, uaaData.noFoundUsersByEmail)


### PR DESCRIPTION
## What

We'd like to allow org managers to resend the invitation link, only when
the user is not active in the UAA.

It does bring an extra call that slows the rendering of the view
slightly, but is improvement for the user experience.

Also:
It may be sending the wrong message when we claim to remove the user,
yet all we do is unfriend them from our organisation. Making it more
clear.

## How to review

- Run the application
- As org manager have a look around users
- Attempt to find inactive user and see they have the resend button applied