### PR TITLE
Do not include CSRF for calculator

### DIFF
--- a/src/components/calculator/calculator.njk
+++ b/src/components/calculator/calculator.njk
@@ -48,7 +48,6 @@
                 <td class="govuk-table__cell" scope="row">{{ serviceName }} {{ version }}</td>
                 <td class="govuk-table__cell ">
                   <form class="paas-service-selection" method="get">
-                    <input type="hidden" name="_csrf" value="{{ csrf }}" />
                     {{ stateFields(state) }}
                     {% if plans.length > 1 %}
                       {{ govukSelect({
@@ -62,7 +61,7 @@
                         <input type="hidden" name="items[{{ state.items.length }}][numberOfNodes]" value="{{ plans[0].numberOfNodes }}" />
                         <input type="hidden" name="items[{{ state.items.length }}][storageInMB]" value="{{ plans[0].storageInMB }}" />
                     {% else %}
-                      <input type="hidden" name="items[{{ state.items.length }}][planGUID]" value="{{ plans[0].planGUID }}"> 
+                      <input type="hidden" name="items[{{ state.items.length }}][planGUID]" value="{{ plans[0].planGUID }}">
                       {% if serviceName == "app" %}
                         <div style="width: 46%">
                           {{ govukSelect({
@@ -123,7 +122,6 @@
           </td>
           <td>
             <form method="get">
-              <input type="hidden" name="_csrf" value="{{ csrf }}" />
               {{ stateFields(state, remove=loop.index0) }}
               <button class="paas-remove-button" type="submit" arria-label="Remove">&times;</button>
             </form>


### PR DESCRIPTION
What
----

The calculator is a GET method and does not require CSRF.

But including it might cause problems in the long run because
people share the calculator urls.

How to review
-------------

Code review

Who can review
---------------

Not me