### PR TITLE
Remediate OOM killing on PaaS by increasing memory

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,6 @@
 applications:
 - name: paas-admin
   command: node dist/main.js
-  memory: 512M
+  memory: 2G
   buildpack: nodejs_buildpack
   stack: cflinuxfs3


### PR DESCRIPTION
What
----

Scale up PaaSmin with more memory, to stop it from being OOM-killed when people access the bills for large orgs

How to review
-------------

Code review

Who can review
---------------

Not @tlwr
