### PR TITLE
Hide detected buildpack for docker apps overview

### DIFF
--- a/src/components/applications/applications.test.ts
+++ b/src/components/applications/applications.test.ts
@@ -59,6 +59,7 @@ describe('applications test suite', () => {
 
     expect(response.body).toMatch(/Stack/);
     expect(response.body).toMatch(/cflinuxfs3/);
+    expect(response.body).toMatch(/Detected Buildpack/);
     expect(response.body).not.toMatch(/Docker Image/);
     expect(response.body).not.toMatch(/This application needs upgrading or it may go offline/);
   });
@@ -72,6 +73,7 @@ describe('applications test suite', () => {
 
     expect(response.body).not.toMatch(/Stack/);
     expect(response.body).not.toMatch(/cflinuxfs3/);
+    expect(response.body).not.toMatch(/Detected Buildpack/);
     expect(response.body).toMatch(/Docker Image/);
     expect(response.body).toMatch(/governmentpaas\/is-cool/);
   });

--- a/src/components/applications/applications.ts
+++ b/src/components/applications/applications.ts
@@ -44,9 +44,29 @@ export async function viewApplication(ctx: IContext, params: IParameters): Promi
 
   const stack = await cf.stack(application.entity.stack_guid);
 
+  const appRuntimeInfo = [
+    [
+      {text: 'Detected Buildpack'},
+      {text: summarisedApplication.entity.detected_buildpack},
+    ],
+    [
+      {text: 'Stack'},
+      {text: stack.entity.name},
+    ],
+  ];
+  const dockerRuntimeInfo = [
+    [
+      {text: 'Docker Image'},
+      {text: summarisedApplication.entity.docker_image},
+    ],
+  ];
+  const isDocker = summarisedApplication.entity.docker_image != null;
+  const actualRuntimeInfo = isDocker ? dockerRuntimeInfo : appRuntimeInfo;
+
   return {
     body: applicationOverviewTemplate.render({
       application: summarisedApplication,
+      actualRuntimeInfo,
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
       csrf: ctx.csrf,

--- a/src/components/applications/overview.njk
+++ b/src/components/applications/overview.njk
@@ -43,23 +43,8 @@
             {
               text: application.entity.name
             }
-          ],
-          [
-            {
-              text: 'Detected Buildpack'
-            },
-            {
-              text: application.entity.detected_buildpack
-            }
-          ],
-          [
-            {
-              text: ('Docker Image' if application.entity.docker_image else 'Stack')
-            },
-            {
-              text: (application.entity.docker_image or stack.entity.name)
-            }
-          ],
+          ]
+        ].concat(actualRuntimeInfo).concat([
           [
             {
               text: 'Instances'
@@ -116,7 +101,7 @@
               text: application.entity.ports
             }
           ]
-        ]
+        ])
       }) }}
 
       <h4 class="govuk-heading-s">On the commandline</h4>


### PR DESCRIPTION
What
----

As a developer looking at the overview of my Docker application, I do not want to see the `Detected Buildpack`, because it is irrelevant and confusing.

How to review
-------------

Code review

Automated tests

Who can review
---------------

Not @tlwr