### PR TITLE
[#163555458] Fix links to tech docs

### DIFF
--- a/notify_templates/README
+++ b/notify_templates/README
@@ -1,0 +1,3 @@
+These templates have to be manually updated in the Notify admin UI.
+
+They are kept here for reference, and so that we have a record of them in source control.

--- a/notify_templates/welcome.txt
+++ b/notify_templates/welcome.txt
@@ -16,16 +16,13 @@ We’ve added your account to the following organisation in our ((location)) reg
 New organisations are created on our London platform. If you require hosting in Ireland please contact gov-uk-paas-support@digital.cabinet-office.gov.uk.
 
 Read more about organisations:
-https://docs.cloud.service.gov.uk/#organisations
-
-You can find advice about choosing a password:
-https://docs.cloud.service.gov.uk/#choosing-passwords
+https://docs.cloud.service.gov.uk/orgs_spaces_users.html
 
 To get started, look at our Quick Setup Guide:
-https://docs.cloud.service.gov.uk/#quick-setup-guide
+https://docs.cloud.service.gov.uk/get_started.html
 
 You can find our privacy policy here:
-https://docs.cloud.service.gov.uk/#privacy-policy
+https://www.cloud.service.gov.uk/privacy-notice
 
 To check the status of GOV.UK PaaS, and see the availability of live
 applications and database connectivity, visit

--- a/notify_templates/welcome.txt
+++ b/notify_templates/welcome.txt
@@ -1,0 +1,36 @@
+Subject: Welcome to the Government PaaS
+
+Hello,
+
+Open this link to create your account and set your password. It only works once.
+
+((url))
+
+In some departments antivirus systems check and invalidate links in inbound emails. If you’re unable to access the URL above, please contact
+gov-uk-paas-support@digital.cabinet-office.gov.uk.
+
+We’ve added your account to the following organisation in our ((location)) region:
+
+((organisation))
+
+New organisations are created on our London platform. If you require hosting in Ireland please contact gov-uk-paas-support@digital.cabinet-office.gov.uk.
+
+Read more about organisations:
+https://docs.cloud.service.gov.uk/#organisations
+
+You can find advice about choosing a password:
+https://docs.cloud.service.gov.uk/#choosing-passwords
+
+To get started, look at our Quick Setup Guide:
+https://docs.cloud.service.gov.uk/#quick-setup-guide
+
+You can find our privacy policy here:
+https://docs.cloud.service.gov.uk/#privacy-policy
+
+To check the status of GOV.UK PaaS, and see the availability of live
+applications and database connectivity, visit
+https://status.cloud.service.gov.uk. We recommend you sign up to this service
+to get alerts and incident updates.
+
+Regards,
+Government PaaS team.

--- a/src/components/organizations/organizations.njk
+++ b/src/components/organizations/organizations.njk
@@ -38,16 +38,16 @@
       <h3>Installation options:</h3>
       <ul>
         <li>
-          <a href="{{ cfDownloadLinkLocation }}macosx64{{ cfDownloadLinkSource }}" class="govuk-link">Mac OS X 64 bit</a>
+          <a href="https://packages.cloudfoundry.org/stable?release=macosx64&source=github" class="govuk-link">Mac OS X 64 bit</a>
         </li>
         <li>
-          <a href="{{ cfDownloadLinkLocation }}windows64{{ cfDownloadLinkSource }}" class="govuk-link">Windows 64 bit</a>
+          <a href="https://packages.cloudfoundry.org/stable?release=windows64&source=github" class="govuk-link">Windows 64 bit</a>
         </li>
         <li>
-          <a href="{{ cfDownloadLinkLocation }}debian64{{ cfDownloadLinkSource }}" class="govuk-link">Debian 64 bit</a>
+          <a href="https://packages.cloudfoundry.org/stable?release=debian64&source=github" class="govuk-link">Debian 64 bit</a>
         </li>
         <li>
-          <a href="{{ cfDownloadLinkLocation }}redhat64{{ cfDownloadLinkSource }}" class="govuk-link">RedHat 64 bit</a>
+          <a href="https://packages.cloudfoundry.org/stable?release=redhat64&source=github" class="govuk-link">RedHat 64 bit</a>
         </li>
       </ul>
     </div>
@@ -63,21 +63,21 @@
   <div class="paas-info-section">
     <div class="govuk-grid-row paas-info-section">
       <div class="govuk-grid-column-one-third">
-        <h3><a href="{{ documentationLink }}setting-up-the-command-line" class="govuk-link">Setup and deploy your first app</a></h3>
+        <h3><a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line" class="govuk-link">Setup and deploy your first app</a></h3>
         <p>View our guide on logging in and deploying your first app to GOV.UK PaaS.</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <h3><a href="{{ documentationLink }}organisations-spaces-amp-targets" class="govuk-link">Learn more about orgs and spaces</a></h3>
+        <h3><a href="https://docs.cloud.service.gov.uk/#organisations-spaces-amp-targets" class="govuk-link">Learn more about orgs and spaces</a></h3>
         <p>Get familiar with the basic concepts of Cloud Foundry-based platforms, and what setting up environments looks like.</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <h3><a href="{{ documentationLink }}managing-users" class="govuk-link">Manage team members</a></h3>
+        <h3><a href="https://docs.cloud.service.gov.uk/#managing-users" class="govuk-link">Manage team members</a></h3>
         <p>Learn how to manage permission levels for your users using the command line tool (for org managers only).</p>
       </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <h3><a href="{{ documentationLink }}system-status-alerts-and-updates" class="govuk-link">Get GOV.UK PaaS updates</a></h3>
+        <h3><a href="https://docs.cloud.service.gov.uk/#system-status-alerts-and-updates" class="govuk-link">Get GOV.UK PaaS updates</a></h3>
         <p>Discover how to get system status alerts and updates about new features.</p>
       </div>
     </div>

--- a/src/components/organizations/organizations.njk
+++ b/src/components/organizations/organizations.njk
@@ -63,22 +63,22 @@
   <div class="paas-info-section">
     <div class="govuk-grid-row paas-info-section">
       <div class="govuk-grid-column-one-third">
-        <h3><a href="https://docs.cloud.service.gov.uk/#setting-up-the-command-line" class="govuk-link">Setup and deploy your first app</a></h3>
+        <h3><a href="https://docs.cloud.service.gov.uk/get_started.html#set-up-the-cloud-foundry-command-line" class="govuk-link">Set up and deploy your first app</a></h3>
         <p>View our guide on logging in and deploying your first app to GOV.UK PaaS.</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <h3><a href="https://docs.cloud.service.gov.uk/#organisations-spaces-amp-targets" class="govuk-link">Learn more about orgs and spaces</a></h3>
+        <h3><a href="https://docs.cloud.service.gov.uk/orgs_spaces_users.html" class="govuk-link">Learn more about orgs and spaces</a></h3>
         <p>Get familiar with the basic concepts of Cloud Foundry-based platforms, and what setting up environments looks like.</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <h3><a href="https://docs.cloud.service.gov.uk/#managing-users" class="govuk-link">Manage team members</a></h3>
+        <h3><a href="https://docs.cloud.service.gov.uk/orgs_spaces_users.html#users-and-user-roles" class="govuk-link">Manage team members</a></h3>
         <p>Learn how to manage permission levels for your users using the command line tool (for org managers only).</p>
       </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <h3><a href="https://docs.cloud.service.gov.uk/#system-status-alerts-and-updates" class="govuk-link">Get GOV.UK PaaS updates</a></h3>
-        <p>Discover how to get system status alerts and updates about new features.</p>
+        <h3><a href="https://status.cloud.service.gov.uk/" class="govuk-link">Get GOV.UK PaaS status updates</a></h3>
+        <p>Check the status of GOV.UK PaaS, and see the availability of live applications and database connectivity. We recommend you sign up to this service to get alerts and incident updates.</p>
       </div>
     </div>
   </div>

--- a/src/components/organizations/organizations.ts
+++ b/src/components/organizations/organizations.ts
@@ -19,18 +19,12 @@ export async function listOrganizations(ctx: IContext, _params: IParameters): Pr
   });
 
   const organizations = await cf.organizations().then(sortOrganizationsByName);
-  const cfDownloadLinkLocation = 'https://packages.cloudfoundry.org/stable?release=';
-  const cfDownloadLinkSource = '&amp;source=github';
-  const documentationLink = 'https://docs.cloud.service.gov.uk/#';
 
   return {
     body: organizationsTemplate.render({
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
       csrf: ctx.csrf,
-      cfDownloadLinkLocation,
-      cfDownloadLinkSource,
-      documentationLink,
       organizations,
       location: ctx.app.location,
     }),


### PR DESCRIPTION
What
----

This fixes the links to the tech docs, which all seem to pre-date the switch to the multi-page layout.

As part of this I've also pulled the current email template from Notify into this repo so that we can track changes to it. It will require manually updating in Notify once the changes are merged.

How to review
-------------

Code review should be enough - might be easier commit-by-commit.

## :rotating_light: After merging :rotating_light: 

Login to the Notify admin UI and update the email template with the new version.

Who can review
---------------

Not me.