### PR TITLE
Initialise GOV.UK scripts on paas-admin

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -62,6 +62,7 @@ export default function(config: IAppConfig) {
   app.use('/assets', staticGzip('dist/assets', {immutable: true}));
   app.use('/assets', staticGzip('node_modules/govuk-frontend', {immutable: true}));
   app.use('/assets', staticGzip('node_modules/govuk-frontend/assets', {immutable: true}));
+  app.use('/assets', staticGzip('src/frontend/javascript', { immutable: true }));
   app.use(compression());
 
   app.use(helmet());

--- a/src/frontend/javascript/init.js
+++ b/src/frontend/javascript/init.js
@@ -1,0 +1,4 @@
+(function () {
+  window.GOVUKFrontend.initAll();
+}());
+

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -99,4 +99,7 @@
 
 {% block bodyEnd %}
   <script src="/assets/all.js"></script>
+  <script>
+    window.GOVUKFrontend.initAll();
+  </script>
 {% endblock %}

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -99,7 +99,5 @@
 
 {% block bodyEnd %}
   <script src="/assets/all.js"></script>
-  <script>
-    window.GOVUKFrontend.initAll();
-  </script>
+  <script src="/assets/init.js"></script>
 {% endblock %}


### PR DESCRIPTION
What
----

We've faced an issue where the mobile verion of the site would not
function correctly - specifically when it comes to mobile menu - due to
JavaScript not being initialised.

How to review
-------------

- Run application
- Shrink the window to mobile view
- See if the menu trigger works