### PR TITLE
[#160508552] Add location banner

### DIFF
--- a/src/components/app/app.test.config.ts
+++ b/src/components/app/app.test.config.ts
@@ -16,7 +16,7 @@ export const config: IAppConfig = {
   oauthClientID: 'key',
   oauthClientSecret: 'secret',
   cloudFoundryAPI: 'https://example.com/api',
-  awsRegion: 'eu-west-1',
+  location: 'eu-west-1',
   uaaAPI: 'https://example.com/uaa',
   authorizationAPI: 'https://example.com/login',
   notifyAPIKey: 'test-123456-qwerty',

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -95,7 +95,7 @@ export default function(config: IAppConfig) {
     uaaAPI: config.uaaAPI,
   }));
 
-  app.use(termsCheckerMiddleware({
+  app.use(termsCheckerMiddleware(config.awsRegion, {
     apiEndpoint: config.accountsAPI,
     secret: config.accountsSecret,
   }));

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -25,7 +25,7 @@ export interface IAppConfig {
   readonly accountsAPI: string;
   readonly accountsSecret: string;
   readonly cloudFoundryAPI: string;
-  readonly awsRegion: string;
+  readonly location: string;
   readonly logger: BaseLogger;
   readonly notifyAPIKey: string;
   readonly notifyWelcomeTemplateID: string | null;
@@ -95,7 +95,7 @@ export default function(config: IAppConfig) {
     uaaAPI: config.uaaAPI,
   }));
 
-  app.use(termsCheckerMiddleware(config.awsRegion, {
+  app.use(termsCheckerMiddleware(config.location, {
     apiEndpoint: config.accountsAPI,
     secret: config.accountsSecret,
   }));

--- a/src/components/applications/applications.ts
+++ b/src/components/applications/applications.ts
@@ -52,6 +52,7 @@ export async function viewApplication(ctx: IContext, params: IParameters): Promi
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }

--- a/src/components/applications/applications.ts
+++ b/src/components/applications/applications.ts
@@ -52,7 +52,7 @@ export async function viewApplication(ctx: IContext, params: IParameters): Promi
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }

--- a/src/components/calculator/calculator.ts
+++ b/src/components/calculator/calculator.ts
@@ -104,6 +104,7 @@ export async function getCalculator(ctx: IContext, params: IParameters): Promise
       csrf: ctx.csrf,
       state,
       quote,
+      location: ctx.app.awsRegion,
     }),
   };
 }

--- a/src/components/calculator/calculator.ts
+++ b/src/components/calculator/calculator.ts
@@ -104,7 +104,7 @@ export async function getCalculator(ctx: IContext, params: IParameters): Promise
       csrf: ctx.csrf,
       state,
       quote,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }

--- a/src/components/errors/error.ts
+++ b/src/components/errors/error.ts
@@ -7,6 +7,18 @@ import internalServerError from './error.500.njk';
 
 export class UserFriendlyError extends Error {}
 
+/* istanbul ignore next */
+function platformLocation(region: string): string {
+  switch (region) {
+    case 'eu-west-1':
+      return 'Ireland';
+    case 'eu-west-2':
+      return 'London';
+    default:
+      return region;
+  }
+}
+
 export function internalServerErrorMiddleware(err: Error, req: any, res: express.Response, next: express.NextFunction) {
   req.log.error(err);
 
@@ -18,18 +30,23 @@ export function internalServerErrorMiddleware(err: Error, req: any, res: express
     res.status(500);
     res.send(internalServerError.render({
       errorMessage: err.message,
+      location: platformLocation(process.env.AWS_REGION || ''),
     }));
 
     return;
   }
 
   res.status(500);
-  res.send(internalServerError.render({}));
+  res.send(internalServerError.render({
+    location: platformLocation(process.env.AWS_REGION || ''),
+  }));
 }
 
 export function pageNotFoundMiddleware(_req: any, res: express.Response, _next: express.NextFunction) {
   res.status(404);
-  res.send(pageNotFound.render({}));
+  res.send(pageNotFound.render({
+    location: platformLocation(process.env.AWS_REGION || ''),
+  }));
 }
 
 export default {

--- a/src/components/organizations/organizations.ts
+++ b/src/components/organizations/organizations.ts
@@ -32,6 +32,7 @@ export async function listOrganizations(ctx: IContext, _params: IParameters): Pr
       cfDownloadLinkSource,
       documentationLink,
       organizations,
+      location: ctx.app.awsRegion,
     }),
   };
 }

--- a/src/components/organizations/organizations.ts
+++ b/src/components/organizations/organizations.ts
@@ -32,7 +32,7 @@ export async function listOrganizations(ctx: IContext, _params: IParameters): Pr
       cfDownloadLinkSource,
       documentationLink,
       organizations,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }

