### PR TITLE
[#164135751] Make org permissions display order consistent

### DIFF
--- a/src/components/users/permissions.njk
+++ b/src/components/users/permissions.njk
@@ -25,35 +25,14 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header name" scope="col">Org name</th>
-      <th class="govuk-table__header" scope="col">Org billing manager</th>
       <th class="govuk-table__header" scope="col">Org manager</th>
+      <th class="govuk-table__header" scope="col">Org billing manager</th>
       <th class="govuk-table__header" scope="col">Org auditor</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="row">{{ organization.entity.name }}</th>
-      <td class="govuk-table__cell ">
-        <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][current]">
-        {% if  (billingManagers | length < 2) and (values.org_roles[organization.metadata.guid].billing_managers) %}
-          {% set isCheckboxDisabled = true %}
-          <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][desired]">
-        {% else %}
-          {% set isCheckboxDisabled = false %}
-        {% endif %}
-        {{ govukCheckboxes({
-          id: "org_roles[" + organization.metadata.guid + "][billing_managers]",
-          name: "org_roles[" + organization.metadata.guid + "][billing_managers][desired]",
-          items: [
-            {
-              value: "1",
-              html: "<span>Billing manager</span>",
-              checked: values.org_roles[organization.metadata.guid].billing_managers,
-              disabled: isCheckboxDisabled
-            }
-          ]
-        }) }}
-      </td>
       <td class="govuk-table__cell ">
         <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].managers }}" name="org_roles[{{ organization.metadata.guid }}][managers][current]">
         {% if  (managers | length < 2) and (values.org_roles[organization.metadata.guid].managers) %}
@@ -70,6 +49,27 @@
               value: "1",
               html: "<span>Org manager</span>",
               checked: values.org_roles[organization.metadata.guid].managers,
+              disabled: isCheckboxDisabled
+            }
+          ]
+        }) }}
+      </td>
+      <td class="govuk-table__cell ">
+        <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][current]">
+        {% if  (billingManagers | length < 2) and (values.org_roles[organization.metadata.guid].billing_managers) %}
+          {% set isCheckboxDisabled = true %}
+          <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][desired]">
+        {% else %}
+          {% set isCheckboxDisabled = false %}
+        {% endif %}
+        {{ govukCheckboxes({
+          id: "org_roles[" + organization.metadata.guid + "][billing_managers]",
+          name: "org_roles[" + organization.metadata.guid + "][billing_managers][desired]",
+          items: [
+            {
+              value: "1",
+              html: "<span>Billing manager</span>",
+              checked: values.org_roles[organization.metadata.guid].billing_managers,
               disabled: isCheckboxDisabled
             }
           ]


### PR DESCRIPTION
What
----

Orders organisation permissions consistently in both overview and edit views.

How to review
-------------

Build and deploy a version of `paas-admin` locally from this branch and check that the organisation permissions are displayed in a consistent order:

1. Org manager
2. Org billing manager
3. Org auditor

Who can review
---------------
Anyone but me