### PR TITLE
[FIX] Copy init.js script to assets folder

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -14,7 +14,8 @@ let cfg = {
   mode: NODE_ENV,
 
   entry: {
-    main: ['./src/main.ts']
+    main: ['./src/main.ts'],
+    "assets/init": ['./src/frontend/javascript/init.js']
   },
 
   output: {

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -62,7 +62,6 @@ export default function(config: IAppConfig) {
   app.use('/assets', staticGzip('dist/assets', {immutable: true}));
   app.use('/assets', staticGzip('node_modules/govuk-frontend', {immutable: true}));
   app.use('/assets', staticGzip('node_modules/govuk-frontend/assets', {immutable: true}));
-  app.use('/assets', staticGzip('src/frontend/javascript', { immutable: true }));
   app.use(compression());
 
   app.use(helmet());


### PR DESCRIPTION
What
----

When we moved the GDS frontend init call to a separated file, we
referred to a file in src. but that file is not copied when the
app is built and pussed to CF :(

Instead, we must copy the file as part of webpack. We remove the
middleware route for `src` as it is not needed.

Fixes #100

See 64f9a098086d47b316552d7f729cd17c331d887e

How to review
-------------

Code review

Who can review
---------------

Anyone