### PR TITLE
Support: Fix bug showing allocations

### DIFF
--- a/src/components/spaces/applications.njk
+++ b/src/components/spaces/applications.njk
@@ -37,13 +37,19 @@
             <th class="govuk-table__header" scope="row">
               <a href="{{ linkTo('admin.organizations.spaces.applications.view', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, applicationGUID: application.metadata.guid}) }}" class="govuk-link">{{ application.entity.name }}</a>
             </th>
-            <td class="govuk-table__cell ">
-              {{ application.entity.running_instances }}/{{ application.entity.instances }}
+            <td class="govuk-table__cell " title="{{ application.entity.running_instances }} running / {{ application.entity.instances }} desired">
+              {{ application.entity.running_instances }}
+              /
+              {{ application.entity.instances }}
             </td>
-            <td class="govuk-table__cell ">
+            <td class="govuk-table__cell " title="Total: {{ ((application.entity.memory * application.entity.instances) / 1024) | round(2) }}gb">
+              {{ application.entity.instances }}
+              &times;
               {{ (application.entity.memory / 1024) | round(2) }}gb
             </td>
-            <td class="govuk-table__cell ">
+            <td class="govuk-table__cell " title="Total: {{ ((application.entity.disk_quota * application.entity.instances) / 1024) | round(2) }}gb">
+              {{ application.entity.instances }}
+              &times;
               {{ (application.entity.disk_quota / 1024) | round(2) }}gb
             </td>
             <td class="govuk-table__cell ">

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -61,6 +61,8 @@ describe('spaces test suite', () => {
     });
 
     expect(response.body).toContain('has 1 apps');
+
+    expect(response.body).toContain('2gb');
   });
 
   it('should show list of applications in space', async () => {

--- a/src/components/spaces/spaces.ts
+++ b/src/components/spaces/spaces.ts
@@ -161,7 +161,7 @@ export async function listSpaces(ctx: IContext, params: IParameters): Promise<IR
         running_apps: applications.filter((app: IApplication) => app.entity.state.toLowerCase() !== 'stopped'),
         stopped_apps: applications.filter((app: IApplication) => app.entity.state.toLowerCase() === 'stopped'),
         memory_allocated: applications.reduce((allocated: number, app: IApplication) =>
-          allocated + app.entity.memory, 0),
+          allocated + (app.entity.memory * app.entity.instances), 0),
         quota,
       },
       metadata: space.metadata,

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -478,7 +478,7 @@ export const appSummary = `{
   "detected_buildpack_guid": null,
   "environment_json": null,
   "memory": 1024,
-  "instances": 1,
+  "instances": 2,
   "disk_quota": 1024,
   "state": "STOPPED",
   "version": "d457b51a-d7cb-494d-b39e-3171ec75bd60",

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -479,7 +479,7 @@ export const appSummary = `{
   "environment_json": null,
   "memory": 1024,
   "instances": 2,
-  "disk_quota": 1024,
+  "disk_quota": 4096,
   "state": "STOPPED",
   "version": "d457b51a-d7cb-494d-b39e-3171ec75bd60",
   "command": null,


### PR DESCRIPTION
What
----

### Fix bug in org summary

The org summary space shows a summary for each space:

![Screen Shot 2019-04-25 at 14 45 09](https://user-images.githubusercontent.com/1482692/56740386-c02dd680-6768-11e9-90bf-c68efcc621c8.png)
*the GOV.UK Notify org summary page*

The above number is the total amount of memory used for each app assuming that the number of instances for each app is one.

Now the calculation includes the number of instances.

### Add additional columns in space summary

The space summary page shows the amount of memory and disk used for each app:

![Screen Shot 2019-04-25 at 14 47 21](https://user-images.githubusercontent.com/1482692/56740852-9f19b580-6769-11e9-9dd5-e0ba5f6b9059.png)
*the GOV.UK Notify production space summary

Now, if the number of instances is not 1, the total amount is calculated:

![Screen Shot 2019-04-25 at 15 41 34](https://user-images.githubusercontent.com/1482692/56744607-bf00a780-6770-11e9-9f9b-5e5a2c390744.png)
*what it looks like with stub-api*


How to review
-------------

- Code review
- Spin up with stub-api locally (see README) and check

Who can review
---------------

Pair with @46bit 