### PR TITLE
[#161315584] Include all spaces / plans in filter dropdowns

### DIFF
--- a/src/components/statements/statements.test.ts
+++ b/src/components/statements/statements.test.ts
@@ -104,6 +104,30 @@ describe('statements test suite', () => {
     expect(response.body).toContain('batman');
   });
 
+  it ('populates filter dropdowns with all spaces / services', async () => {
+    // tslint:disable:max-line-length
+    nock(config.billingAPI)
+      .get('/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20').reply(200, billingData.billableEvents);
+    // tslint:enable:max-line-length
+
+    const response = await statement.viewStatement(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      rangeStart: '2018-01-01',
+      space: 'bc8d3381-390d-4bd7-8c71-25309900a2e3',
+      service: 'f4d4b95a-f55e-4593-8d54-3364c25798c4',
+    });
+
+    // Spaces
+    expect(response.body).toContain('All spaces</option>');
+    expect(response.body).toContain('pretty-face</option>');
+    expect(response.body).toContain('real-hero</option>');
+
+    // Services and apps
+    expect(response.body).toContain('All Services</option>');
+    expect(response.body).toContain('app</option>');
+    expect(response.body).toContain('staging</option>');
+  });
+
   it('should throw an error due to selecting middle of the month', async () => {
     await expect(statement.viewStatement(ctx, {
         organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -194,10 +194,10 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
   const listSpaces = [{guid: 'none', name: 'All spaces'}, ...[...spaces].sort(sortByName)];
   const listPlans = [{guid: 'none', name: 'All Services'}, ...plans.sort(sortByName)];
 
-  const itemsFilteredBySpaceAndService = items
-    .filter(item => filterSpace   === 'none' || item.spaceGUID === params.space)
-    .filter(item => filterService === 'none' || item.planGUID  === params.service);
-  const filteredItems = order(itemsFilteredBySpaceAndService, {sort: orderBy, order: orderDirection});
+  const unorderedFilteredItems = items.filter(item =>
+      (filterSpace   === 'none' || item.spaceGUID === filterSpace) &&
+      (filterService === 'none' || item.planGUID  === filterService));
+  const filteredItems = order(unorderedFilteredItems, {sort: orderBy, order: orderDirection});
 
   if (params.download) {
     return {

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -162,7 +162,7 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
     }};
   }, {});
 
-  let items = Object.values(itemsObject);
+  const items = Object.values(itemsObject);
 
   const listOfPastYearMonths: {[i: string]: string} = {};
 
@@ -170,24 +170,6 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
     const month = moment().subtract(i, 'month').startOf('month');
 
     listOfPastYearMonths[month.format(YYYMMDD)] = `${month.format('MMMM')} ${month.format('YYYY')}`;
-  }
-
-  if (filterSpace !== 'none') {
-    items = items.reduce((all: IResourceUsage[], next: IResourceUsage) => {
-      if (next.spaceGUID === params.space) {
-        all.push(next);
-      }
-      return all;
-    }, []);
-  }
-
-  if (filterService !== 'none') {
-    items = items.reduce((all: IResourceUsage[], next: IResourceUsage) => {
-      if (next.planGUID === params.service) {
-        all.push(next);
-      }
-      return all;
-    }, []);
   }
 
   const orderBy = params.sort || 'name';
@@ -212,7 +194,10 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
   const listSpaces = [{guid: 'none', name: 'All spaces'}, ...[...spaces].sort(sortByName)];
   const listPlans = [{guid: 'none', name: 'All Services'}, ...plans.sort(sortByName)];
 
-  const filteredItems = order(items, {sort: orderBy, order: orderDirection});
+  const itemsFilteredBySpaceAndService = items
+    .filter(item => filterSpace   === 'none' || item.spaceGUID === params.space)
+    .filter(item => filterService === 'none' || item.planGUID  === params.service);
+  const filteredItems = order(itemsFilteredBySpaceAndService, {sort: orderBy, order: orderDirection});
 
   if (params.download) {
     return {


### PR DESCRIPTION
What
----

Previously we were filtering the items down to the selected space / plan
and then getting the list of spaces / plans from the filtered items.
Consequently the list of spaces / plans didn't include all the things it
should have.

A couple of nice extras

* we can switch from `let` to `const` for `items` because we're not
  reassigning it anymore.
* we can use `filter` instead of `reduce` and it's much simpler (and
  probably a bit more efficient)

How to review
-------------

* Code review
* Deploy to a dev environment (or locally) and test (steps to repro in
  [#161315584](https://www.pivotaltracker.com/story/show/161315584))

Who can review
---------------

Anyone