### PR TITLE
[#163084536] Removal of an org permission from a user instead removes all org permissions

### DIFF
--- a/src/components/users/permissions.njk
+++ b/src/components/users/permissions.njk
@@ -37,6 +37,7 @@
         <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][current]">
         {% if  (billingManagers | length < 2) and (values.org_roles[organization.metadata.guid].billing_managers) %}
           {% set isCheckboxDisabled = true %}
+          <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][desired]">
         {% else %}
           {% set isCheckboxDisabled = false %}
         {% endif %}
@@ -57,6 +58,7 @@
         <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].managers }}" name="org_roles[{{ organization.metadata.guid }}][managers][current]">
         {% if  (managers | length < 2) and (values.org_roles[organization.metadata.guid].managers) %}
           {% set isCheckboxDisabled = true %}
+          <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].managers }}" name="org_roles[{{ organization.metadata.guid }}][managers][desired]">
         {% else %}
           {% set isCheckboxDisabled = false %}
         {% endif %}

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -373,7 +373,7 @@ describe('users test suite', async () => {
     expect(response.body).toContain('Confirm user deletion');
   });
 
-  it('should update the user, set BillingManager role and show success - User Edit', async () => {
+  it('should update the user, set BillingManager role and show success - User Edit', async () => { // TODO: fix label
     const response = await users.deleteUser(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
       userGUID: '5ff19d4c-8fa0-4d74-94e0-52eac86d55a8',
@@ -429,6 +429,32 @@ describe('users test suite', async () => {
     expect(response.body).toContain('Updated a team member');
   });
 
+  it('should update the user, remove BillingManager role and show success - User Edit', async () => {
+    const scope = nock(ctx.app.cloudFoundryAPI)
+    // tslint:disable:max-line-length
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/uaa-user-changeperms-123456?recursive=true').reply(200, `{}`)
+      // tslint:enable:max-line-length
+    ;
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-changeperms-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          billing_managers: {
+            current: '1',
+          },
+        }),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+    expect(response.body).toContain('Updated a team member');
+    expect(scope.isDone());
+    scope.done();
+  });
+
   it('should update the user, set OrgManager role and show success - User Edit', async () => {
     const response = await users.updateUser(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
@@ -450,6 +476,36 @@ describe('users test suite', async () => {
     expect(response.body).toContain('Updated a team member');
   });
 
+  it('should update the user, remove OrgManager role and show success - User Edit', async () => {
+    const scope = nock(ctx.app.cloudFoundryAPI)
+    // tslint:disable:max-line-length
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/uaa-user-changeperms-123456?recursive=true').reply(200, `{}`)
+      // tslint:enable:max-line-length
+    ;
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-changeperms-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          managers: {
+            current: '1',
+          },
+          auditors: {
+            current: '1',
+            desired: '1',
+          },
+        }),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+    expect(response.body).toContain('Updated a team member');
+    expect(scope.isDone());
+    scope.done();
+  });
+
   it('should update the user, set OrgAuditor role and show success - User Edit', async () => {
     const response = await users.updateUser(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
@@ -469,6 +525,32 @@ describe('users test suite', async () => {
     });
 
     expect(response.body).toContain('Updated a team member');
+  });
+
+  it('should update the user, remove OrgAuditor role and show success - User Edit', async () => {
+    const scope = nock(ctx.app.cloudFoundryAPI)
+    // tslint:disable:max-line-length
+    .delete('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/uaa-user-changeperms-123456?recursive=true').reply(200, `{}`)
+      // tslint:enable:max-line-length
+    ;
+    const response = await users.updateUser(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      userGUID: 'uaa-user-changeperms-123456',
+    }, {
+      org_roles: {
+        '3deb9f04-b449-4f94-b3dd-c73cefe5b275': composeOrgRoles({
+          auditors: {
+            current: '1',
+          },
+        }),
+      },
+      space_roles: {
+        '5489e195-c42b-4e61-bf30-323c331ecc01': composeSpaceRoles({}),
+      },
+    });
+    expect(response.body).toContain('Updated a team member');
+    expect(scope.isDone());
+    scope.done();
   });
 
   it('should update the user, set SpaceManager role and show success - User Edit', async () => {

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -29,6 +29,8 @@ import inviteTemplate from './invite.njk';
 import inviteSuccessTemplate from './invite.success.njk';
 import usersTemplate from './users.njk';
 
+import { isUndefined } from 'util';
+
 interface IInvalid {
   readonly field: string;
   readonly message: string;
@@ -120,7 +122,7 @@ async function setAllUserRolesForOrg(
         return Promise.resolve(undefined);
       }
 
-      if (!newPermission && oldPermission === '0') {
+      if (isUndefined(newPermission) && oldPermission === '0') {
         return Promise.resolve(undefined);
       }
 
@@ -153,7 +155,7 @@ async function setAllUserRolesForOrg(
         return Promise.resolve(undefined);
       }
 
-      if (!newPermission && oldPermission === '0') {
+      if (isUndefined(newPermission) && oldPermission === '0') {
         return Promise.resolve(undefined);
       }
 

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -787,6 +787,33 @@ export const userRolesForOrg = `{
     },
     {
       "metadata": {
+        "guid": "uaa-user-changeperms-123456",
+        "url": "/v2/users/uaa-user-changeperms-123456",
+        "created_at": "2016-06-08T16:41:35Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "admin": false,
+        "active": false,
+        "default_space_guid": null,
+        "username": "user@example.com",
+        "organization_roles": [
+          "org_user",
+          "org_manager",
+          "org_auditor",
+          "billing_manager"
+        ],
+        "spaces_url": "/v2/users/uaa-user-changeperms-123456/spaces",
+        "organizations_url": "/v2/users/uaa-user-changeperms-123456/organizations",
+        "managed_organizations_url": "/v2/users/uaa-user-changeperms-123456/managed_organizations",
+        "billing_managed_organizations_url": "/v2/users/uaa-user-changeperms-123456/billing_managed_organizations",
+        "audited_organizations_url": "/v2/users/uaa-user-changeperms-123456/audited_organizations",
+        "managed_spaces_url": "/v2/users/uaa-user-changeperms-123456/managed_spaces",
+        "audited_spaces_url": "/v2/users/uaa-user-changeperms-123456/audited_spaces"
+      }
+    },
+    {
+      "metadata": {
         "guid": "99022be6-feb8-4f78-96f3-7d11f4d476f1",
         "url": "/v2/users/99022be6-feb8-4f78-96f3-7d11f4d476f1",
         "created_at": "2016-06-08T16:41:35Z",


### PR DESCRIPTION
What
----

When any single org permission is removed from a user (ie. the checkbox is unchecked), all org permissions were removed from that user.

When a checkbox is unchecked in a HTML form, the `value` is just not serialised and sent, rather than a 0 being sent.

Instead of checking for truthiness of the new value, we now just check to see if the POSTed form value is undefined.

How to review
-------------

* Code review
* Build paasmin from this branch, and deploy to an environment. Add permissions to a user, then remove them - you should see it behaving as expected (permission is added and removed accordingly), vs previous behaviour (permission is removed, along with all others)


Who can review
---------------

Anyone but me and @mogds 