--- a/src/components/reports/cost.ts
+++ b/src/components/reports/cost.ts
@@ -82,7 +82,7 @@ export async function viewCostReport(
       quotaCostRecords,
       totalBillables,
       billableEventCount,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }

--- a/src/components/reports/cost.ts
+++ b/src/components/reports/cost.ts
@@ -82,6 +82,7 @@ export async function viewCostReport(
       quotaCostRecords,
       totalBillables,
       billableEventCount,
+      location: ctx.app.awsRegion,
     }),
   };
 }

--- a/src/components/services/services.ts
+++ b/src/components/services/services.ts
@@ -54,7 +54,7 @@ export async function viewService(ctx: IContext, params: IParameters): Promise<I
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }

--- a/src/components/services/services.ts
+++ b/src/components/services/services.ts
@@ -54,6 +54,7 @@ export async function viewService(ctx: IContext, params: IParameters): Promise<I
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }

--- a/src/components/spaces/spaces.ts
+++ b/src/components/spaces/spaces.ts
@@ -64,6 +64,7 @@ export async function listApplications(ctx: IContext, params: IParameters): Prom
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }
@@ -114,6 +115,7 @@ export async function listBackingServices(ctx: IContext, params: IParameters): P
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }
@@ -188,6 +190,7 @@ export async function listSpaces(ctx: IContext, params: IParameters): Promise<IR
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }

--- a/src/components/spaces/spaces.ts
+++ b/src/components/spaces/spaces.ts
@@ -64,7 +64,7 @@ export async function listApplications(ctx: IContext, params: IParameters): Prom
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }
@@ -115,7 +115,7 @@ export async function listBackingServices(ctx: IContext, params: IParameters): P
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }
@@ -190,7 +190,7 @@ export async function listSpaces(ctx: IContext, params: IParameters): Promise<IR
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -239,6 +239,7 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -239,7 +239,7 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }

--- a/src/components/terms/middleware.test.ts
+++ b/src/components/terms/middleware.test.ts
@@ -31,7 +31,7 @@ app.use((req: any, _res: any, next: any) => {
   next();
 });
 
-app.use(termsCheckerMiddleware({
+app.use(termsCheckerMiddleware(config.awsRegion, {
   apiEndpoint: config.accountsAPI,
   secret: config.accountsSecret,
 }));

--- a/src/components/terms/middleware.test.ts
+++ b/src/components/terms/middleware.test.ts
@@ -31,7 +31,7 @@ app.use((req: any, _res: any, next: any) => {
   next();
 });
 
-app.use(termsCheckerMiddleware(config.awsRegion, {
+app.use(termsCheckerMiddleware(config.location, {
   apiEndpoint: config.accountsAPI,
   secret: config.accountsSecret,
 }));

--- a/src/components/terms/middleware.ts
+++ b/src/components/terms/middleware.ts
@@ -16,7 +16,7 @@ function sync(f: MiddlewareFunction) {
   };
 }
 
-export function termsCheckerMiddleware(config: IAccountsClientConfig): express.Handler {
+export function termsCheckerMiddleware(location: string, config: IAccountsClientConfig): express.Handler {
   const accounts = new AccountsClient(config);
   const app = express();
 
@@ -25,6 +25,7 @@ export function termsCheckerMiddleware(config: IAccountsClientConfig): express.H
     res.send(termsTemplate.render({
       document,
       csrf: req.csrfToken(),
+      location,
     }));
   }));
 

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -77,18 +77,6 @@ interface IUserPostBody {
 
 const VALID_EMAIL = /[^.]@[^.]/;
 
-/* istanbul ignore next */
-function platformLocation(ctx: IContext): string {
-  switch (ctx.app.awsRegion) {
-    case 'eu-west-1':
-      return 'Ireland';
-    case 'eu-west-2':
-      return 'London';
-    default:
-      return ctx.app.awsRegion;
-  }
-}
-
 async function setAllUserRolesForOrg(
   cf: CloudFoundryClient,
   params: IParameters,
@@ -379,7 +367,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
         await notify.sendWelcomeEmail(values.email, {
           organisation: organization.entity.name,
           url: invitation.inviteLink,
-          location: platformLocation(ctx),
+          location: ctx.app.awsRegion,
         });
       } catch (err) {
         ctx.log.error(`a user was assigned to org ${params.organizationGUID} ` +
@@ -492,7 +480,7 @@ export async function resendInvitation(ctx: IContext, params: IParameters, _: ob
   await notify.sendWelcomeEmail(user.entity.username, {
     organisation: organization.entity.name,
     url: invitation.inviteLink,
-    location: platformLocation(ctx),
+    location: ctx.app.awsRegion,
   });
 
   return {

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -198,7 +198,7 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
       linkTo: ctx.linkTo,
       users: usersWithSpaces,
       organization,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }
@@ -260,7 +260,7 @@ export async function inviteUserForm(ctx: IContext, params: IParameters): Promis
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }
@@ -369,7 +369,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
         await notify.sendWelcomeEmail(values.email, {
           organisation: organization.entity.name,
           url: invitation.inviteLink,
-          location: ctx.app.awsRegion,
+          location: ctx.app.location,
         });
       } catch (err) {
         ctx.log.error(`a user was assigned to org ${params.organizationGUID} ` +
@@ -387,7 +387,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
         isAdmin,
         isBillingManager,
         isManager,
-        location: ctx.app.awsRegion,
+        location: ctx.app.location,
       }),
     };
   } catch (err) {
@@ -405,7 +405,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
           isAdmin,
           isBillingManager,
           isManager,
-          location: ctx.app.awsRegion,
+          location: ctx.app.location,
         }),
         status: 400,
       };
@@ -484,7 +484,7 @@ export async function resendInvitation(ctx: IContext, params: IParameters, _: ob
   await notify.sendWelcomeEmail(user.entity.username, {
     organisation: organization.entity.name,
     url: invitation.inviteLink,
-    location: ctx.app.awsRegion,
+    location: ctx.app.location,
   });
 
   return {
@@ -494,7 +494,7 @@ export async function resendInvitation(ctx: IContext, params: IParameters, _: ob
       csrf: ctx.csrf,
       errors: [],
       organization,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }
@@ -587,7 +587,7 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }
@@ -653,7 +653,7 @@ export async function updateUser(ctx: IContext, params: IParameters, body: objec
         isAdmin,
         isBillingManager,
         isManager,
-        location: ctx.app.awsRegion,
+        location: ctx.app.location,
       }),
     };
   } catch (err) {
@@ -672,7 +672,7 @@ export async function updateUser(ctx: IContext, params: IParameters, body: objec
           isAdmin,
           isBillingManager,
           isManager,
-          location: ctx.app.awsRegion,
+          location: ctx.app.location,
         }),
         status: 400,
       };
