### PR TITLE
[support] Fix resending of invitation emails

### DIFF
--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -492,6 +492,7 @@ export async function resendInvitation(ctx: IContext, params: IParameters, _: ob
   await notify.sendWelcomeEmail(user.entity.username, {
     organisation: organization.entity.name,
     url: invitation.inviteLink,
+    location: platformLocation(ctx),
   });
 
   return {


### PR DESCRIPTION
## What

Addresses issue[1]. The invitation email template was updated to take a
`location` field[2], but we (I) only updated one of the locations where
we use this Notify template.

[1] https://github.com/alphagov/paas-admin/issues/110
[2] https://github.com/alphagov/paas-admin/pull/109

How to review
-------------

You can apply this diff in paas-cf:

```
diff --git a/concourse/pipelines/create-cloudfoundry.yml b/concourse/pipelines/create-cloudfoundry.yml
index a27bf500..b1309a64 100644
--- a/concourse/pipelines/create-cloudfoundry.yml
+++ b/concourse/pipelines/create-cloudfoundry.yml
@@ -366,7 +366,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/paas-admin
-      tag_filter: v0.45.0
+      branch: fix-invitation-resending
 
   - name: paas-log-cache-adapter
     type: git
```

Then run `make dev pipelines` and `make dev run_job JOB=post-deploy` to deploy this version of paas-admin. Try to invite a user and then resend the invitation email.

Who can review
---------------

Anyone but me.
