### PR TITLE
Add simple stub API for running without CF

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ Execute the unit tests to ensure everything looks good:
 npm test
 ```
 
-Start the server in development mode
+Start the server pointing at stubbed APIs
+
+```sh
+# In one terminal tab
+npm run start:stub-api
+
+# In a second terminal tab
+npm run start:with-stub-api
+```
+
+Start the server pointing at real APIs in development mode
 
 ```sh
 API_URL="https://api.$DEPLOY_ENV.dev.cloudpipeline.digital" \
@@ -77,6 +87,7 @@ OAUTH_CLIENT_SECRET="my-secret" \
 ACCOUNTS_SECRET="my-accounts-secret" \
 NOTIFY_API_KEY="qwerty123456" \
 NOTIFY_WELCOME_TEMPLATE_ID="qwerty123456" \
+AWS_REGION="eu-west-2" \
 npm start
 ```
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "fix:vulnerabilities": "npm audit fix --update-binary",
     "start": "export PORT=${PORT-3000}; export LOG_LEVEL=${LOG_LEVEL-warn}; if [ \"$NODE_ENV\" = 'production' ]; then npm run -s start:production; else npm run -s start:dev; fi",
     "start:dev": "NODE_ENV=development ENABLE_WATCH=true ENABLE_SERVER=true ALLOW_INSECURE_SESSION=true npm run -s build | pino-pretty",
+    "start:stub-api": "STUB_API_PORT=${STUB_API_PORT-1337} PORT=${PORT-3000} ts-node stub-api/index.ts",
+    "start:with-stub-api": "STUB_API_PORT=${STUB_API_PORT-1337}; API_URL=http://0:${STUB_API_PORT} BILLING_URL=http://0:${STUB_API_PORT} ACCOUNTS_URL=http://0:${STUB_API_PORT} UAA_URL=http://0:${STUB_API_PORT} OAUTH_CLIENT_ID=my-client-id OAUTH_CLIENT_SECRET=my-secret ACCOUNTS_SECRET=my-accounts-secret NOTIFY_API_KEY=qwerty123456 NOTIFY_WELCOME_TEMPLATE_ID=qwerty123456 AWS_REGION=eu-west-2 npm start",
     "start:production": "NODE_ENV=production ALLOW_INSECURE_SESSION=true npm run -s build && node dist/main.js | pino-pretty",
     "push": "NODE_ENV=production npm run -s build && cf push",
     "clean": "rm -rf dist/* || echo 'already clean'"
@@ -74,6 +76,7 @@
     "tap": "12.0.1",
     "ts-jest": "23.1.3",
     "ts-loader": "4.4.2",
+    "ts-node": "^7.0.0",
     "ts-mocha": "^2.0.0",
     "tslint": "5.11.0",
     "tslint-consistent-codestyle": "1.13.3",

--- a/stub-api/index.ts
+++ b/stub-api/index.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import stubUaa from './stub-uaa';
+import stubAccounts from './stub-accounts';
+import stubCf from './stub-cf';
+
+const app = express();
+
+const adminPort = process.env['PORT'] || '3000';
+const stubApiPort = process.env['STUB_API_PORT'] || '3001';
+const config = {adminPort: adminPort, stubApiPort: stubApiPort};
+
+const cyan = '\x1b[36m';
+const reset = '\x1b[0m';
+
+app.use((req, _res, next) => {
+  console.log(`${cyan}stub-api${reset} ${req.method} ${req.path}`);
+  next();
+});
+
+stubUaa(app, config);
+stubAccounts(app, config);
+stubCf(app, config);
+
+app.listen(stubApiPort, () => console.log(`${cyan}stub-api${reset} Started, listening on port ${stubApiPort}`));

--- a/stub-api/stub-accounts.ts
+++ b/stub-api/stub-accounts.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+function mockAccounts(app: express.Application, _config: { stubApiPort: string, adminPort: string }) {
+  app.get('/users/some-user/documents', (_req, res) => {
+    res.send(JSON.stringify([]));
+  });
+};
+
+export default mockAccounts;

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import * as testData from '../src/lib/cf/cf.test.data';
+
+function mockCF(app: express.Application, config: {stubApiPort: string, adminPort: string}) {
+  const { stubApiPort } = config;
+
+  const info = JSON.stringify({
+    name: "",
+    build: "",
+    support: "https://youtu.be/ZZ5LpwO-An4",
+    version: 0,
+    description: "",
+    authorization_endpoint: `http://0:${stubApiPort}`,
+    token_endpoint: `http://0:${stubApiPort}`,
+    min_cli_version: null,
+    min_recommended_cli_version: null,
+    app_ssh_endpoint: null,
+    app_ssh_host_key_fingerprint: null,
+    app_ssh_oauth_client: null,
+    doppler_logging_endpoint: null,
+    api_version: "2.128.0",
+    osbapi_version: "2.14",
+    user: "default-stub-api-user"
+  });
+
+  app.get('/v2/info'                                 , (_, res) => res.send(info));
+  app.get('/v2/organizations'                        , (_, res) => res.send(testData.organizations));
+  app.get('/v2/organizations/:guid'                  , (_, res) => res.send(testData.organization));
+  app.get('/v2/quota_definitions'                    , (_, res) => res.send(testData.organizations));
+  app.get('/v2/quota_definitions'                    , (_, res) => res.send(testData.organizations));
+  app.get('/v2/quota_definitions/:guid'              , (_, res) => res.send(testData.organizationQuota));
+  app.get('/v2/organizations/:guid/spaces'           , (_, res) => res.send(testData.spaces));
+  app.get('/v2/spaces/:guid/apps'                    , (_, res) => res.send(testData.apps));
+  app.get('/v2/apps/:guid'                           , (_, res) => res.send(testData.app));
+  app.get('/v2/apps/:guid/summary'                   , (_, res) => res.send(testData.appSummary));
+  app.get('/v2/spaces/:guid'                         , (_, res) => res.send(testData.space));
+  app.get('/v2/spaces/:guid/summary'                 , (_, res) => res.send(testData.spaceSummary));
+  app.get('/v2/space_quota_definitions/:guid'        , (_, res) => res.send(testData.spaceQuota));
+  app.get('/v2/spaces/:guid/service_instances'       , (_, res) => res.send(testData.services));
+  app.get('/v2/service_instances/:guid'              , (_, res) => res.send(testData.serviceInstance));
+  app.get('/v2/service_plans/:guid'                  , (_, res) => res.send(testData.servicePlan));
+  app.get('/v2/services/:guid'                       , (_, res) => res.send(testData.service));
+  app.get('/v2/user_provided_service_instances'      , (_, res) => res.send(testData.userServices));
+  app.get('/v2/user_provided_service_instances/:guid', (_, res) => res.send(testData.userServiceInstance));
+  app.get('/v2/users/uaa-id-253/spaces'              , (_, res) => res.send(testData.spaces));
+  app.get('/v2/organizations/:guid/user_roles'       , (_, res) => res.send(testData.userRolesForOrg));
+  app.get('/v2/spaces/:guid/user_roles'              , (_, res) => res.send(testData.userRolesForSpace));
+};
+
+export default mockCF;

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+
+const tokenKey = 'tokensecret';
+function mockUAA(app: express.Application, config: {stubApiPort: string, adminPort: string}) {
+  const { adminPort } = config;
+  const fakeJwt = jwt.sign({
+    user_id: 'some-user',
+    scope: [],
+    exp: 2535018460,
+  }, tokenKey);
+
+  app.post(
+    '/oauth/token',
+    (_req, res) => res.send(JSON.stringify({access_token: fakeJwt}))
+  );
+
+  app.get(
+    '/oauth/authorize',
+    (_req, res) => {
+      const location = `http://0:${adminPort}/auth/login/callback?code=some-code`;
+      res.redirect(301, location);
+    }
+  );
+
+  app.get(
+    '/token_keys',
+    (_req, res) => res.send(JSON.stringify({keys: [{value: tokenKey}]}))
+  );
+
+}
+
+export default mockUAA;


### PR DESCRIPTION
What
----

It's often nice to be able to work on front end issues without having to
have a full backend up and running. This is particularly true of
paas-admin, because you need a correctly configured Cloud Foundry, UAA,
paas-accounts, and (to some degree) paas-billing to be running before
you can click around in paas-admin.

By adding a "stub" API we can run the frontend in isolation from a
"real" backend.

This is also useful if you're working without an internet connection.

There's not too much code needed to get this to work, because we already
have most of the API responses we need mocked out for various tests.

I've used TypeScript for the stub-api so it's consistent with the rest
of the app, and so we can import cf.test.data.ts from the existing
codebase. I've taken a direct dependency on ts-node so you can run the
stub-api without having a separate compile step - this isn't a new
dependency because we already depend on it through ts-mocha.

How to review
-------------

* Code review
* Check out the branch and follow the instructions added to the README

Who can review
---------------

Not @richardtowers