### PR TITLE
[ZenDesk ticket 3116118] Scale memory to 512M

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,5 +2,5 @@
 applications:
 - name: paas-admin
   command: node dist/main.js
-  memory: 256M
+  memory: 512M
   buildpack: nodejs_buildpack


### PR DESCRIPTION
## What

This app now needs to handle potentially very large JSON responses
from the billing app.

We were seeing crashes in response to requests to
`/reports/cost/2018-07`, such as:

```
2018-08-31T15:50:16.44+0100 [API/1] OUT App instance exited with guid fff62b9f-6032-419d-bc43-b2954e8d7003 payload: {"instance"=>"e47540c4-81d8-43f8-4864-f2d2", "index"=>1, "cell_id"=>"cbab30c0-7295-45d2-a079-d9eb2a517ac0", "reason"=>"CRASHED", "exit_description"=>"APP/PROC/WEB: Exited with status 137 (out of memory)", "crash_count"=>1, "crash_timestamp"=>1535727016418381938, "version"=>"3eb256cc-2ed2-46bf-b433-500adee3e14b"}
```

This indicates the memory consumption from trying to parse the JSON
response was too high for the app.

How to review
-------------

This is hard to test because the problem is only encountered when using production levels of data from the billing app. A relatively safe way of testing in production would be to scale the production app to 512M (using a blue-green deploy) and trying to reproduce the error described in https://govuk.zendesk.com/agent/tickets/3116118 (private link).

After merging we need to do a follow-up pull request in paas-cf to deploy it. We wouldn't need to do this if we supplied manifests in paas-cf, because that would be properly separating code from configuration.

Who can review
---------------

Anyone but me.
