### PR TITLE
[#160021128] Do not pass -p . to ts-mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "jest --coverage",
     "test:audit": "npm audit",
     "test:vulnerabilities": "if npm audit | grep -E -B9999 '\\d+\\s+(high|critical)'; then npm audit; else exit 0; fi",
-    "test:acceptance": "ts-mocha --exit -p . acceptance-tests/**/*.test.ts",
+    "test:acceptance": "ts-mocha --exit acceptance-tests/**/*.test.ts",
     "lint": "npm run -s lint:ts && npm run -s lint:sass",
     "lint:ts": "tslint --format codeFrame -p .",
     "lint:sass": "sass-lint -v",


### PR DESCRIPTION
What?
----

We are having trouble running the acceptance tests since the last
update of ts-mocha (v2.0.0) and ts-node (v7.0.0). It fails with the
following error:

     > ts-mocha --exit -p . acceptance-tests/**/*.test.ts

     [ERROR] ⨯ Unable to compile TypeScript:
     error TS5058: The specified path does not exist: '/tmp/build/30458b2e/paas-admin'.

If you do not pass `-p .` or you pass it as a env var TS_NODE_PROJECT
it works. Apparently this changed and now we need to pass the path
to tsconfig.json:

     -p, --project <value> - relative or absolute path to a tsconfig.json file (equivalent of tsc -p <value>) [default: "./tsconfig.json"]

But there is not really a need for this because we are already in the
right path, so we remove `-p .`



How to review
-------------

Code review

Who can review
---------------

Not me