### PR TITLE
Skip calculator getQuote if there are no items

### DIFF
--- a/src/components/calculator/calculator.test.ts
+++ b/src/components/calculator/calculator.test.ts
@@ -115,6 +115,23 @@ describe('calculator test suite', () => {
     expect(response.body).toMatch(/\baws-s3-bucket\b/);
   });
 
+  it('should get a zero quote if no items are specified', async () => {
+    const rangeStart = moment().startOf('month').format('YYYY-MM-DD');
+    const rangeStop = moment().endOf('month').format('YYYY-MM-DD');
+
+    nock(config.billingAPI)
+      .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
+      .reply(200, `[]`);
+
+    const response = await getCalculator(ctx, {
+      items: [],
+    });
+
+    expect(response.body).toContain('Pricing calculator');
+    expect(response.body).toContain('<p class="paas-price">&pound; 0.00</p>');
+
+  });
+
   it('should use calculator when provided fake services', async () => {
     const rangeStart = moment().startOf('month').format('YYYY-MM-DD');
     const rangeStop = moment().endOf('month').format('YYYY-MM-DD');

--- a/src/components/calculator/calculator.ts
+++ b/src/components/calculator/calculator.ts
@@ -103,7 +103,10 @@ export async function getCalculator(ctx: IContext, params: IParameters): Promise
     items: params.items || [],
     plans,
   };
-  const quote = await getQuote(billing, state);
+  let quote: IQuote = { events: [], exVAT: 0, incVAT: 0 };
+  if (params.items && params.items.length) {
+    quote = await getQuote(billing, state);
+  }
 
   return {
     body: calculatorTemplate.render({


### PR DESCRIPTION
What
----

Previously the calculator would always ask paas-billing for a quote,
even if there were no items in the query. Obviously this always returned
0, but it did so extremely slowly.

It's always going to be free to run nothing on the PaaS.

How to review
-------------

* Code review
* Run locally with stub-api and check it still works (and that no calls
  are made to /forecast_events in the no-items case)
* Check the tests pass on travis

Who can review
---------------

Not @richardtowers