@@ -716,7 +716,7 @@ export async function confirmDeletion(ctx: IContext, params: IParameters): Promi
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }
@@ -756,7 +756,7 @@ export async function deleteUser(ctx: IContext, params: IParameters, _: object):
       isAdmin,
       isBillingManager,
       isManager,
-      location: ctx.app.awsRegion,
+      location: ctx.app.location,
     }),
   };
 }

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -198,6 +198,7 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
       linkTo: ctx.linkTo,
       users: usersWithSpaces,
       organization,
+      location: ctx.app.awsRegion,
     }),
   };
 }
@@ -259,6 +260,7 @@ export async function inviteUserForm(ctx: IContext, params: IParameters): Promis
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }
@@ -385,6 +387,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
         isAdmin,
         isBillingManager,
         isManager,
+        location: ctx.app.awsRegion,
       }),
     };
   } catch (err) {
@@ -402,6 +405,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
           isAdmin,
           isBillingManager,
           isManager,
+          location: ctx.app.awsRegion,
         }),
         status: 400,
       };
@@ -490,6 +494,7 @@ export async function resendInvitation(ctx: IContext, params: IParameters, _: ob
       csrf: ctx.csrf,
       errors: [],
       organization,
+      location: ctx.app.awsRegion,
     }),
   };
 }
@@ -582,6 +587,7 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }
@@ -647,6 +653,7 @@ export async function updateUser(ctx: IContext, params: IParameters, body: objec
         isAdmin,
         isBillingManager,
         isManager,
+        location: ctx.app.awsRegion,
       }),
     };
   } catch (err) {
@@ -665,6 +672,7 @@ export async function updateUser(ctx: IContext, params: IParameters, body: objec
           isAdmin,
           isBillingManager,
           isManager,
+          location: ctx.app.awsRegion,
         }),
         status: 400,
       };
@@ -708,6 +716,7 @@ export async function confirmDeletion(ctx: IContext, params: IParameters): Promi
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }
@@ -747,6 +756,7 @@ export async function deleteUser(ctx: IContext, params: IParameters, _: object):
       isAdmin,
       isBillingManager,
       isManager,
+      location: ctx.app.awsRegion,
     }),
   };
 }

--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -40,3 +40,16 @@
     margin-left: govuk-spacing(3);
   }
 }
+
+.paas-govuk-tag {
+  @extend .govuk-tag;
+  float: right;
+}
+
+.paas-govuk-tag-london {
+  background-color: #005ea5;
+}
+
+.paas-govuk-tag-ireland {
+  background-color: #85994b;
+}

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -59,6 +59,7 @@
       <a href="https://www.cloud.service.gov.uk/" class="govuk-header__link govuk-header__link--service-name">
         Platform as a Service
       </a>
