### PR TITLE
Fix contrast issue

### DIFF
--- a/src/layouts/_contrast-fix.scss
+++ b/src/layouts/_contrast-fix.scss
@@ -1,0 +1,22 @@
+// There is an issue, where all elements provided by the govuk-frontend will
+// have a yellow background set on :focus. It's particularly affecting links,
+// buttons and summary boxes. These elements also have a blue text in them,
+// which could cause difficulty to our users when it comes to reading the
+// content. It means we don't meet the required WCAG 2 AA standard [1].
+
+// Design system team thinks the roll out may take a long time, due to the
+// nature of it being used in the wide government and have no issues with
+// us overriding it with the provided black colour.
+
+// This is only a temporary solution and should be reverted back once the
+// issue upstream is resolved. [2]
+
+// [1]: https://snook.ca/technical/colour_contrast/colour.html#fg=005EA5,bg=FFBF47
+// [2]: https://github.com/alphagov/govuk-frontend/issues/944
+$darkBlue: #003A66;
+
+:focus {
+  &, &:hover, &:link, &:visited, &:active {
+    color: $darkBlue;
+  }
+}

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -17,6 +17,8 @@
 
 @import '../components/statements/statements';
 
+@import './contrast-fix';
+
 .text-right {
   text-align: right;
 }


### PR DESCRIPTION
What
----

There is an issue, where all elements provided by the govuk-frontend will
have a yellow background set on :focus. It's particularly affecting links,
buttons and summary boxes. These elements also have a blue text in them,
which could cause difficulty to our users when it comes to reading the
content. It means we don't meet the required WCAG 2 AA standard [1].

Design system team thinks the roll out may take a long time, due to the
nature of it being used in the wide government and have no issues with
us overriding it with the provided black colour.

This is only a temporary solution and should be reverted back once the
issue upstream is resolved. [2]

[1]: https://snook.ca/technical/colour_contrast/colour.html#fg=005EA5,bg=FFBF47
[2]: https://github.com/alphagov/govuk-frontend/issues/944

How to review
-------------

- See if change makes sense
- Run the application and play around to see if nothing is negatively affected
- Run a standards check with the colours