### PR TITLE
[#160984488] Add CSRF protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -237,6 +237,16 @@
       "integrity": "sha512-EIjmpvnHj+T4nMcKwHwxZKUfDmphIKJc2qnEMhSoOvr1lYEQpuRKRz8orWr//krYIIArS/KGGLfL2YGVUYXmIA==",
       "dev": true
     },
+    "@types/csurf": {
+      "version": "1.9.35",
+      "resolved": "https://registry.npmjs.org/@types/csurf/-/csurf-1.9.35.tgz",
+      "integrity": "sha512-2EVN+Bt2Vd8u+11xeJ64BjCYVOlhqaob82FPAw8VzOOWAYfP8TFvB7RD67CShEz45JXiI+38mlNJHKrArCzFMw==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/express-serve-static-core": "*"
+      }
+    },
     "@types/events": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
@@ -2336,6 +2346,16 @@
         "randomfill": "^1.0.3"
       }
     },
+    "csrf": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
+      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+      "requires": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.5",
+        "uid-safe": "2.1.4"
+      }
+    },
     "css-loader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
@@ -2386,6 +2406,34 @@
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
+      }
+    },
+    "csurf": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.9.0.tgz",
+      "integrity": "sha1-SdLGkl/87Ht95VlZfBU/pTM2QTM=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "csrf": "~3.0.3",
+        "http-errors": "~1.5.0"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.5.1",
+          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+          "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+          "requires": {
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.2",
+            "statuses": ">= 1.3.1 < 2"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+          "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
+        }
       }
     },
     "cuint": {
@@ -14444,6 +14492,11 @@
       "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
       "dev": true
     },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
     "randomatic": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
@@ -14938,6 +14991,11 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "route-parser": {
       "version": "0.0.5",
@@ -20200,6 +20258,11 @@
         }
       }
     },
+    "tsscmp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
+      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
+    },
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
@@ -20348,6 +20411,14 @@
             "source-map": "~0.6.1"
           }
         }
+      }
+    },
+    "uid-safe": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
+      "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
+      "requires": {
+        "random-bytes": "~1.0.0"
       }
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/compression": "0.0.36",
+    "@types/csurf": "^1.9.35",
     "@types/express": "4.16.0",
     "@types/helmet": "0.0.38",
     "@types/jest": "23.3.1",
@@ -90,6 +91,7 @@
     "axios": "0.18.0",
     "compression": "1.7.3",
     "cookie-session": "2.0.0-beta.3",
+    "csurf": "^1.9.0",
     "express": "4.16.3",
     "express-pino-logger": "4.0.0",
     "express-static-gzip": "1.1.1",

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -35,7 +35,7 @@ describe('app test suite', () => {
         path: '/',
       },
     ]);
