### PR TITLE
Bump gov.uk frontend to 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4496,9 +4496,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.2.0.tgz",
-      "integrity": "sha512-vNiUIp8EQACARNTyOwmE110HcQd+zJvkgbKv+gmY28QxqQGGd2DEJ35nblnjElsRJpSgbxwa85iqlNtbR3Q5tA=="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.10.0.tgz",
+      "integrity": "sha512-Tfo76yz5ybFMX1heojeiWAyxUx0gABM2/hfMk1zu+9hWvApmfxeTaQOJkje4jeo1ybRo+FhgKFqqAzkBOOUnqg=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "express": "4.16.3",
     "express-pino-logger": "4.0.0",
     "express-static-gzip": "1.1.1",
-    "govuk-frontend": "^2.2.0",
+    "govuk-frontend": "^2.10.0",
     "helmet": "3.13.0",
     "jmespath": "0.15.0",
     "jsonwebtoken": "8.3.0",

--- a/src/components/statements/statements.njk
+++ b/src/components/statements/statements.njk
@@ -63,7 +63,7 @@
                 </select>
               </td>
               <td class="govuk-table__cell paas-statement-filter">
-                {{ govukButton({text: "Filter" }) }}
+                {{ govukButton({text: "Filter", preventDoubleClick: true}) }}
               </td>
             </tr>
           </tbody>

--- a/src/components/users/delete.njk
+++ b/src/components/users/delete.njk
@@ -25,7 +25,8 @@
       <p class="govuk-heading-m">{{ user.entity.username }}</p>
 
       {{ govukButton({
-        text: "Yes, remove from organisation"
+        text: "Yes, remove from organisation",
+        preventDoubleClick: true
       }) }}
 
       <a href="{{ linkTo('admin.organizations.users.edit', {organizationGUID: organization.metadata.guid, userGUID: user.metadata.guid}) }}" class="govuk-link">

--- a/src/components/users/edit.njk
+++ b/src/components/users/edit.njk
@@ -52,7 +52,8 @@
         <input type="hidden" name="_csrf" value="{{ csrf }}" />
         <p>It would appear the user did not setup their account yet.</p>
         {{ govukButton({
-          text: "Resend user invite"
+          text: "Resend user invite",
+          preventDoubleClick: true
         }) }}
       </form>
     {% endif %}
@@ -62,7 +63,8 @@
       {% include "./permissions.njk" %}
 
       {{ govukButton({
-        text: "Save role changes"
+        text: "Save role changes",
+        preventDoubleClick: true
       }) }}
     </form>
 


### PR DESCRIPTION
What
----
Bump gov.uk frontend to 2.10.0. Also adds the `preventDoubleClick` option to buttons, introduced in v2.8.0.

How to review
-------------
1. Code review

Who can review
---------------
Anyone
