### PR TITLE
[support] Increase timeout for billing access

### DIFF
--- a/src/lib/billing/billing.ts
+++ b/src/lib/billing/billing.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import moment from 'moment';
 import qs from 'qs';
 
-const DEFAULT_TIMEOUT = 30000;
+const DEFAULT_TIMEOUT = 180000;
 
 interface IBillingClientConfig {
   readonly apiEndpoint: string;


### PR DESCRIPTION
What
----

We have been having issues with timeouts when large orgs access their
current monthly statement, this is due to the volume of data being pulled
from the database before the end of month denormalisation process is
run.

How to review
-------------

Code review

Who can review
---------------

Not @LeePorte 
