### PR TITLE
[#160021128] Refactor the backing services listing

### DIFF
--- a/src/components/spaces/backing-services.njk
+++ b/src/components/spaces/backing-services.njk
@@ -33,16 +33,16 @@
         {% for service in services %}
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="row">
-              <a href="{{ linkTo('admin.organizations.spaces.services.view', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.guid}) }}" class="govuk-link">{{ service.name }}</a>
+              <a href="{{ linkTo('admin.organizations.spaces.services.view', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid}) }}" class="govuk-link">{{ service.entity.name }}</a>
             </th>
             <td class="govuk-table__cell ">
-              {{ service.service_plan.service.label | default('User Provided Service') }}
+              {{ service.definition.entity.label | default('User Provided Service') }}
             </td>
             <td class="govuk-table__cell ">
-              {{ service.service_plan.name | default('N/A') }}
+              {{ service.plan.entity.name | default('N/A') }}
             </td>
             <td class="govuk-table__cell ">
-              {{ service.last_operation.state | default('N/A') }}
+              {{ service.entity.last_operation.state | default('N/A') }}
             </td>
           </tr>
         {% endfor %}

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -24,6 +24,8 @@ nock('https://example.com/api').persist()
   .get('/v2/apps/cd897c8c-3171-456d-b5d7-3c87feeabbd1/summary').reply(200, data.appSummary)
   .get('/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/summary').reply(200, data.appSummary)
   .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/service_instances').reply(200, data.services)
+  .get('/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab').reply(200, data.servicePlan)
+  .get('/v2/services/775d0046-7505-40a4-bfad-ca472485e332').reply(200, data.service)
   .get('/v2/user_provided_service_instances?q=space_guid:bc8d3381-390d-4bd7-8c71-25309900a2e3').reply(200, data.services)
   .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3').reply(200, data.space)
   .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').reply(200, data.spaceQuota);
@@ -68,5 +70,6 @@ describe('spaces test suite', () => {
     });
 
     expect(response.body).toContain('name-2064 - Overview');
+    expect(response.body).toContain('name-2104');
   });
 });

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -522,6 +522,7 @@ export const services = `{
         "credentials": {
           "creds-key-60": "creds-val-60"
         },
+        "service_guid": "775d0046-7505-40a4-bfad-ca472485e332",
         "service_plan_guid": "fcf57f7f-3c51-49b2-b252-dc24e0f7dcab",
         "space_guid": "f858c6b3-f6b1-4ae8-81dd-8e8747657fbe",
         "gateway_data": null,


### PR DESCRIPTION
What
----

Now that we've made some recent changes to speed up admin tool, we've
forgotten that we require some extra fields for the backing service
listing.

These are now being added and the template is re-adjusted to fit the
purpose.

Test case has been added to prevent similar mistake happening again to
the same component.

How to review
-------------

- Run application
- Navigate to `admin` > `billing` > `Backing Services`
- Experience the page rendering correctly