### PR TITLE
Improve contrast in "Ireland" tag in header

### DIFF
--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -51,5 +51,5 @@
 }
 
 .paas-govuk-tag-ireland {
-  background-color: #85994b;
+  background-color: #006435;
 }


### PR DESCRIPTION
What
----

We have a tag in the header of paas-admin so users can see which region
they're looking at.

In Ireland the contrast between the text and the background is not
great, so users with poor eyesight may struggle to see what it says.

This switches from `govuk-colour("light-green")` to `govuk-colour("green")`, which improves the contrast ration from 3.2 to 7.3:

light-green: https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=85994B
green: https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=006435

How to review
-------------

BEHOLD:

![image](https://user-images.githubusercontent.com/1696784/56307080-fa312400-613b-11e9-884f-2fe46c4de54b.png)

![image](https://user-images.githubusercontent.com/1696784/56307061-f00f2580-613b-11e9-870c-1516f7db80a5.png)

Who can review
---------------

Not @richardTowers 