### PR TITLE
Add stub stack endpoints to the stub-api

### DIFF
--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -45,6 +45,8 @@ function mockCF(app: express.Application, config: {stubApiPort: string, adminPor
   app.get('/v2/users/uaa-id-253/spaces'              , (_, res) => res.send(testData.spaces));
   app.get('/v2/organizations/:guid/user_roles'       , (_, res) => res.send(testData.userRolesForOrg));
   app.get('/v2/spaces/:guid/user_roles'              , (_, res) => res.send(testData.userRolesForSpace));
+  app.get('/v2/stacks'                               , (_, res) => res.send(testData.stacks));
+  app.get('/v2/stacks/:guid'                         , (_, res) => res.send(testData.stack));
 };
 
 export default mockCF;


### PR DESCRIPTION
What
----

We added calls to these endpoints in #211 and #205, but they weren't in
the stub-api. We can just use the existing testData for them, which is
good enough to click through a journey.

How to review
-------------

* Code review is probably enough
* Test it locally with the stub API if you're a nerd

Who can review
---------------

Not @richardtowers