### PR TITLE
Make clear that you can run >2GB apps on PaaS

### DIFF
--- a/src/components/calculator/calculator.njk
+++ b/src/components/calculator/calculator.njk
@@ -98,7 +98,10 @@
                               {text: "256 MB", value: "256"},
                               {text: "1.0 GB", value: "1024"},
                               {text: "1.5 GB", value: "1536"},
-                              {text: "2.0 GB", value: "2048"}
+                              {text: "2.0 GB", value: "2048"},
+                              {text: "4.0 GB", value: "4096"},
+                              {text: "8.0 GB", value: "8192"},
+                              {text: "16.0 GB", value: "16384"}
                             ]
                           }) }}
                         </div>


### PR DESCRIPTION
What
----

Someone on the PaaS team was led astray by the pricing calculator only allowing selecting app memory sizes below 2GB. This commit adds memory options going up to 16GB to make things clearer.

How to review
-------------

* See if the tests pass;
* Code review.

Who can review
---------------

Not @46bit