### PR TITLE
[#165418008] Stub billing

### DIFF
--- a/stub-api/index.ts
+++ b/stub-api/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import stubUaa from './stub-uaa';
 import stubAccounts from './stub-accounts';
+import stubBilling from './stub-billing';
 import stubCf from './stub-cf';
 
 const app = express();
@@ -19,6 +20,7 @@ app.use((req, _res, next) => {
 
 stubUaa(app, config);
 stubAccounts(app, config);
+stubBilling(app, config);
 stubCf(app, config);
 
 app.listen(stubApiPort, () => console.log(`${cyan}stub-api${reset} Started, listening on port ${stubApiPort}`));

--- a/stub-api/stub-accounts.ts
+++ b/stub-api/stub-accounts.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 
 function mockAccounts(app: express.Application, _config: { stubApiPort: string, adminPort: string }) {
-  app.get('/users/some-user/documents', (_req, res) => {
+  app.get('/users/:guid/documents', (_req, res) => {
     res.send(JSON.stringify([]));
   });
 };

--- a/stub-api/stub-billing.ts
+++ b/stub-api/stub-billing.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+function mockBilling(app: express.Application, _config: { stubApiPort: string, adminPort: string }) {
+  app.get('/billable_events', (_req, res) => {
+    res.send(JSON.stringify([]));
+  });
+};
+
+export default mockBilling;

--- a/stub-api/stub-billing.ts
+++ b/stub-api/stub-billing.ts
@@ -1,8 +1,69 @@
 import express from 'express';
 
+const defaultPriceDetails = {
+  name: "default-price-name",
+  stop: "2019-01-23T14:42:55+00:00",
+  start: "2019-01-22T10:44:05+00:00",
+  ex_vat: "0.0224000000000000000000000",
+  inc_vat: "0.02688000000000000000000000",
+  vat_code: "Standard",
+  vat_rate: "0.2",
+  plan_name: "app",
+  currency_code: "USD",
+  currency_rate: "0.8"
+};
+const defaultBillingEvent = {
+      event_guid: "default-event-guid",
+      event_start: "2019-01-22T10:44:05+00:00",
+      event_stop: "2019-01-23T14:42:55+00:00",
+      resource_guid: "default-resource-guid",
+      resource_name: "default-resource",
+      resource_type: "app",
+      org_guid: "some-org-guid",
+      org_name: "some-org",
+      space_guid: "some-space-guid",
+      space_name: "some-space",
+      plan_guid: "some-plan-guid",
+      quota_definition_guid: null,
+      number_of_nodes: 2,
+      memory_in_mb: 128,
+      storage_in_mb: 0,
+      price: {}
+    }
 function mockBilling(app: express.Application, _config: { stubApiPort: string, adminPort: string }) {
   app.get('/billable_events', (_req, res) => {
-    res.send(JSON.stringify([]));
+    res.send(JSON.stringify([
+      {
+        ...defaultBillingEvent,
+        resource_name: 'up',
+        price: {inc_vat: "100.00", ex_vat: "80.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+      },
+      {
+        ...defaultBillingEvent,
+        resource_name: 'down',
+        price: {inc_vat: "334.00", ex_vat: "314.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+      },
+      {
+        ...defaultBillingEvent,
+        resource_name: 'strange',
+        price: {inc_vat: "10.00", ex_vat: "8.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+      },
+      {
+        ...defaultBillingEvent,
+        resource_name: 'charm',
+        price: {inc_vat: "532.00", ex_vat: "512.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+      },
+      {
+        ...defaultBillingEvent,
+        resource_name: 'bottom',
+        price: {inc_vat: "100.00", ex_vat: "80.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+      },
+      {
+        ...defaultBillingEvent,
+        resource_name: 'top',
+        price: {inc_vat: "100.00", ex_vat: "80.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+      },
+    ]));
   });
 };
 

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -5,7 +5,7 @@ const tokenKey = 'tokensecret';
 function mockUAA(app: express.Application, config: {stubApiPort: string, adminPort: string}) {
   const { adminPort } = config;
   const fakeJwt = jwt.sign({
-    user_id: 'some-user',
+    user_id: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
     scope: [],
     exp: 2535018460,
   }, tokenKey);


### PR DESCRIPTION
What
----

Implemented a stub of the billing endpoint so you can look at the billing pages without needing a real cloud foundry + billing api. 

How to review
-------------

* Code review
* Run `npm run start:stub-api` in one tab and `npm run start:with-stub-api` in another, check you can get to the billing statement pages from localhost:3000
* Check out this screenshot:

![0 0 0 0_3000_organisations_a7aff246-5f5b-4cf8-87d8-f316053e4a20_statements_2019-04-01](https://user-images.githubusercontent.com/1696784/56358279-1b465300-61d6-11e9-87ee-2e8bcf5cfb79.png)

Who can review
---------------

Not @richardTowers 