### PR TITLE
Enable strict null checks, fix possible issue

### DIFF
--- a/src/components/reports/cost.ts
+++ b/src/components/reports/cost.ts
@@ -29,6 +29,10 @@ interface IQuotaCostRecord extends ICostable {
   readonly quotaName: string;
 }
 
+function getFirstBillableEventQuotaGUID(billableEvents: ReadonlyArray<IBillableEvent>): string | undefined {
+  return billableEvents && billableEvents[0] && billableEvents[0].quotaGUID;
+}
+
 export async function viewCostReport(
   ctx: IContext,
   params: IParameters,
@@ -57,9 +61,9 @@ export async function viewCostReport(
 
   const orgQuotas: {[key: string]: IOrganizationQuota} = (await Promise.all(
     orgs.map(async (org: IOrganization) => {
-      const orgBillableEvent = orgBillableEvents[org.metadata.guid];
-      let orgQuotaGUID;
-      orgQuotaGUID = orgBillableEvent === undefined ? org.entity.quota_definition_guid : orgBillableEvent[0].quotaGUID;
+      const orgQuotaGUID =
+        getFirstBillableEventQuotaGUID(orgBillableEvents[org.metadata.guid]) ||
+        org.entity.quota_definition_guid;
       const quota = await cf.organizationQuota(orgQuotaGUID);
       return {[org.metadata.guid]: quota};
     }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strictNullChecks": false,
     "strict": true,
     "outDir": "dist",
     "module": "commonjs",
@@ -16,7 +15,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "isolatedModules": false,
     "pretty": true,
     "allowJs": true,


### PR DESCRIPTION
What
----

Previously we disabled the strictNullChecks option because it was
warning us about passing a `(string | undefined)` into a function that
wanted a `(string)`.

It looks like the compiler was warning us about a genuine issue here
though:

* If there were any billable events for a particular org in the time
  period, `orgBillableEvent` would be defined, and `orgBillableEvent[0]`
  would be defined
* The event could be one from before we started writing `quotaGUID` to
  the databases, so `orgBillableEvent[0].quotaGUID` could still be
  undefined
* The conditional would have set `orgQuotaGUID` to undefined in this
  case.
* Calling `cf.organizationQuota` with undefined would result in an
  error.

This commit pulls the code to get the first billable event out into a
function so it's a bit clearer what it's doing. This function is clear
about the fact that it can return undefined. We can then use the this
thing as the first option in the conditional, and fall back to the
current quota if that doesn't work.

How to review
-------------

* Code review
* Check the tests still pass

Who can review
---------------

Not @richardtowers