### PR TITLE
Fix active tab when in billing

### DIFF
--- a/src/organizations/subnav/element.njk
+++ b/src/organizations/subnav/element.njk
@@ -4,7 +4,7 @@
   </div>
 
   <nav class="govuk-grid-column-two-thirds">
-    <a href="{{ linkTo('admin.organizations.view', {organizationGUID: organization.metadata.guid}) }}" class="govuk-link {% if not routePartOf('admin.organizations.users') %} active {% endif %}">
+    <a href="{{ linkTo('admin.organizations.view', {organizationGUID: organization.metadata.guid}) }}" class="govuk-link {% if not routePartOf('admin.organizations.users') and not routePartOf('admin.statement') %} active {% endif %}">
       Overview
     </a>
 


### PR DESCRIPTION
What
----

Currently, it would underline both tabs as active, due to the route
matching. It's not desired behaviour and we're fixing it by providing
some additional logic to the check.

How to review
-------------

- Run app
- Visit billing
- See only billing tab underlined