### PR TITLE
Remove low-value, flakey test

### DIFF
--- a/src/layouts/govuk.test.ts
+++ b/src/layouts/govuk.test.ts
@@ -5,10 +5,4 @@ describe('layout test suite', () => {
     const html = govukTemplate.render({location: 'Taggy McTaggington'});
     expect(html).toContain('Taggy McTaggington');
   });
-
-  it('it should fail to render with no parameters', async () => {
-    expect(
-      () => { govukTemplate.render({}); },
-    ).toThrowError();
-  });
 });


### PR DESCRIPTION
What
----

This test was checking that the layout template would throw an error if
called without a location. It looks like it should do this, because it
calls `location.toLowerCase()`, which should error if location is
undefined.

This test passes on Travis, but fails on my machine. I haven't spent
long looking into why it fails because I think the test is pointless:

* Calling `render()` without params would be a programming error, so it
  feels like overkill to test it
* The tests use a different `.njk` loader to production, so the tests
  aren't even really testing the same code path as production.

Pointless tests that behave differently on different machines are bad,
so let's get rid of it.

How to review
-------------

* Code review

Who can review
---------------

Not @richardtowers