+      <span class="paas-govuk-tag paas-govuk-tag-{{location.toLowerCase()}}">{{location}}</span>
 
       <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
       <nav>

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -36,30 +36,58 @@
 {% endblock %}
 
 {% block header %}
-  {{ govukHeader({
-    homepageUrl: "/",
-    containerClasses: "govuk-width-container",
-    serviceName: "Platform as a Service",
-    serviceUrl: "https://www.cloud.service.gov.uk/",
-    navigation: [
-      {
-        href: "/",
-        text: "My Organisations"
-      },
-      {
-        href: "https://docs.cloud.service.gov.uk/",
-        text: "Documentation"
-      },
-      {
-        href: "mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk",
-        text: "Support"
-      },
-      {
-        href: "/auth/logout",
-        text: "Sign out"
-      }
-    ]
-  }) }}
+<header class="govuk-header " role="banner" data-module="header">
+  <div class="govuk-header__container govuk-width-container">
+
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+
+          <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
+            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+
+            <image src="/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+      </a>
+    </div>
+    <div class="govuk-header__content">
+
+      <a href="https://www.cloud.service.gov.uk/" class="govuk-header__link govuk-header__link--service-name">
+        Platform as a Service
+      </a>
+
+      <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <nav>
+        <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+          <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+            <a class="govuk-header__link" href="/">
+              My Organisations
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="https://docs.cloud.service.gov.uk/">
+              Documentation
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">
+              Support
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="/auth/logout">
+              Sign out
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</header>
 {% endblock %}
 
 {% block main %}

--- a/src/layouts/govuk.test.ts
+++ b/src/layouts/govuk.test.ts
@@ -1,8 +1,13 @@
 import govukTemplate from './govuk.njk';
 
 describe('layout test suite', () => {
-  it('it should render ok without any special parameters', async () => {
+  it('it should render a location tag', async () => {
+    const html = govukTemplate.render({location: 'Taggy McTaggington'});
+    expect(html).toContain('Taggy McTaggington');
+  });
+
+  it('it should fail to render with no parameters', async () => {
     const html = govukTemplate.render({});
-    expect(html).toContain('Platform as a Service');
+    expect(html).toBeNull();
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,9 +33,21 @@ function onShutdown() {
   process.exit(0);
 }
 
+/* istanbul ignore next */
+function platformLocation(region: string): string {
+  switch (region) {
+    case 'eu-west-1':
+      return 'Ireland';
+    case 'eu-west-2':
+      return 'London';
+    default:
+      return region;
+  }
+}
+
 async function main() {
   const cloudFoundryAPI = expectEnvVariable('API_URL');
-  const awsRegion = expectEnvVariable('AWS_REGION');
+  const awsRegion = platformLocation(expectEnvVariable('AWS_REGION'));
   let authorizationAPI = process.env.AUTHORIZATION_URL;
   let uaaAPI = process.env.UAA_URL;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ function platformLocation(region: string): string {
 
 async function main() {
   const cloudFoundryAPI = expectEnvVariable('API_URL');
-  const awsRegion = platformLocation(expectEnvVariable('AWS_REGION'));
+  const location = platformLocation(expectEnvVariable('AWS_REGION'));
   let authorizationAPI = process.env.AUTHORIZATION_URL;
   let uaaAPI = process.env.UAA_URL;
 
@@ -71,7 +71,7 @@ async function main() {
     oauthClientID: expectEnvVariable('OAUTH_CLIENT_ID'),
     oauthClientSecret: expectEnvVariable('OAUTH_CLIENT_SECRET'),
     cloudFoundryAPI,
-    awsRegion,
+    location,
     authorizationAPI,
     uaaAPI,
     notifyAPIKey: expectEnvVariable('NOTIFY_API_KEY'),


### PR DESCRIPTION
What
----

Add a location tag for every page on pazmin which lets people know which platform they are using (AWS region).

How to review
-------------

* Deploy:
  * locally change the paas-admin resource to pin this branch instead of a tag 
  * run `make dev pipelines`
  * run `make dev run_job JOB=post-deploy`
* manually check every feasible page, because we don't have proper tests. Good luck.
* I haven't tested the Terms page yet (`/agreements/:name`).
  **Note:** I tried creating a user in prod and wasn't forced to make the agreement, so I think we may have already broken this feature.

I don't like the way I have implemented this. I am worried any page would break silently (no tests would fail) if the way the parameter gets passed in changes. The user experience for such an error would be to see a blank page. Not good. Ideally I want some kind of default filter (`location | defaul('unknown')`) to at least stop it breaking (the CSS selector for `-unknown` could be `display:none;`). Such a filter is used elsewhere in this repository, but I couldn't get it to work for me. I am not much of a NodeJS person.

Who can review
---------------

Anybody, but I would like @richardTowers opinion on it.