### PR TITLE
Fix error message display

### DIFF
--- a/src/components/errors/error.500.njk
+++ b/src/components/errors/error.500.njk
@@ -7,5 +7,5 @@
 {% block content %}
   {{ super() }}
   <h1 class="govuk-heading-xl">Sorry an error occurred</h1>
-  <p class="govuk-body">{{ errorMessage }} | default(Something went wrong while processing the request.', true)</p>
+  <p class="govuk-body">{{ errorMessage | default('Something went wrong while processing the request.') }}</p>
 {% endblock %}


### PR DESCRIPTION
What
----

Fixing bad nunjucks formatting.

How to review
-------------

- Run application `BILLING_URL=1.2.3.4:8080 npm start`
- Go to billing, see an error correctly
- Bonus, Change [this](https://github.com/alphagov/paas-admin/blob/master/src/components/statements/statements.ts#L135) to use `Error` instead
- Go to billing, see an default error correctly
