### PR TITLE
Increase timeout when talking to billing ; ignore test orgs

### DIFF
--- a/src/components/reports/cost.ts
+++ b/src/components/reports/cost.ts
@@ -50,7 +50,11 @@ export async function viewCostReport(
     apiEndpoint: ctx.app.cloudFoundryAPI,
   });
 
-  const orgs = await cf.organizations();
+  const orgs = (await cf.organizations()).filter(org => {
+    const name = org.entity.name;
+    // ignore orgs used by tests
+    return !(name.match(/^(CAT|SMOKE|PERF|ACC)/));
+  });
   const orgGUIDs = orgs.map(o => o.metadata.guid);
 
   const billableEvents = await billingClient.getBillableEvents({

--- a/src/lib/billing/billing.ts
+++ b/src/lib/billing/billing.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import moment from 'moment';
 import qs from 'qs';
 
-const DEFAULT_TIMEOUT = 180000;
+const DEFAULT_TIMEOUT = 300000;
 
 interface IBillingClientConfig {
   readonly apiEndpoint: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import Server from './server';
 sourceMapSupport.install();
 
 const logger = pino({
-  level: process.env.LOG_LEVEL || 'warn',
+  level: process.env.LOG_LEVEL || 'info',
 });
 
 function expectEnvVariable(variableName: string): string {


### PR DESCRIPTION
What
----

- Add a timeout when talking to paas-billing
- ignore test orgs (e.g. CAT / PERF / SMOKE)
- Increase log level to info

How to review
-------------

Code review

Who can review
---------------

Not @tlwr or @mogds 
