### PR TITLE
[#SUPPORT] Update from alpha to beta

### DIFF
--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -69,7 +69,7 @@
 {% block beforeContent %}
   {{ govukPhaseBanner({
     tag: {
-      text: 'alpha'
+      text: 'beta'
     },
     html: 'This is a new service – your <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">feedback</a> will help us to improve it.'
   }) }}


### PR DESCRIPTION
What
----

I think the paas-admin phase banner was set to `ALPHA` because
paas-admin was a new service that we're getting feedback on.

From the point of view of a tenant this is confusing though, because
they don't see paas-admin as being a separate thing to the PaaS. This
means it looks like the whole PaaS is in alpha, which it isn't. For
example:

http://govuk.zendesk.com/agent/tickets/3411752

Furthermore, paas-admin itself really feels like it's in beta now - it's
available to all our tenants, new tenants are using it by default, and
we're not planning on throwing the implementation away to build a new
one.

How to review
-------------

* Check this is the right thing to do

Who can review
---------------

Anyone, but it would be good to get James' opinion as well since it's a
bit of a product thing.