-    const ctx = initContext({}, r, r.find('/'), config);
+    const ctx = initContext({csrfToken: () => ''}, r, r.find('/'), config);
 
     expect(ctx.routePartOf('test')).toBeTruthy();
     expect(ctx.routePartOf('te')).toBeTruthy();

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -67,9 +67,9 @@ export default function(config: IAppConfig) {
 
   app.use(helmet());
   app.use(helmet.contentSecurityPolicy(csp));
-  app.use(csrf());
 
   app.use(express.urlencoded({extended: true}));
+  app.use(csrf());
 
   app.get('/healthcheck', (_req: express.Request, res: express.Response) => res.send({message: 'OK'}));
 

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -1,5 +1,6 @@
 import compression from 'compression';
 import cookieSession from 'cookie-session';
+import csrf from 'csurf';
 import express from 'express';
 import pinoMiddleware from 'express-pino-logger';
 import staticGzip from 'express-static-gzip';
@@ -66,6 +67,7 @@ export default function(config: IAppConfig) {
 
   app.use(helmet());
   app.use(helmet.contentSecurityPolicy(csp));
+  app.use(csrf());
 
   app.use(express.urlencoded({extended: true}));
 

--- a/src/components/app/context.ts
+++ b/src/components/app/context.ts
@@ -15,6 +15,7 @@ export interface IContext {
   readonly linkTo: (name: string, params?: IParameters) => string;
   readonly log: Logger;
   readonly token: Token;
+  readonly csrf: string;
 }
 
 export function initContext(req: any, router: Router, route: Route, config: IAppConfig): IContext {
@@ -24,5 +25,6 @@ export function initContext(req: any, router: Router, route: Route, config: IApp
     linkTo: (name: string, params: IParameters = {}) => router.findByName(name).composeURL(params),
     log: req.log,
     token: req.token,
+    csrf: req.csrfToken(),
   };
 }

--- a/src/components/app/router-middleware.test.ts
+++ b/src/components/app/router-middleware.test.ts
@@ -48,6 +48,11 @@ describe('app test suite - router-middleware', () => {
       return router.findByName(name).composeURL(params);
     }
 
+    app.use((req: express.Request, _res: express.Response, next: express.NextFunction) => {
+      req.csrfToken = () => '';
+      next();
+    });
+
     app.use(routerMiddleware(router, config));
 
     app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/src/components/applications/applications.test.ts
+++ b/src/components/applications/applications.test.ts
@@ -31,6 +31,7 @@ describe('applications test suite', () => {
     linkTo: () => '__LINKED_TO__',
     log: pino({level: 'silent'}),
     token: new Token(token, [tokenKey]),
+    csrf: '',
   };
 
   it('should show the application overview page', async () => {

--- a/src/components/applications/applications.ts
+++ b/src/components/applications/applications.ts
@@ -46,6 +46,7 @@ export async function viewApplication(ctx: IContext, params: IParameters): Promi
       application: summarisedApplication,
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       space,
       organization,
       isAdmin,

--- a/src/components/calculator/calculator.njk
+++ b/src/components/calculator/calculator.njk
@@ -48,6 +48,7 @@
                 <td class="govuk-table__cell" scope="row">{{ serviceName }} {{ version }}</td>
                 <td class="govuk-table__cell ">
                   <form class="paas-service-selection" method="get">
+                    <input type="hidden" name="_csrf" value="{{ csrf }}" />
                     {{ stateFields(state) }}
                     {% if plans.length > 1 %}
                       {{ govukSelect({
@@ -122,6 +123,7 @@
           </td>
           <td>
             <form method="get">
+              <input type="hidden" name="_csrf" value="{{ csrf }}" />
               {{ stateFields(state, remove=loop.index0) }}
               <button class="paas-remove-button" type="submit" arria-label="Remove">&times;</button>
             </form>

--- a/src/components/calculator/calculator.test.ts
+++ b/src/components/calculator/calculator.test.ts
@@ -20,6 +20,7 @@ const ctx: IContext = {
   linkTo: () => '__LINKED_TO__',
   log: pino({level: 'silent'}),
   token: new Token(token, [tokenKey]),
+  csrf: '',
 };
 
 describe('calculator test suite', () => {

--- a/src/components/calculator/calculator.ts
+++ b/src/components/calculator/calculator.ts
@@ -99,10 +99,11 @@ export async function getCalculator(ctx: IContext, params: IParameters): Promise
 
   return {
     body: calculatorTemplate.render({
-      state,
-      quote,
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
+      state,
+      quote,
     }),
   };
 }

--- a/src/components/organizations/organizations.test.ts
+++ b/src/components/organizations/organizations.test.ts
@@ -58,6 +58,7 @@ const ctx: IContext = {
   linkTo: () => '__LINKED_TO__',
   log: pino({level: 'silent'}),
   token: new Token(token, [tokenKey]),
+  csrf: '',
 };
 
 describe('organizations test suite', () => {

--- a/src/components/organizations/organizations.ts
+++ b/src/components/organizations/organizations.ts
@@ -27,6 +27,7 @@ export async function listOrganizations(ctx: IContext, _params: IParameters): Pr
     body: organizationsTemplate.render({
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       cfDownloadLinkLocation,
       cfDownloadLinkSource,
       documentationLink,

--- a/src/components/reports/cost.test.ts
+++ b/src/components/reports/cost.test.ts
@@ -33,6 +33,7 @@ const ctx: IContext = {
   linkTo: () => '__LINKED_TO__',
   log: pino({level: 'silent'}),
   token: new Token(token, [tokenKey]),
+  csrf: '',
 };
 
 describe('cost report test suite', () => {

--- a/src/components/reports/cost.ts
+++ b/src/components/reports/cost.ts
@@ -76,6 +76,7 @@ export async function viewCostReport(
 
   return {
     body: costReportTemplate.render({
+      csrf: ctx.csrf,
       date: moment(rangeStart).format('MMMM YYYY'),
       orgCostRecords: Object.values(orgCostRecords),
       quotaCostRecords,

--- a/src/components/services/services.test.ts
+++ b/src/components/services/services.test.ts
@@ -34,6 +34,7 @@ const ctx: IContext = {
   linkTo: () => '__LINKED_TO__',
   log: pino({level: 'silent'}),
   token: new Token(token, [tokenKey]),
+  csrf: '',
 };
 
 describe('services test suite', () => {

--- a/src/components/services/services.ts
+++ b/src/components/services/services.ts
@@ -47,6 +47,7 @@ export async function viewService(ctx: IContext, params: IParameters): Promise<I
     body: serviceOverviewTemplate.render({
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       organization,
       service: summarisedService,
       space,

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -43,6 +43,7 @@ const ctx: IContext = {
   linkTo: () => '__LINKED_TO__',
   log: pino({level: 'silent'}),
   token: new Token(token, [tokenKey]),
+  csrf: '',
 };
 
 describe('spaces test suite', () => {

--- a/src/components/spaces/spaces.ts
+++ b/src/components/spaces/spaces.ts
@@ -55,9 +55,10 @@ export async function listApplications(ctx: IContext, params: IParameters): Prom
 
   return {
     body: spaceApplicationsTemplate.render({
-      applications: summarisedApplications,
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
+      applications: summarisedApplications,
       organization,
       space,
       isAdmin,
@@ -104,9 +105,10 @@ export async function listBackingServices(ctx: IContext, params: IParameters): P
 
   return {
     body: spaceBackingServicesTemplate.render({
-      services: [...summarisedServices, ...userServices],
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
+      services: [...summarisedServices, ...userServices],
       organization,
       space,
       isAdmin,
@@ -178,6 +180,7 @@ export async function listSpaces(ctx: IContext, params: IParameters): Promise<IR
     body: spacesTemplate.render({
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       managers,
       organization: summerisedOrganization,
       spaces: summarisedSpaces,

--- a/src/components/statements/statements.njk
+++ b/src/components/statements/statements.njk
@@ -23,6 +23,7 @@
 
     <div class="govuk-grid-column-full">
       <form method="get" action="{{ linkTo('admin.statement.dispatcher', {organizationGUID: organization.metadata.guid}) }}" class="paas-statement-range">
+        <input type="hidden" name="_csrf" value="{{ csrf }}" />
         <table class="govuk-table paas-statement-filters">
           <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
@@ -123,6 +124,7 @@
       </p>
     {% endif %}
     <form method="get" action="{{ linkTo('admin.statement.dispatcher', {organizationGUID: organization.metadata.guid}) }}" class="paas-statement-range">
+      <input type="hidden" name="_csrf" value="{{ csrf }}" />
       <input type="hidden" name="rangeStart" value="{{ filterMonth }}" />
       <input type="hidden" name="space" value="{{ filterSpace.metadata.guid }}" />
       <input type="hidden" name="service" value="{{ filterService.metadata.guid }}" />

--- a/src/components/statements/statements.test.ts
+++ b/src/components/statements/statements.test.ts
@@ -50,6 +50,7 @@ const ctx: IContext = {
   linkTo: (name, params) => `${name}/${params ? params.rangeStart : ''}`,
   log: pino({level: 'silent'}),
   token: new Token(token, [tokenKey]),
+  csrf: '',
 };
 
 describe('statements test suite', () => {

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -229,9 +229,11 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
     incVAT: filteredItems.reduce((sum, event) => sum + event.price.incVAT, 0),
   };
 
-  return { body: usageTemplate.render({
+  return {
+    body: usageTemplate.render({
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       organization,
       filter,
       totals,
@@ -252,7 +254,8 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
       isAdmin,
       isBillingManager,
       isManager,
-    }) };
+    }),
+  };
 }
 
 export async function downloadCSV(ctx: IContext, params: IParameters): Promise<IResponse> {

--- a/src/components/terms/middleware.test.ts
+++ b/src/components/terms/middleware.test.ts
@@ -15,6 +15,8 @@ const app = express();
 app.use(express.urlencoded({extended: true}));
 
 app.use((req: any, _res: any, next: any) => {
+  req.log = console;
+  req.csrfToken = () => '';
   const fakeUserID = req.path.slice(1);
   if (!fakeUserID) {
     next();
@@ -94,13 +96,14 @@ describe('terms test suite', () => {
     const agent = request.agent(app);
     const response = await agent.post('/agreements').type('form').send({
       document_name: 'my-doc',
+      _csrf: '',
     });
     expect(response.status).toEqual(302);
   });
 
   it('should skip middleware if method not a GET request', async () => {
     const agent = request.agent(app);
-    const response = await agent.post('/user-with-pending');
+    const response = await agent.post('/user-with-pending').send({_csrf: ''});
     expect(response.text).toEqual('HOME');
     expect(response.status).toEqual(200);
   });

--- a/src/components/terms/middleware.ts
+++ b/src/components/terms/middleware.ts
@@ -22,7 +22,10 @@ export function termsCheckerMiddleware(config: IAccountsClientConfig): express.H
 
   app.get('/agreements/:name', sync(async (req, res) => {
     const document = await accounts.getDocument(req.params.name);
-    res.send(termsTemplate.render({document}));
+    res.send(termsTemplate.render({
+      document,
+      csrf: req.csrfToken(),
+    }));
   }));
 
   app.post('/agreements', sync(async (req, res) => {

--- a/src/components/terms/terms.njk
+++ b/src/components/terms/terms.njk
@@ -9,6 +9,7 @@
   {{ super() }}
 
   <form method="post" action="/agreements">
+    <input type="hidden" name="_csrf" value="{{ csrf }}" />
     <div class="md">
       {{ document.content | markdown | safe }}
     </div>

--- a/src/components/users/delete.njk
+++ b/src/components/users/delete.njk
@@ -19,6 +19,7 @@
 
   <div class="govuk-grid-column-two-thirds">
     <form method="post" class="govuk-!-mt-r6 paas-remove-user">
+      <input type="hidden" name="_csrf" value="{{ csrf }}" />
       <h2 class="govuk-heading-l">Are you sure you'd like to remove the following user?</h2>
 
       <p class="govuk-heading-m">{{ user.entity.username }}</p>

--- a/src/components/users/edit.njk
+++ b/src/components/users/edit.njk
@@ -49,6 +49,7 @@
 
     {% if not isActive %}
       <form method="post" action="{{ linkTo('admin.organizations.users.invite.resend', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-!-mt-r6">
+        <input type="hidden" name="_csrf" value="{{ csrf }}" />
         <p>It would appear the user did not setup their account yet.</p>
         {{ govukButton({
           text: "Resend user invite"
@@ -57,6 +58,7 @@
     {% endif %}
 
     <form method="post" class="govuk-!-mt-r6">
+      <input type="hidden" name="_csrf" value="{{ csrf }}" />
       {% include "./permissions.njk" %}
 
       {{ govukButton({

--- a/src/components/users/invite.njk
+++ b/src/components/users/invite.njk
@@ -33,6 +33,7 @@
     {% endif %}
 
     <form method="post" class="govuk-!-mt-r6">
+      <input type="hidden" name="_csrf" value="{{ csrf }}" />
       {{ govukInput({
         label: {
           text: "Email address"

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -23,6 +23,7 @@ const ctx: IContext = {
   linkTo: () => '__LINKED_TO__',
   log: pino({level: 'silent'}),
   token: new Token(accessToken, [tokenKey]),
+  csrf: '',
 };
 
 function composeOrgRoles(setup: object) {

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -191,6 +191,7 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
   return {
     body: usersTemplate.render({
       routePartOf: ctx.routePartOf,
+      csrf: ctx.csrf,
       isAdmin,
       isManager,
       isBillingManager,
@@ -251,6 +252,7 @@ export async function inviteUserForm(ctx: IContext, params: IParameters): Promis
       errors: [],
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       organization,
       spaces,
       values,
@@ -377,6 +379,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
         errors,
         routePartOf: ctx.routePartOf,
         linkTo: ctx.linkTo,
+        csrf: ctx.csrf,
         organization,
         isAdmin,
         isBillingManager,
@@ -388,9 +391,10 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
     if (err instanceof ValidationError) {
       return {
         body: inviteTemplate.render({
-          errors: err.errors,
           routePartOf: ctx.routePartOf,
           linkTo: ctx.linkTo,
+          csrf: ctx.csrf,
+          errors: err.errors,
           organization,
           spaces,
           values,
@@ -479,9 +483,10 @@ export async function resendInvitation(ctx: IContext, params: IParameters, _: ob
 
   return {
     body: inviteSuccessTemplate.render({
-      errors: [],
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
+      errors: [],
       organization,
     }),
   };
@@ -565,6 +570,7 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
       errors: [],
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       managers,
       billingManagers,
       organization,
@@ -634,6 +640,7 @@ export async function updateUser(ctx: IContext, params: IParameters, body: objec
       body: editSuccessTemplate.render({
         routePartOf: ctx.routePartOf,
         linkTo: ctx.linkTo,
+        csrf: ctx.csrf,
         organization,
         isAdmin,
         isBillingManager,
@@ -645,9 +652,10 @@ export async function updateUser(ctx: IContext, params: IParameters, body: objec
     if (err instanceof ValidationError) {
       return {
         body: editTemplate.render({
-          errors: err.errors,
           routePartOf: ctx.routePartOf,
           linkTo: ctx.linkTo,
+          csrf: ctx.csrf,
+          errors: err.errors,
           organization,
           spaces,
           user,
@@ -692,6 +700,7 @@ export async function confirmDeletion(ctx: IContext, params: IParameters): Promi
     body: deleteTemplate.render({
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       organization,
       user,
       isAdmin,
@@ -731,6 +740,7 @@ export async function deleteUser(ctx: IContext, params: IParameters, _: object):
     body: deleteSuccessTemplate.render({
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
       organization,
       isAdmin,
       isBillingManager,

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -15,6 +15,8 @@
 {% endblock %}
 
 {% block head %}
+  <meta name="csrf-token" content="{{csrf}}" />
+
   <!--[if !IE 8]><!-->
     <link href="./govuk.screen.scss" media="screen" rel="stylesheet" />
     <link href="./govuk.print.scss" media="print" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
What
----

We'd like to make sure the application is well protected against the
[CSRF]. @richardTowers has well spotted that `helmet` middleware is not
doing that for us, meaning we need to take an action to assure ourselves
we deliver secure software.

The `csurf` npm package is a middleware that can do things for us
without much effort.

After introduction of `csurf` package and the implementation, the thests
started to fail due to missing function.

This is a hacky way to assure the function exists while not all of the
middlewares have been setup.

Yet again, this shows lacks in implementation of the tests.

[CSRF]: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)

How to review
-------------

⚠️ ~~**I have not tested this, since I don't have my environment running.**~~ ⚠️

- Install dependencies
- Code review
- Run the application
- Navigate around as much as possible to make sure nothing is restricted
- Attempt to send few forms, particularly `user invite` and `permission management`
- Attempt to submit a form from external service (see code sample below for help)

Code sample
------------

Make sure to fill in the URL properly.

```html
<html>
  <body>
    <form action="__PLEASE_PROVIDE_URL_TO_INVITE_PAGE__" method="post">
      Email: <input type="email" name="email" value="evil@hacker.com">
      <br>
      <button type="submit">powah!</button>
    </form>
  </body>
</html>
```
