### PR TITLE
Tighten types for invitation emails

### DIFF
--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -11,7 +11,7 @@ import {
 import NotificationClient from '../../lib/notify';
 import { IParameters, IResponse } from '../../lib/router';
 import { NotFoundError } from '../../lib/router/errors';
-import UAAClient from '../../lib/uaa';
+import UAAClient, { IUaaInvitation } from '../../lib/uaa';
 
 import { IContext } from '../app/context';
 import {
@@ -326,7 +326,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
 
     const uaaUser = await uaa.findUser(values.email);
     let userGUID = uaaUser && uaaUser.id;
-    let invitation;
+    let invitation: IUaaInvitation | undefined;
 
     if (!userGUID) {
       invitation = await uaa.inviteUser(

--- a/src/lib/notify/notify.client.test.ts
+++ b/src/lib/notify/notify.client.test.ts
@@ -10,7 +10,8 @@ describe('lib/notify test suite', () => {
       .post('/').reply(200, {content: {body: 'FAKE_NOTIFY_RESPONSE'}});
 
     const notify = new NotificationClient({apiKey: 'test-key-1234', templates: {welcome: 'WELCOME_ID'}});
-    const notifyResponse = await notify.sendWelcomeEmail('jeff@jeff.com');
+    const personalisation = {url: 'https://default.url', organisation: 'DefaultOrg', location: 'DefaultLocation'};
+    const notifyResponse = await notify.sendWelcomeEmail('jeff@jeff.com', personalisation);
 
     expect(notifyResponse.body.content.body).toContain('FAKE_NOTIFY_RESPONSE');
   });

--- a/src/lib/notify/notify.client.ts
+++ b/src/lib/notify/notify.client.ts
@@ -1,7 +1,5 @@
 import { NotifyClient } from 'notifications-node-client';
 
-import { IParameters } from '../router';
-
 interface ITemplates {
   readonly [name: string]: string | null;
 }
@@ -9,6 +7,12 @@ interface ITemplates {
 interface IConfig {
   readonly apiKey: string;
   readonly templates: ITemplates;
+}
+
+interface IWelcomeEmailParameters {
+  readonly organisation: string;
+  readonly url: string;
+  readonly location: string;
 }
 
 export default class NotificationClient {
@@ -21,7 +25,7 @@ export default class NotificationClient {
     this.templates = config.templates || {};
   }
 
-  public async sendWelcomeEmail(emailAddress: string, personalisation: IParameters = {}) {
+  public async sendWelcomeEmail(emailAddress: string, personalisation: IWelcomeEmailParameters) {
     /* istanbul ignore next */
     if (!this.templates.welcome) {
       throw new Error(`NotifyClient: templates.welcome: id is required`);

--- a/src/lib/uaa/index.ts
+++ b/src/lib/uaa/index.ts
@@ -1,1 +1,1 @@
-export { default, authenticate, authenticateUser } from './uaa';
+export { default, authenticate, authenticateUser, IUaaInvitation } from './uaa';

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -19,6 +19,11 @@ interface IClientConfig {
   readonly signingKeys?: ReadonlyArray<string>;
 }
 
+export interface IUaaInvitation {
+  userId: string;
+  inviteLink: string;
+}
+
 export default class UAAClient {
   private accessToken: string;
   private readonly apiEndpoint: string;
@@ -99,7 +104,7 @@ export default class UAAClient {
     return response.data.resources[0];
   }
 
-  public async inviteUser(email: string, clientID: string, redirectURI: string) {
+  public async inviteUser(email: string, clientID: string, redirectURI: string): Promise<IUaaInvitation> {
     const data = {emails: [email]};
     const response = await this.request(
       'post',


### PR DESCRIPTION
What
----

In #111 we fixed a bug where we hadn't passed `location` into the
welcome email personalisation. This could have been caught by the type
system, but we were using the loose `IParameters` type (which just says
"an object with some keys") and the even looser `any` type (which can be
assigned to anything).

I had to make the UAAClient declare the type of the inviteUser response,
otherwise the `inviteLink` parameter would have had the `any` type, but
we know it has to be a string.

I didn't bother checking what all the fields on the UAAClient inviteUser
response were - I've only typed the two fields we actually use.

How to review
-------------

* Code review

Who can review
---------------

Not @richardTowers