### PR TITLE
Enable sorting billing statements by amount

### DIFF
--- a/src/components/statements/statements.njk
+++ b/src/components/statements/statements.njk
@@ -158,7 +158,12 @@
               <button type="submit" name="sort" value="plan" class="govuk-button filter-header {{ orderDirection if orderBy == 'plan' }}">Plan</button>
             </th>
             <th class="govuk-table__header" scope="col" style="text-align: right">Ex VAT</th>
-            <th class="govuk-table__header" scope="col" style="text-align: right">Inc VAT</th>
+            <th class="govuk-table__header" scope="col" style="text-align: right">
+              {% if orderBy == "amount" %}
+                <input type="hidden" name="order" value="{{ newOrder }}">
+              {% endif %}
+              <button type="submit" name="sort" value="amount" class="govuk-button filter-header {{ orderDirection if orderBy == 'amount' }}">Inc VAT</button>
+            </th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">

--- a/src/components/statements/statements.test.ts
+++ b/src/components/statements/statements.test.ts
@@ -202,11 +202,11 @@ describe('statements test suite', () => {
 
   it('should sort by different fields correctly', async () => {
     const a = [
-      {...resourceTemplate, resourceName: 'z', planName: 'Athens', spaceName: '3'},
-      {...resourceTemplate, resourceName: 'a', planName: 'Berlin', spaceName: '4'},
-      {...resourceTemplate, resourceName: 'b', planName: 'Dublin', spaceName: '1'},
-      {...resourceTemplate, resourceName: 'd', planName: 'Berlin', spaceName: '3'},
-      {...resourceTemplate, resourceName: 'd', planName: 'Cairo', spaceName: '2'},
+      {...resourceTemplate, resourceName: 'z', planName: 'Athens', spaceName: '3', price: { exVAT: 0, incVAT: 1}},
+      {...resourceTemplate, resourceName: 'a', planName: 'Berlin', spaceName: '4', price: { exVAT: 0, incVAT: 2}},
+      {...resourceTemplate, resourceName: 'b', planName: 'Dublin', spaceName: '1', price: { exVAT: 0, incVAT: 3}},
+      {...resourceTemplate, resourceName: 'd', planName: 'Berlin', spaceName: '3', price: { exVAT: 0, incVAT: 4}},
+      {...resourceTemplate, resourceName: 'd', planName: 'Cairo', spaceName: '2', price: { exVAT: 0, incVAT: 5}},
     ];
 
     const cases = [
@@ -216,6 +216,8 @@ describe('statements test suite', () => {
       {sort: 'name', order: 'desc', out: ['z', 'd', 'd', 'b', 'a']},
       {sort: 'space', order: 'desc', out: ['4', '3', '3', '2', '1']},
       {sort: 'plan', order: 'desc', out: ['Dublin', 'Cairo', 'Berlin', 'Berlin', 'Athens']},
+      {sort: 'amount', order: 'desc', out: [5, 4, 3, 2, 1]},
+      {sort: 'amount', order: 'asc', out: [1, 2, 3, 4, 5]},
     ];
 
     for (const c of cases) {
@@ -237,6 +239,11 @@ describe('statements test suite', () => {
           case 'plan':
             expect(t.planName).toEqual(c.out[i]);
             break;
+          case 'amount':
+            expect(t.price.incVAT).toEqual(c.out[i]);
+            break;
+          default:
+            fail(`Unexpected sort: ${c.sort}`);
         }
       });
     }

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -48,7 +48,7 @@ interface IResourceWithPlanName {
   readonly planName: string;
 }
 
-export type ISortableBy = 'name' | 'space' | 'plan';
+export type ISortableBy = 'name' | 'space' | 'plan' | 'amount';
 export type ISortableDirection = 'asc' | 'desc';
 
 export interface ISortable {
@@ -254,6 +254,9 @@ export function order(items: IResourceUsage[], sort: ISortable): IResourceUsage[
       break;
     case 'space':
       items.sort(sortBySpace);
+      break;
+    case 'amount':
+      items.sort((x, y) => x.price.incVAT - y.price.incVAT);
       break;
     case 'name':
     default:


### PR DESCRIPTION
What
----

Before:

![image](https://user-images.githubusercontent.com/1696784/57702761-a8a28900-7656-11e9-8049-b5449e3a9de5.png)

After:

![image](https://user-images.githubusercontent.com/1696784/57702722-945e8c00-7656-11e9-93a8-ae908fe2a27f.png)

```
Andy Paine [2:21 PM]
...
feature request
sort by cost
not entirely sure why I would want to sort by name, space or plan but
not cost on a billing page :rotating_thinking_face:

Richard Towers [2:23 PM]
yeah, fair point lol
```

How to review
-------------

* Code review
* Run with `stub-api` and check it works locally
* (If you're feeling thorough) Push down a dev environment and test it properly

Who can review
---------------

Not @richardtowers