### PR TITLE
[#165851677] Warn about cflinuxfs2 on org, space and app pages

### DIFF
--- a/src/components/applications/applications.test.ts
+++ b/src/components/applications/applications.test.ts
@@ -17,10 +17,13 @@ describe('applications test suite', () => {
     .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/summary').times(1).reply(200, data.appSummary)
     .get('/v2/apps/646f636b-6572-0d0a-8697-86641668c123').times(1).reply(200, data.dockerApp)
     .get('/v2/apps/646f636b-6572-0d0a-8697-86641668c123/summary').times(1).reply(200, data.dockerAppSummary)
+    .get('/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7').times(1).reply(200, data.appUsingCflinuxfs2)
+    .get('/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7/summary').times(1).reply(200, data.appSummaryUsingCflinuxfs2)
     .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52').times(1).reply(200, data.space)
     .get('/v2/spaces/1053174d-eb79-4f16-bf82-9f83a52d6e84').times(1).reply(200, data.space)
     .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9').times(1).reply(200, data.organization)
-    .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728').times(1).reply(200, data.stack);
+    .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728').times(1).reply(200, data.stack)
+    .get('/v2/stacks/dd63d39a-85f8-48ef-bb73-89097192cfcb').times(1).reply(200, data.stackCflinuxfs2);
 
   const tokenKey = 'secret';
   const token = jwt.sign({
@@ -54,9 +57,10 @@ describe('applications test suite', () => {
       spaceGUID: '7846301e-c84c-4ba9-9c6a-2dfdae948d52',
     });
 
-    expect(response.body).toMatch(/cflinuxfs3/);
     expect(response.body).toMatch(/Stack/);
+    expect(response.body).toMatch(/cflinuxfs3/);
     expect(response.body).not.toMatch(/Docker Image/);
+    expect(response.body).not.toMatch(/This application needs upgrading or it may go offline/);
   });
 
   it('should say the name of the docker image being used', async () => {
@@ -66,9 +70,21 @@ describe('applications test suite', () => {
       spaceGUID: '7846301e-c84c-4ba9-9c6a-2dfdae948d52',
     });
 
-    expect(response.body).not.toMatch(/cflinuxfs3/);
     expect(response.body).not.toMatch(/Stack/);
+    expect(response.body).not.toMatch(/cflinuxfs3/);
     expect(response.body).toMatch(/Docker Image/);
     expect(response.body).toMatch(/governmentpaas\/is-cool/);
+  });
+
+  it('should say a warning if the cflinuxfs2 stack is being used', async () => {
+    const response = await viewApplication(ctx, {
+      applicationGUID: 'ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7',
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      spaceGUID: '7846301e-c84c-4ba9-9c6a-2dfdae948d52',
+    });
+
+    expect(response.body).toMatch(/Stack/);
+    expect(response.body).toMatch(/cflinuxfs2/);
+    expect(response.body).toMatch(/This application needs upgrading or it may go offline/);
   });
 });

--- a/src/components/applications/overview.njk
+++ b/src/components/applications/overview.njk
@@ -21,6 +21,17 @@
         {{ application.entity.name }}
       </h1>
 
+      {% if stack.entity.name == 'cflinuxfs2' %}
+        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+          <h2 class="govuk-error-summary__title" id="error-summary-title">
+            This application needs upgrading or it may go offline
+          </h2>
+          <div class="govuk-error-summary__body">
+            <p style="margin-bottom: 0;">This application is using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2">performing the upgrade yourself</a>.</p>
+          </div>
+        </div>
+      {% endif %}
+
       {{ govukTable({
         caption: 'Application details',
         firstCellIsHeader: false,

--- a/src/components/spaces/_spaces.scss
+++ b/src/components/spaces/_spaces.scss
@@ -28,6 +28,19 @@
     padding-left: govuk-spacing(3) - 1px;
   }
 
+  &.space-warning {
+    border-color: #b10e1e;
+
+    .space-warning-wrapper {
+      clear: both;
+      padding: 16px 0 0 15px;
+
+      .govuk-warning-text {
+        margin-bottom: 0;
+      }
+    }
+  }
+
   h4 {
     @include govuk-font($size: 16);;
   }

--- a/src/components/spaces/applications.njk
+++ b/src/components/spaces/applications.njk
@@ -20,6 +20,27 @@
 
   {% if applications.length > 0 %}
 
+    {% if cflinuxfs2UpgradeNeeded %}
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-title">
+          Application(s) need upgrading or they may go offline
+        </h2>
+        <div class="govuk-error-summary__body">
+          <p>Some applications in this space are using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2">performing the upgrade yourself</a>.</p>
+          <p>The following applications are affected:</p>
+          <ul class="govuk-list govuk-error-summary__list">
+            {% for application in applications %}
+              {% if application.entity.stack_guid === cflinuxfs2StackGUID %}
+                <li>
+                  <a href="{{ linkTo('admin.organizations.spaces.applications.view', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, applicationGUID: application.metadata.guid}) }}" color="#b10e1e">{{ application.entity.name }}</a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    {% endif %}
+
     <table class="govuk-table space-overview">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/src/components/spaces/spaces.njk
+++ b/src/components/spaces/spaces.njk
@@ -55,10 +55,31 @@
     </div>
   </details>
 
+  {% if cflinuxfs2UpgradeNeeded %}
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        Application(s) need upgrading or they may go offline
+      </h2>
+      <div class="govuk-error-summary__body">
+        <p>Some spaces below in this space are using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2">performing the upgrade yourself</a>.</p>
+        <p>Applications in the following spaces are affected:</p>
+        <ul class="govuk-list govuk-error-summary__list">
+          {% for space in spaces %}
+            {% if space.entity.cflinuxfs2UpgradeNeeded %}
+              <li>
+                <a href="{{ linkTo('admin.organizations.spaces.applications.list', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid}) }}" color="#b10e1e">{{ space.entity.name }}</a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  {% endif %}
+
   <div class="govuk-grid-row space-wrapper">
   {% for space in spaces %}
     <a href="{{ linkTo('admin.organizations.spaces.applications.list', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid}) }}" id="space-{{ space.metadata.guid }}" class="govuk-link">
-      <section class="govuk-grid-row space">
+      <section class="govuk-grid-row space {% if space.entity.cflinuxfs2UpgradeNeeded %} space-warning {% endif %}">
         <div class="govuk-grid-column-one-third">
           <h3>
             <span class="paas-caption">Space:</span>
@@ -96,6 +117,18 @@
             </p>
           </div>
         </div>
+
+        {% if space.entity.cflinuxfs2UpgradeNeeded %}
+          <div class="space-warning-wrapper">
+            <div class="govuk-warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                Application(s) in this space need upgrading or they may go offline soon
+              </strong>
+            </div>
+          </div>
+        {% endif %}
       </section>
     </a>
   {% endfor %}

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -27,6 +27,7 @@ nock('https://example.com/api').persist()
   .get('/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab').reply(200, data.servicePlan)
   .get('/v2/services/775d0046-7505-40a4-bfad-ca472485e332').reply(200, data.service)
   .get('/v2/user_provided_service_instances?q=space_guid:bc8d3381-390d-4bd7-8c71-25309900a2e3').reply(200, data.services)
+  .get('/v2/stacks').reply(200, data.spaces)
   .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3').reply(200, data.space)
   .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').reply(200, data.spaceQuota);
 // tslint:enable:max-line-length

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -254,7 +254,7 @@ export const spaceSummary = `{
       "ports": null
     }
   ],
-  "services": [
+  " =": [
     {
       "guid": "5cf08d8b-848c-4f27-bd92-8080fa021783",
       "name": "name-1385",
@@ -632,6 +632,144 @@ export const dockerAppSummary = `{
   "staging_failed_description": null,
   "diego": false,
   "docker_image": "governmentpaas/is-cool",
+  "docker_credentials": {
+   "username": null,
+   "password": null
+  },
+  "package_updated_at": "2016-06-08T16:41:22Z",
+  "detected_start_command": "",
+  "enable_ssh": true,
+  "ports": null
+}`;
+
+export const appUsingCflinuxfs2 = `{
+  "metadata": {
+    "guid": "ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7",
+    "url": "/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7",
+    "created_at": "2016-06-08T16:41:44Z",
+    "updated_at": "2016-06-08T16:41:44Z"
+  },
+  "entity": {
+    "name": "name-2401",
+    "production": false,
+    "space_guid": "7846301e-c84c-4ba9-9c6a-2dfdae948d52",
+    "stack_guid": "dd63d39a-85f8-48ef-bb73-89097192cfcb",
+    "buildpack": null,
+    "detected_buildpack": null,
+    "detected_buildpack_guid": null,
+    "environment_json": null,
+    "memory": 1024,
+    "instances": 1,
+    "disk_quota": 1024,
+    "state": "STOPPED",
+    "version": "df19a7ea-2003-4ecb-a909-e630e43f2719",
+    "command": null,
+    "console": false,
+    "debug": null,
+    "staging_task_id": null,
+    "package_state": "PENDING",
+    "health_check_http_endpoint": "",
+    "health_check_type": "port",
+    "health_check_timeout": null,
+    "staging_failed_reason": null,
+    "staging_failed_description": null,
+    "diego": false,
+    "docker_image": null,
+    "docker_credentials": {
+      "username": null,
+      "password": null
+    },
+    "package_updated_at": "2016-06-08T16:41:45Z",
+    "detected_start_command": "",
+    "enable_ssh": true,
+    "ports": null,
+    "space_url": "/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52",
+    "stack_url": "/v2/stacks/dd63d39a-85f8-48ef-bb73-89097192cfcb",
+    "routes_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/routes",
+    "events_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/events",
+    "service_bindings_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/service_bindings",
+    "route_mappings_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/route_mappings"
+  }
+}`;
+
+export const appSummaryUsingCflinuxfs2 = `{
+  "guid": "ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7",
+  "name": "name-79",
+  "routes": [
+    {
+      "guid": "2d642293-7448-45c6-a864-937c77b9c09a",
+      "host": "host-1",
+      "port": null,
+      "path": "",
+      "domain": {
+        "guid": "02e200d3-5b18-497b-aafd-17fc3bece05f",
+        "name": "domain-1.example.com"
+      }
+    }
+  ],
+  "running_instances": 0,
+  "services": [
+    {
+      "guid": "307f8c47-7796-4d90-bd40-6a56764e37b3",
+      "name": "name-82",
+      "bound_app_count": 1,
+      "last_operation": null,
+      "dashboard_url": null,
+      "service_plan": {
+        "guid": "a7229730-4c4a-418c-a449-9d9f1f2fb3c2",
+        "name": "name-83",
+        "service": {
+          "guid": "724a9245-900e-47cb-b924-0a7a98dea977",
+          "label": "label-1",
+          "provider": null,
+          "version": null
+        }
+      }
+    }
+  ],
+  "available_domains": [
+    {
+      "guid": "02e200d3-5b18-497b-aafd-17fc3bece05f",
+      "name": "domain-1.example.com",
+      "owning_organization_guid": "58a46adc-2e73-4f9c-b7ba-5e72e875cd18"
+    },
+    {
+      "guid": "f067af33-4141-4e69-bbd5-d7b3e01140fa",
+      "name": "customer-app-domain1.com",
+      "router_group_guid": null,
+      "router_group_type": null
+    },
+    {
+      "guid": "ccdb1696-d3e3-4786-a9c1-11bc64b2090a",
+      "name": "customer-app-domain2.com",
+      "router_group_guid": null,
+      "router_group_type": null
+    }
+  ],
+  "production": false,
+  "space_guid": "1053174d-eb79-4f16-bf82-9f83a52d6e84",
+  "stack_guid": "dd63d39a-85f8-48ef-bb73-89097192cfcb",
+  "buildpack": null,
+  "detected_buildpack": null,
+  "detected_buildpack_guid": null,
+  "environment_json": null,
+  "memory": 1024,
+  "instances": 2,
+  "disk_quota": 4096,
+  "state": "STOPPED",
+  "version": "d457b51a-d7cb-494d-b39e-3171ec75bd60",
+  "command": null,
+  "console": false,
+  "debug": null,
+  "staging_task_id": null,
+  "package_state": "PENDING",
+  "health_check_http_endpoint": "",
+  "health_check_type": "port",
+  "health_check_timeout": null,
+  "staging_failed_reason": null,
+  "staging_failed_description": null,
+  "diego": false,
+  "docker_image": null,
   "docker_credentials": {
    "username": null,
    "password": null
@@ -1143,4 +1281,39 @@ export const stack = `{
     "description": "Cloud Foundry Linux-based filesystem (Ubuntu 18.04)"
   }
 }`;
+
+export const stackCflinuxfs2 = `{
+  "metadata": {
+    "guid": "dd63d39a-85f8-48ef-bb73-89097192cfcb",
+    "url": "/v2/stacks/dd63d39a-85f8-48ef-bb73-89097192cfcb",
+    "created_at": "2019-04-08T15:15:16Z",
+    "updated_at": "2019-04-08T15:15:16Z"
+  },
+  "entity": {
+    "name": "cflinuxfs2",
+    "description": "Cloud Foundry Linux-based filesystem (Ubuntu 14.04)"
+  }
+}`;
+
+export const stacksWithoutCflinuxfs2 = `{
+  "total_results": 1,
+  "total_pages": 1,
+  "prev_url": null,
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "bb9ca94f-b456-4ebd-ab09-eb7987cce728",
+        "url": "/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728",
+        "created_at": "2019-04-08T15:15:16Z",
+        "updated_at": "2019-04-08T15:15:16Z"
+      },
+      "entity": {
+        "name": "cflinuxfs3",
+        "description": "Cloud Foundry Linux-based filesystem (Ubuntu 18.04)"
+      }
+    }
+  ]
+}`;
+
 // tslint:enable:max-line-length

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -366,4 +366,21 @@ describe('lib/cf test suite', () => {
 
     expect(stack.entity.name).toEqual('cflinuxfs3');
   });
+
+  test('should get the GUID of cflinuxfs2', async () => {
+    const client = new CloudFoundryClient(config);
+    const cflinuxfs2StackGUID = await client.cflinuxfs2StackGUID();
+
+    expect(cflinuxfs2StackGUID).toEqual('dd63d39a-85f8-48ef-bb73-89097192cfcb');
+  });
+
+  test('should return undefined when cflinuxfs2 is not present', async () => {
+    nock.cleanAll();
+    nock('https://example.com/api').get('/v2/stacks').reply(200, data.stacksWithoutCflinuxfs2);
+
+    const client = new CloudFoundryClient(config);
+    const cflinuxfs2StackGUID = await client.cflinuxfs2StackGUID();
+
+    expect(cflinuxfs2StackGUID).toEqual(undefined);
+  });
 });

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -241,6 +241,12 @@ export default class CloudFoundryClient {
     return response.data;
   }
 
+  public async cflinuxfs2StackGUID(): Promise<string | undefined> {
+    const response = await this.stacks();
+    const cflinuxfs2 = response.filter((stack: cf.IStack) => stack.entity.name === 'cflinuxfs2');
+    return cflinuxfs2.length > 0 ? cflinuxfs2[0].metadata.guid : undefined;
+  }
+
   public async setOrganizationRole(
     organizationGUID: string,
     userGUID: string,


### PR DESCRIPTION
What
----

Adds highly-visible warnings to our admin panel when tenant apps are still on `cflinuxfs2`.

Right now this hardcodes the GUID of `cflinuxfs2` in our `prod` and `prod-lon` environments. This will be reverted once the migration to `cflinuxfs3` is complete. But it may be easier to test this if we stop hardcoding the GUIDs… and that would help solve another issue: right now the application pages say nothing about the stack in use, and so aren't useful for tenants telling if things are on `cflinuxfs3` yet.

The visuals are based upon https://design-system.service.gov.uk/components/warning-text/ and https://design-system.service.gov.uk/components/error-summary/.

## Why

Tenants with lots of orgs, spaces and apps but limited CF knowledge have found it difficult to identify and coordinate what needed upgrading. This PR would turn `paas-admin` into a real-time checklist of what still needs upgrading.

How to review
-------------

* ~Review https://github.com/alphagov/paas-tech-docs/pull/212, wait for it to go live, and check that is accessible at https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2;~ *done*;
* Code review (recognising this is only going to be in the codebase short-term.)

Who can review
---------------

Not @46bit

## Simulated screenshots

These are done manually but convey the idea:

<img width="927" alt="Screenshot 2019-05-02 23 11 50" src="https://user-images.githubusercontent.com/163111/57110294-fe5e6380-6d2f-11e9-87ea-82a3b6527973.png">

---

<img width="987" alt="Screenshot 2019-05-02 23 18 01" src="https://user-images.githubusercontent.com/163111/57110470-92302f80-6d30-11e9-8be8-c7ea2d2ad75e.png">

---

<img width="972" alt="Screenshot 2019-05-02 23 14 03" src="https://user-images.githubusercontent.com/163111/57110302-03231780-6d30-11e9-8bab-6de6d0d62811.png">
