### PR TITLE
Remove unecessary async in describes

### DIFF
--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -105,7 +105,7 @@ describe('app test suite', () => {
     expect(response.status).toEqual(500);
   });
 
-  describe('when authenticated', async () => {
+  describe('when authenticated', () => {
     const app = init(config);
     const agent = request.agent(app);
     const time = Math.floor(Date.now() / 1000);
@@ -206,7 +206,7 @@ describe('app test suite', () => {
     });
   });
 
-  describe('when token expires', async () => {
+  describe('when token expires', () => {
     const app = init(config);
     const agent = request.agent(app);
     const time = Math.floor(Date.now() / 1000);

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -64,7 +64,7 @@ function composeSpaceRoles(setup: object) {
   };
 }
 
-describe('users test suite', async () => {
+describe('users test suite', () => {
   // tslint:disable:max-line-length
   const nockCF = nock(ctx.app.cloudFoundryAPI).persist();
   const nockUAA = nock(ctx.app.uaaAPI).persist();
@@ -617,7 +617,7 @@ describe('users test suite', async () => {
   });
 });
 
-describe('permissions calling cc api', async () => {
+describe('permissions calling cc api', () => {
   beforeEach(() => {
     nock.cleanAll();
   });


### PR DESCRIPTION
What
----

Travis has been warning us that jest-jasmine doesn't support async
describes:

https://travis-ci.org/alphagov/paas-admin/jobs/524993283#L570

Turns out we don't need these blocks to be async, because they don't
await anything. All the awaits happen inside `it('blah', () => {})`
functions, which jasmine runs later anyway.

How to review
-------------

* Code review
* Check the tests still pass

Who can review
---------------

Not @richardtowers