### PR TITLE
[#166027792] Implement SSO uplift journey for GDS users

### DIFF
--- a/src/components/account/account.test.ts
+++ b/src/components/account/account.test.ts
@@ -1,13 +1,12 @@
 import jwt from 'jsonwebtoken';
 import nock, {RequestBodyMatcher} from 'nock';
-import uaa, {IUaaUser} from '../../lib/uaa';
 
+import pino = require('pino');
 import * as uaaData from '../../lib/uaa/uaa.test.data';
 import {IContext} from '../app';
 import {config} from '../app/app.test.config';
 import {Token} from '../auth';
 import * as account from './account';
-import pino = require('pino');
 
 describe('account test suite', () => {
   let ctx: IContext;
@@ -33,7 +32,8 @@ describe('account test suite', () => {
 
       it('should contain an explanation of the process, and a link to the docs', async () => {
         const response = await account.getUseGoogleSSO(ctx, {});
-        expect(response.body).toContain('https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function');
+        expect(response.body)
+          .toContain('https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function');
         expect(response.body).toContain('id="sso-process-explanation"');
       });
     });
@@ -47,7 +47,7 @@ describe('account test suite', () => {
         const response = await account.getUseGoogleSSO(ctx, {});
         expect(response.body).toContain('id="opt-out-process-explanation"');
       });
-    })
+    });
   });
 
   describe('account.use-google-sso.post', () => {
@@ -56,7 +56,7 @@ describe('account test suite', () => {
     });
 
     it('should set the logged in user\'s origin to google', async () => {
-      let isOriginGoogle: RequestBodyMatcher = (body) => body.origin == 'google';
+      const isOriginGoogle: RequestBodyMatcher = (body) => body.origin === 'google';
       nock(ctx.app.uaaAPI).persist()
         .put(`/Users/${uaaData.userId}`, isOriginGoogle).reply(200, uaaData.userId);
 
@@ -70,7 +70,7 @@ describe('account test suite', () => {
 
       const response = await account.postUseGoogleSSO(ctx, {});
       expect(response.body).toContain('Successful');
-    })
+    });
   });
 
   describe('AccountUser', () => {
@@ -79,97 +79,91 @@ describe('account test suite', () => {
       it('name combines user\'s given and family names', () => {
         // We don't have a full implementation of this type
         // because it's used to represent a JSON payload
-        let uaaUser = {} as IUaaUser;
-        uaaUser.name = {
-          givenName: 'User',
-          familyName: 'Name'
+        const uaaUser: any = {
+          name: {
+            givenName: 'User',
+            familyName: 'Name',
+          },
         };
 
-        let acctUser = new account.AccountUser(uaaUser);
+        const acctUser = new account.AccountUser(uaaUser);
         expect(acctUser.name).toEqual('User Name');
       });
     });
 
     describe('email', () => {
       it('email returns the users username', () => {
-        let uaaUser = {} as IUaaUser;
-        uaaUser.userName = 'foo@bar.org';
+        const uaaUser: any = {userName: 'foo@bar.org'};
 
-        let acctUser = new account.AccountUser(uaaUser);
+        const acctUser = new account.AccountUser(uaaUser);
         expect(acctUser.email).toEqual('foo@bar.org');
       });
     });
 
     describe('isGDSUser', () => {
       it('returns false if the user\'s username isn\'t a GDS one', () => {
-        let uaaUser = {} as IUaaUser;
-        uaaUser.userName = 'foo@bar.org';
+        const uaaUser: any = {userName: 'foo@bar.org'};
 
-        let acctUser = new account.AccountUser(uaaUser);
+        const acctUser = new account.AccountUser(uaaUser);
         expect(acctUser.isGDSUser).toBeFalsy();
       });
 
       it('returns true if the user\'s primary email address is a GDS one', () => {
-        let uaaUser = {} as IUaaUser;
-        uaaUser.userName = 'fake.address+paas-admin@digital.cabinet-office.gov.uk';
+        const uaaUser: any = {userName: 'fake.address+paas-admin@digital.cabinet-office.gov.uk'};
 
-        let acctUser = new account.AccountUser(uaaUser);
+        const acctUser = new account.AccountUser(uaaUser);
         expect(acctUser.isGDSUser).toBeTruthy();
       });
     });
 
     describe('authenticationMethod', () => {
       it('returns u&p if the user\'s origin is uaa', () => {
-        let uaaUser = {} as IUaaUser;
-        uaaUser.origin = 'uaa';
+        const uaaUser: any = {origin: 'uaa'};
 
-        let acctUser = new account.AccountUser(uaaUser);
+        const acctUser = new account.AccountUser(uaaUser);
         expect(acctUser.authenticationMethod).toEqual('Username & password');
       });
 
-      it('returns google if the user\'s origin is uaa', () => {
-        let uaaUser = {} as IUaaUser;
-        uaaUser.origin = 'google';
+      it('returns google if the user\'s origin is google', () => {
+        const uaaUser: any = {origin: 'google'};
 
-        let acctUser = new account.AccountUser(uaaUser);
+        const acctUser = new account.AccountUser(uaaUser);
         expect(acctUser.authenticationMethod).toEqual('Google');
       });
 
       it('returns unknown if the user\'s origin is not uaa or google', () => {
-        let uaaUser = {} as IUaaUser;
-        uaaUser.origin = 'other';
+        const uaaUser: any = {origin: 'other'};
 
-        let acctUser = new account.AccountUser(uaaUser);
+        const acctUser = new account.AccountUser(uaaUser);
         expect(acctUser.authenticationMethod).toEqual('Unknown');
       });
     });
 
     describe('origin', () => {
       it('returns the origin of the underlying user', () => {
-        let uaaUser = {} as IUaaUser;
-        uaaUser.origin = 'foo';
+        const uaaUser: any = {origin: 'foo'};
 
-        let acctUser = new account.AccountUser(uaaUser);
+        const acctUser = new account.AccountUser(uaaUser);
         expect(acctUser.origin).toEqual('foo');
-      })
-    })
+      });
+    });
   });
 });
 
 function setUpUAA(userData: string): IContext {
-  let token = jwt.sign({
+  const token = jwt.sign({
     user_id: uaaData.userId,
     scope: [],
-    exp: 2535018460
+    exp: 2535018460,
   }, 'secret');
 
-  let ctx = {
+  const ctx = {
     app: config,
     routePartOf: () => false,
     linkTo: (routeName: string) => routeName,
     log: pino({level: 'silent'}),
     token: new Token(token, ['secret']),
-    csrf: ' '
+    csrf: ' ',
   };
 
   nock.cleanAll();

--- a/src/components/account/account.test.ts
+++ b/src/components/account/account.test.ts
@@ -1,0 +1,181 @@
+import jwt from 'jsonwebtoken';
+import nock, {RequestBodyMatcher} from 'nock';
+import uaa, {IUaaUser} from '../../lib/uaa';
+
+import * as uaaData from '../../lib/uaa/uaa.test.data';
+import {IContext} from '../app';
+import {config} from '../app/app.test.config';
+import {Token} from '../auth';
+import * as account from './account';
+import pino = require('pino');
+
+describe('account test suite', () => {
+  let ctx: IContext;
+
+  describe('account.use-google-sso.view', () => {
+
+    describe('non-GDS users', () => {
+      beforeEach(() => {
+        ctx = setUpUAA(uaaData.user);
+      });
+
+      it('should redirect back to home', async () => {
+        const response = await account.getUseGoogleSSO(ctx, {});
+        expect(response.redirect).toEqual('admin.home');
+        expect(response.body).toBeFalsy();
+      });
+    });
+
+    describe('GDS users', () => {
+      beforeEach(() => {
+        ctx = setUpUAA(uaaData.gdsUser);
+      });
+
+      it('should contain an explanation of the process, and a link to the docs', async () => {
+        const response = await account.getUseGoogleSSO(ctx, {});
+        expect(response.body).toContain('https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function');
+        expect(response.body).toContain('id="sso-process-explanation"');
+      });
+    });
+
+    describe('SSO users', () => {
+      beforeEach(() => {
+        ctx = setUpUAA(uaaData.ssoUser);
+      });
+
+      it('should contain an explanation of the process for opting out', async () => {
+        const response = await account.getUseGoogleSSO(ctx, {});
+        expect(response.body).toContain('id="opt-out-process-explanation"');
+      });
+    })
+  });
+
+  describe('account.use-google-sso.post', () => {
+    beforeEach(() => {
+      ctx = setUpUAA(uaaData.user);
+    });
+
+    it('should set the logged in user\'s origin to google', async () => {
+      let isOriginGoogle: RequestBodyMatcher = (body) => body.origin == 'google';
+      nock(ctx.app.uaaAPI).persist()
+        .put(`/Users/${uaaData.userId}`, isOriginGoogle).reply(200, uaaData.userId);
+
+      await account.postUseGoogleSSO(ctx, {});
+      expect(nock.isDone()).toBeTruthy();
+    });
+
+    it('should render a success page', async () => {
+      nock(ctx.app.uaaAPI).persist()
+        .put(`/Users/${uaaData.userId}`).reply(200, uaaData.userId);
+
+      const response = await account.postUseGoogleSSO(ctx, {});
+      expect(response.body).toContain('Successful');
+    })
+  });
+
+  describe('AccountUser', () => {
+
+    describe('name', () => {
+      it('name combines user\'s given and family names', () => {
+        // We don't have a full implementation of this type
+        // because it's used to represent a JSON payload
+        let uaaUser = {} as IUaaUser;
+        uaaUser.name = {
+          givenName: 'User',
+          familyName: 'Name'
+        };
+
+        let acctUser = new account.AccountUser(uaaUser);
+        expect(acctUser.name).toEqual('User Name');
+      });
+    });
+
+    describe('email', () => {
+      it('email returns the users username', () => {
+        let uaaUser = {} as IUaaUser;
+        uaaUser.userName = 'foo@bar.org';
+
+        let acctUser = new account.AccountUser(uaaUser);
+        expect(acctUser.email).toEqual('foo@bar.org');
+      });
+    });
+
+    describe('isGDSUser', () => {
+      it('returns false if the user\'s username isn\'t a GDS one', () => {
+        let uaaUser = {} as IUaaUser;
+        uaaUser.userName = 'foo@bar.org';
+
+        let acctUser = new account.AccountUser(uaaUser);
+        expect(acctUser.isGDSUser).toBeFalsy();
+      });
+
+      it('returns true if the user\'s primary email address is a GDS one', () => {
+        let uaaUser = {} as IUaaUser;
+        uaaUser.userName = 'fake.address+paas-admin@digital.cabinet-office.gov.uk';
+
+        let acctUser = new account.AccountUser(uaaUser);
+        expect(acctUser.isGDSUser).toBeTruthy();
+      });
+    });
+
+    describe('authenticationMethod', () => {
+      it('returns u&p if the user\'s origin is uaa', () => {
+        let uaaUser = {} as IUaaUser;
+        uaaUser.origin = 'uaa';
+
+        let acctUser = new account.AccountUser(uaaUser);
+        expect(acctUser.authenticationMethod).toEqual('Username & password');
+      });
+
+      it('returns google if the user\'s origin is uaa', () => {
+        let uaaUser = {} as IUaaUser;
+        uaaUser.origin = 'google';
+
+        let acctUser = new account.AccountUser(uaaUser);
+        expect(acctUser.authenticationMethod).toEqual('Google');
+      });
+
+      it('returns unknown if the user\'s origin is not uaa or google', () => {
+        let uaaUser = {} as IUaaUser;
+        uaaUser.origin = 'other';
+
+        let acctUser = new account.AccountUser(uaaUser);
+        expect(acctUser.authenticationMethod).toEqual('Unknown');
+      });
+    });
+
+    describe('origin', () => {
+      it('returns the origin of the underlying user', () => {
+        let uaaUser = {} as IUaaUser;
+        uaaUser.origin = 'foo';
+
+        let acctUser = new account.AccountUser(uaaUser);
+        expect(acctUser.origin).toEqual('foo');
+      })
+    })
+  });
+});
+
+function setUpUAA(userData: string): IContext {
+  let token = jwt.sign({
+    user_id: uaaData.userId,
+    scope: [],
+    exp: 2535018460
+  }, 'secret');
+
+  let ctx = {
+    app: config,
+    routePartOf: () => false,
+    linkTo: (routeName: string) => routeName,
+    log: pino({level: 'silent'}),
+    token: new Token(token, ['secret']),
+    csrf: ' '
+  };
+
+  nock.cleanAll();
+  nock(ctx.app.uaaAPI)
+    .get(`/Users/${uaaData.userId}`).reply(200, userData)
+    .post('/oauth/token?grant_type=client_credentials').reply(200, `{"access_token": "FAKE_ACCESS_TOKEN"}`);
+
+  return ctx;
+}

--- a/src/components/account/account.ts
+++ b/src/components/account/account.ts
@@ -1,8 +1,8 @@
 import {IParameters, IResponse} from '../../lib/router';
 import UAAClient, {IUaaUser} from '../../lib/uaa';
 import {IContext} from '../app';
-import useGoogleSSOTemplate from './use-google-sso.njk';
 import successfulUpliftTemplate from './successful-uplift.njk';
+import useGoogleSSOTemplate from './use-google-sso.njk';
 
 export class AccountUser {
   constructor(private user: IUaaUser) {
@@ -41,7 +41,7 @@ export async function getUseGoogleSSO(ctx: IContext, _params: IParameters): Prom
 
   if (!user.isGDSUser) {
     return {
-      redirect: ctx.linkTo("admin.home")
+      redirect: ctx.linkTo('admin.home'),
     };
   }
 
@@ -51,8 +51,8 @@ export async function getUseGoogleSSO(ctx: IContext, _params: IParameters): Prom
       linkTo: ctx.linkTo,
       csrf: ctx.csrf,
       location: ctx.app.location,
-      user: user,
-    })
+      user,
+    }),
   };
 }
 
@@ -71,8 +71,8 @@ export async function postUseGoogleSSO(ctx: IContext, _params: IParameters): Pro
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
       csrf: ctx.csrf,
-      location: ctx.app.location
-    })
+      location: ctx.app.location,
+    }),
   };
 }
 

--- a/src/components/account/account.ts
+++ b/src/components/account/account.ts
@@ -1,0 +1,89 @@
+import {IParameters, IResponse} from '../../lib/router';
+import UAAClient, {IUaaUser} from '../../lib/uaa';
+import {IContext} from '../app';
+import useGoogleSSOTemplate from './use-google-sso.njk';
+import successfulUpliftTemplate from './successful-uplift.njk';
+
+export class AccountUser {
+  constructor(private user: IUaaUser) {
+  }
+
+  get name(): string {
+    return `${this.user.name.givenName} ${this.user.name.familyName}`;
+  }
+
+  get email(): string {
+    return this.user.userName;
+  }
+
+  get authenticationMethod(): string {
+    switch (this.user.origin) {
+      case 'uaa':
+        return 'Username & password';
+      case 'google':
+        return 'Google';
+      default:
+        return 'Unknown';
+    }
+  }
+
+  get isGDSUser(): boolean {
+    return this.email.endsWith('@digital.cabinet-office.gov.uk');
+  }
+
+  get origin(): string {
+    return this.user.origin;
+  }
+}
+
+export async function getUseGoogleSSO(ctx: IContext, _params: IParameters): Promise<IResponse> {
+  const user = await fetchLoggedInUser(ctx);
+
+  if (!user.isGDSUser) {
+    return {
+      redirect: ctx.linkTo("admin.home")
+    };
+  }
+
+  return {
+    body: useGoogleSSOTemplate.render({
+      routePartOf: ctx.routePartOf,
+      linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
+      location: ctx.app.location,
+      user: user,
+    })
+  };
+}
+
+export async function postUseGoogleSSO(ctx: IContext, _params: IParameters): Promise<IResponse> {
+  const uaa = new UAAClient({
+    apiEndpoint: ctx.app.uaaAPI,
+    clientCredentials: {
+      clientID: ctx.app.oauthClientID,
+      clientSecret: ctx.app.oauthClientSecret,
+    },
+  });
+  await uaa.setUserOrigin(ctx.token.userID, 'google');
+
+  return {
+    body: successfulUpliftTemplate.render({
+      routePartOf: ctx.routePartOf,
+      linkTo: ctx.linkTo,
+      csrf: ctx.csrf,
+      location: ctx.app.location
+    })
+  };
+}
+
+export async function fetchLoggedInUser(ctx: IContext): Promise<AccountUser> {
+  const uaa = new UAAClient({
+    apiEndpoint: ctx.app.uaaAPI,
+    clientCredentials: {
+      clientID: ctx.app.oauthClientID,
+      clientSecret: ctx.app.oauthClientSecret,
+    },
+  });
+
+  return new AccountUser(await uaa.getUser(ctx.token.userID));
+}

--- a/src/components/account/index.ts
+++ b/src/components/account/index.ts
@@ -1,0 +1,1 @@
+export * from './account';

--- a/src/components/account/successful-uplift.njk
+++ b/src/components/account/successful-uplift.njk
@@ -1,0 +1,25 @@
+{% extends "../../layouts/govuk.njk" %}
+{% from "govuk-frontend/components/panel/macro.njk" import govukPanel %}
+
+{% block pageTitle %}
+  Success - You can now log in with Google SSO
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <section>
+        {{ govukPanel({
+          titleText: "SSO Activation Successful"
+        }) }}
+        <p>
+          You can now log in using Google SSO. You have not been logged out now.
+        </p>
+        <a href="{{ linkTo("admin.home") }}">Back to account</a>
+      </section>
+    </div>
+  </div>
+
+{% endblock %}

--- a/src/components/account/use-google-sso.njk
+++ b/src/components/account/use-google-sso.njk
@@ -1,0 +1,58 @@
+{% extends "../../layouts/govuk.njk" %}
+{% from "govuk-frontend/components/button/macro.njk" import govukButton %}
+
+{% block pageTitle %}
+  Use Google SSO
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+  <a href="{{ linkTo("admin.home") }}" class="govuk-back-link">Back</a>
+  <div class="govuk-grid-row">
+    {% if user.origin == "uaa" %}
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">
+          Using Google single sign-on (SSO)
+        </h1>
+        <section id="sso-process-explanation">
+          <p>
+            Activating Google single sign-on for your GOV.UK PaaS account means you can no longer
+            sign in using your existing username and password. Instead, you will sign in using
+            using the single sign-on option on the log in screen.
+          </p>
+          <p>
+            You will also need to
+            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
+              use single sign-on on at the command line
+            </a>.
+          </p>
+        </section>
+
+        <form method="post" action="{{ linkTo("account.use-google-sso.post") }}" class="govuk-form">
+          <input type="hidden" name="_csrf" value="{{ csrf }}" />
+          {{ govukButton({
+            text: "Activate Google single sign-on"
+          }) }}
+        </form>
+      </div>
+    {% else %}
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Using Google single sign-on (SSO)</h1>
+        <section id="opt-out-process-explanation">
+          <p>
+            You are currently set-up to use Google single sign-on.
+            You will also need to
+            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
+              use single sign-on on at the command line
+            </a>.
+          </p>
+          <p>
+            If you would like cancel Google single sign-on, send an email to
+            <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">support</a>.
+          </p>
+        </section>
+      </div>
+    {% endif %}
+  </div>
+
+{% endblock %}

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -5,6 +5,7 @@ import request from 'supertest';
 
 import { info, organizations } from '../../lib/cf/cf.test.data';
 import Router, { IParameters } from '../../lib/router';
+import * as uaaData from '../../lib/uaa/uaa.test.data';
 
 import init from './app';
 import { config } from './app.test.config';
@@ -16,6 +17,7 @@ const tokenKey = 'tokensecret';
 nock(config.uaaAPI).persist()
   .post('/oauth/token?grant_type=client_credentials').reply(200, `{"access_token": "TOKEN_FROM_ENDPOINT"}`)
   .get('/token_keys').reply(200, {keys: [{value: tokenKey}]})
+  .get(`/Users/uaa-user-123`).reply(200, uaaData.gdsUser)
 ;
 
 nock(config.accountsAPI).persist()

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -1,5 +1,6 @@
 import Router, { IParameters } from '../../lib/router';
 
+import * as account from '../account';
 import * as applications from '../applications';
 import * as organizations from '../organizations';
 import * as reports from '../reports';
@@ -111,6 +112,17 @@ const router = new Router([
     name: 'admin.reports.view',
     path: '/reports/cost/:rangeStart',
   },
+  {
+    action: account.getUseGoogleSSO,
+    name: 'account.use-google-sso.view',
+    path: '/my-account/use-google-sso'
+  },
+  {
+    action: account.postUseGoogleSSO,
+    name: 'account.use-google-sso.post',
+    method: 'post',
+    path: '/my-account/use-google-sso',
+  }
 ]);
 
 export default router;

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -115,14 +115,14 @@ const router = new Router([
   {
     action: account.getUseGoogleSSO,
     name: 'account.use-google-sso.view',
-    path: '/my-account/use-google-sso'
+    path: '/my-account/use-google-sso',
   },
   {
     action: account.postUseGoogleSSO,
     name: 'account.use-google-sso.post',
     method: 'post',
     path: '/my-account/use-google-sso',
-  }
+  },
 ]);
 
 export default router;

--- a/src/components/organizations/organizations.njk
+++ b/src/components/organizations/organizations.njk
@@ -80,6 +80,13 @@
         <h3><a href="https://status.cloud.service.gov.uk/" class="govuk-link">Get GOV.UK PaaS status updates</a></h3>
         <p>Check the status of GOV.UK PaaS, and see the availability of live applications and database connectivity. We recommend you sign up to this service to get alerts and incident updates.</p>
       </div>
+
+      {% if user.isGDSUser %}
+      <div class="govuk-grid-column-one-third">
+        <h3><a href="{{ linkTo("account.use-google-sso.view") }}" class="govuk-link">Set up Google single sign-on</a></h3>
+        <p>GOV.UK PaaS supports Google single sign-on as an authentication method</p>
+      </div>
+      {% endif %}
     </div>
   </div>
 

--- a/src/components/organizations/organizations.test.ts
+++ b/src/components/organizations/organizations.test.ts
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 import nock from 'nock';
 import pino from 'pino';
+import * as uaaData from '../../lib/uaa/uaa.test.data';
 
 import { config } from '../app/app.test.config';
 import { IContext } from '../app/context';
@@ -60,6 +61,10 @@ const ctx: IContext = {
   token: new Token(token, [tokenKey]),
   csrf: '',
 };
+
+nock(ctx.app.uaaAPI).persist()
+  .get(`/Users/uaa-user-123`).reply(200, uaaData.gdsUser)
+  .post('/oauth/token?grant_type=client_credentials').reply(200, `{"access_token": "FAKE_ACCESS_TOKEN"}`);
 
 describe('organizations test suite', () => {
   it('should show the organisation pages', async () => {

--- a/src/components/organizations/organizations.ts
+++ b/src/components/organizations/organizations.ts
@@ -1,8 +1,8 @@
 import CloudFoundryClient from '../../lib/cf';
 import { IOrganization } from '../../lib/cf/types';
 import { IParameters, IResponse } from '../../lib/router';
-import { IContext } from '../app/context';
 import * as account from '../account';
+import { IContext } from '../app/context';
 
 import organizationsTemplate from './organizations.njk';
 
@@ -31,7 +31,7 @@ export async function listOrganizations(ctx: IContext, _params: IParameters): Pr
       csrf: ctx.csrf,
       organizations,
       location: ctx.app.location,
-      user: user
+      user,
     }),
   };
 }

--- a/src/components/organizations/organizations.ts
+++ b/src/components/organizations/organizations.ts
@@ -1,8 +1,8 @@
 import CloudFoundryClient from '../../lib/cf';
 import { IOrganization } from '../../lib/cf/types';
 import { IParameters, IResponse } from '../../lib/router';
-
 import { IContext } from '../app/context';
+import * as account from '../account';
 
 import organizationsTemplate from './organizations.njk';
 
@@ -19,7 +19,10 @@ export async function listOrganizations(ctx: IContext, _params: IParameters): Pr
     logger: ctx.app.logger,
   });
 
-  const organizations = await cf.organizations().then(sortOrganizationsByName);
+  const [organizations, user] = await Promise.all([
+    cf.organizations().then(sortOrganizationsByName),
+    account.fetchLoggedInUser(ctx),
+  ]);
 
   return {
     body: organizationsTemplate.render({
@@ -28,6 +31,7 @@ export async function listOrganizations(ctx: IContext, _params: IParameters): Pr
       csrf: ctx.csrf,
       organizations,
       location: ctx.app.location,
+      user: user
     }),
   };
 }

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -134,7 +134,6 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
   }));
 
   const currencyRates = await billingClient.getCurrencyRates(filter);
-  // FIXME: Ideally we should support multiple USD currency rates, or not show this information
   const usdCurrencyRate = currencyRates.filter(currencyRate => currencyRate.code === 'USD')[0];
 
   /* istanbul ignore next */

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -175,25 +175,6 @@ describe('users test suite', () => {
     expect(response.status).toEqual(400);
   });
 
-  // TODO: implement this when refactoring tests
-  // tslint:disable:max-line-length
-  // it('should show error message when email is invalid acording to invite_users', async () => {
-  //   nock('https://example.com/uaa')
-  //     .post('/invite_users?redirect_uri=https://www.cloud.service.gov.uk/next-steps?success&client_id=user_invitation').reply(200, `{new_invites: []}`)
-  //     .get('/Users?filter=email+eq+%22bang@thingcom%22').reply(200, uaaData.noFoundUsersByEmail)
-  //   ;
-  //   const response = await request(app)
-  //     .post('/3deb9f04-b449-4f94-b3dd-c73cefe5b275/invite')
-  //     .type('form')
-  //     .send({
-  //       email: 'bang@thingcom',
-  //       'org_roles[3deb9f04-b449-4f94-b3dd-c73cefe5b275][billing_managers]': '1'
-  //     });
-  //   t.equal(response.status, 400);
-  //   expect(response.text).toContain('a valid email address is required');
-  // });
-  // tslint:enable:max-line-length
-
   it('should show error message when invitee is already a member of org', async () => {
     const response = await users.inviteUser(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
@@ -373,7 +354,7 @@ describe('users test suite', () => {
     expect(response.body).toContain('Confirm user deletion');
   });
 
-  it('should update the user, set BillingManager role and show success - User Edit', async () => { // TODO: fix label
+  it('should update the user, set BillingManager role and show success - User Edit', async () => {
     const response = await users.deleteUser(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
       userGUID: '5ff19d4c-8fa0-4d74-94e0-52eac86d55a8',

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -361,7 +361,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
       );
 
       /* istanbul ignore next */
-      if (!invitation) { // TODO: test me
+      if (!invitation) {
         throw new ValidationError([{field: 'email', message: 'a valid email address is required'}]);
       }
 
@@ -504,7 +504,7 @@ export async function resendInvitation(ctx: IContext, params: IParameters, _: ob
   );
 
   /* istanbul ignore next */
-  if (!invitation) { // TODO: test me
+  if (!invitation) {
     throw new ValidationError([{field: 'email', message: 'a valid email address is required'}]);
   }
 

--- a/src/lib/billing/billing.test.ts
+++ b/src/lib/billing/billing.test.ts
@@ -92,7 +92,6 @@ describe('lib/billing test suite', () => {
 
     // tslint:disable:max-line-length
     nock(config.billingAPI)
-      // FIXME: We could totally use the fake events to generate the URL... QS however didn't work as expected :(
       .get(`/forecast_events?range_start=2018-01-01&range_stop=2018-01-02&org_guid=3deb9f04-b449-4f94-b3dd-c73cefe5b275&events=%5B%7B%22event_guid%22%3A%2200000000-0000-0000-0000-000000000001%22%2C%22event_start%22%3A%222018-01-01%22%2C%22event_stop%22%3A%222018-01-02%22%2C%22resource_guid%22%3A%2200000000-0000-0000-0001-000000000001%22%2C%22resource_name%22%3A%22fake-app-1%22%2C%22resource_type%22%3A%22app%22%2C%22org_guid%22%3A%223deb9f04-b449-4f94-b3dd-c73cefe5b275%22%2C%22space_guid%22%3A%2200000001-0001-0000-0000-000000000000%22%2C%22space_name%22%3A%22spaceName%22%2C%22plan_guid%22%3A%22f4d4b95a-f55e-4593-8d54-3364c25798c4%22%2C%22number_of_nodes%22%3A2%2C%22memory_in_mb%22%3A2048%2C%22storage_in_mb%22%3A1024%7D%5D`)
       .reply(200, `[
         {

--- a/src/lib/billing/billing.ts
+++ b/src/lib/billing/billing.ts
@@ -194,7 +194,7 @@ function parseBillableEvent(ev: IBillableEventResponse): IBillableEvent {
 }
 
 function parsePricingPlan(plan: IPricingPlanResponse): IPricingPlan {
-  // FIXME: extracting the serviceName from the planName is not a reliable
+  // NOTE: extracting the serviceName from the planName is not a reliable
   // method, and we do not want to have to give paas-admin scopes to look up
   // this information if cf. A better solution is to get paas-billing should
   // provide this information

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -6,8 +6,6 @@ import * as cf from './types';
 
 import {intercept} from '../axios-logger/axios';
 
-// FIXME: We're hitting issues with long running requests to CF API. We're setting a hard limit here,
-// but intend to roll it back to more acceptable/desired behavior in the future.
 const DEFAULT_TIMEOUT = 30000;
 
 interface IClientCredentials {

--- a/src/lib/uaa/index.ts
+++ b/src/lib/uaa/index.ts
@@ -1,1 +1,2 @@
 export { default, authenticate, authenticateUser, IUaaInvitation } from './uaa';
+export * from './uaa.types';

--- a/src/lib/uaa/uaa.test.data.ts
+++ b/src/lib/uaa/uaa.test.data.ts
@@ -1,3 +1,5 @@
+export const userId = "47ea627c-45b4-4b2b-ab76-3683068fdc89";
+
 export const usersByEmail = `{
   "resources" : [ {
     "emails" : [ {
@@ -29,7 +31,7 @@ export const user = `{
   },
   "emails" : [ {
     "value" : "zGLifk@test.org",
-    "primary" : false
+    "primary" : true
   } ],
   "groups" : [ {
     "value" : "6e4ee08e-1318-44cf-b4cb-9c88a983aefc",
@@ -109,6 +111,210 @@ export const user = `{
   "active" : true,
   "verified" : true,
   "origin" : "uaa",
+  "zoneId" : "uaa",
+  "passwordLastModified" : "2018-05-22T23:45:25.000Z",
+  "previousLogonTime" : 1527032725655,
+  "lastLogonTime" : 1527032725657,
+  "schemas" : [ "urn:scim:schemas:core:1.0" ]
+}`;
+
+export const gdsUser = `{
+  "id" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+  "externalId" : "test-user",
+  "meta" : {
+    "version" : 0,
+    "created" : "2018-05-22T23:45:25.621Z",
+    "lastModified" : "2018-05-22T23:45:25.621Z"
+  },
+  "userName" : "gds+fake_user@digital.cabinet-office.gov.uk",
+  "name" : {
+    "familyName" : "User",
+    "givenName" : "GDS"
+  },
+  "emails" : [ {
+    "value" : "gds+fake_user@digital.cabinet-office.gov.uk",
+    "primary" : true
+  } ],
+  "groups" : [ {
+    "value" : "6e4ee08e-1318-44cf-b4cb-9c88a983aefc",
+    "display" : "profile",
+    "type" : "DIRECT"
+  }, {
+    "value" : "589f428b-7375-4be7-b805-8ecfa2911692",
+    "display" : "user_attributes",
+    "type" : "DIRECT"
+  }, {
+    "value" : "a8478fb8-46e6-473a-b788-53223f77fcd8",
+    "display" : "password.write",
+    "type" : "DIRECT"
+  }, {
+    "value" : "01d6be0c-2bbd-46a2-b46d-cef08fdc4ca8",
+    "display" : "scim.me",
+    "type" : "DIRECT"
+  }, {
+    "value" : "d49949c7-be6e-4008-be38-b6ec76d82ce8",
+    "display" : "openid",
+    "type" : "DIRECT"
+  }, {
+    "value" : "0d89798f-7327-4e9b-ace1-95751def91d6",
+    "display" : "scim.userids",
+    "type" : "DIRECT"
+  }, {
+    "value" : "8737f07c-3365-44dd-8d1c-8efd535a4b79",
+    "display" : "cloud_controller.read",
+    "type" : "DIRECT"
+  }, {
+    "value" : "93c713d2-6f88-4faf-9ab4-c2e992bbae31",
+    "display" : "cloud_controller.write",
+    "type" : "DIRECT"
+  }, {
+    "value" : "07723467-2fbd-4d76-8bf1-3e14449a2f45",
+    "display" : "approvals.me",
+    "type" : "DIRECT"
+  }, {
+    "value" : "6253cc94-fec4-4951-8467-00c8fb26abcc",
+    "display" : "cloud_controller_service_permissions.read",
+    "type" : "DIRECT"
+  }, {
+    "value" : "3bc97cf0-125a-41b1-8ff5-35b221fa4732",
+    "display" : "oauth.approvals",
+    "type" : "DIRECT"
+  }, {
+    "value" : "f96bdc88-b553-419b-9801-41427b4ec489",
+    "display" : "uaa.offline_token",
+    "type" : "DIRECT"
+  }, {
+    "value" : "44daaaa0-0df4-4d87-b230-cda36f148490",
+    "display" : "uaa.user",
+    "type" : "DIRECT"
+  }, {
+    "value" : "fc742b38-3446-4a9f-8267-1293f8d06261",
+    "display" : "roles",
+    "type" : "DIRECT"
+  } ],
+  "approvals" : [ {
+    "userId" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+    "clientId" : "client id",
+    "scope" : "scim.read",
+    "status" : "APPROVED",
+    "lastUpdatedAt" : "2018-05-22T23:45:25.643Z",
+    "expiresAt" : "2018-05-22T23:45:35.643Z"
+  }, {
+    "userId" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+    "clientId" : "identity",
+    "scope" : "uaa.user",
+    "status" : "APPROVED",
+    "lastUpdatedAt" : "2018-05-22T23:45:55.650Z",
+    "expiresAt" : "2018-05-22T23:45:55.650Z"
+  } ],
+  "phoneNumbers" : [ {
+    "value" : "5555555555"
+  } ],
+  "active" : true,
+  "verified" : true,
+  "origin" : "uaa",
+  "zoneId" : "uaa",
+  "passwordLastModified" : "2018-05-22T23:45:25.000Z",
+  "previousLogonTime" : 1527032725655,
+  "lastLogonTime" : 1527032725657,
+  "schemas" : [ "urn:scim:schemas:core:1.0" ]
+}`;
+
+export const ssoUser = `{
+  "id" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+  "externalId" : "test-user",
+  "meta" : {
+    "version" : 0,
+    "created" : "2018-05-22T23:45:25.621Z",
+    "lastModified" : "2018-05-22T23:45:25.621Z"
+  },
+  "userName" : "gds+fake_user@digital.cabinet-office.gov.uk",
+  "name" : {
+    "familyName" : "User",
+    "givenName" : "GDS"
+  },
+  "emails" : [ {
+    "value" : "gds+fake_user@digital.cabinet-office.gov.uk",
+    "primary" : true
+  } ],
+  "groups" : [ {
+    "value" : "6e4ee08e-1318-44cf-b4cb-9c88a983aefc",
+    "display" : "profile",
+    "type" : "DIRECT"
+  }, {
+    "value" : "589f428b-7375-4be7-b805-8ecfa2911692",
+    "display" : "user_attributes",
+    "type" : "DIRECT"
+  }, {
+    "value" : "a8478fb8-46e6-473a-b788-53223f77fcd8",
+    "display" : "password.write",
+    "type" : "DIRECT"
+  }, {
+    "value" : "01d6be0c-2bbd-46a2-b46d-cef08fdc4ca8",
+    "display" : "scim.me",
+    "type" : "DIRECT"
+  }, {
+    "value" : "d49949c7-be6e-4008-be38-b6ec76d82ce8",
+    "display" : "openid",
+    "type" : "DIRECT"
+  }, {
+    "value" : "0d89798f-7327-4e9b-ace1-95751def91d6",
+    "display" : "scim.userids",
+    "type" : "DIRECT"
+  }, {
+    "value" : "8737f07c-3365-44dd-8d1c-8efd535a4b79",
+    "display" : "cloud_controller.read",
+    "type" : "DIRECT"
+  }, {
+    "value" : "93c713d2-6f88-4faf-9ab4-c2e992bbae31",
+    "display" : "cloud_controller.write",
+    "type" : "DIRECT"
+  }, {
+    "value" : "07723467-2fbd-4d76-8bf1-3e14449a2f45",
+    "display" : "approvals.me",
+    "type" : "DIRECT"
+  }, {
+    "value" : "6253cc94-fec4-4951-8467-00c8fb26abcc",
+    "display" : "cloud_controller_service_permissions.read",
+    "type" : "DIRECT"
+  }, {
+    "value" : "3bc97cf0-125a-41b1-8ff5-35b221fa4732",
+    "display" : "oauth.approvals",
+    "type" : "DIRECT"
+  }, {
+    "value" : "f96bdc88-b553-419b-9801-41427b4ec489",
+    "display" : "uaa.offline_token",
+    "type" : "DIRECT"
+  }, {
+    "value" : "44daaaa0-0df4-4d87-b230-cda36f148490",
+    "display" : "uaa.user",
+    "type" : "DIRECT"
+  }, {
+    "value" : "fc742b38-3446-4a9f-8267-1293f8d06261",
+    "display" : "roles",
+    "type" : "DIRECT"
+  } ],
+  "approvals" : [ {
+    "userId" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+    "clientId" : "client id",
+    "scope" : "scim.read",
+    "status" : "APPROVED",
+    "lastUpdatedAt" : "2018-05-22T23:45:25.643Z",
+    "expiresAt" : "2018-05-22T23:45:35.643Z"
+  }, {
+    "userId" : "47ea627c-45b4-4b2b-ab76-3683068fdc89",
+    "clientId" : "identity",
+    "scope" : "uaa.user",
+    "status" : "APPROVED",
+    "lastUpdatedAt" : "2018-05-22T23:45:55.650Z",
+    "expiresAt" : "2018-05-22T23:45:55.650Z"
+  } ],
+  "phoneNumbers" : [ {
+    "value" : "5555555555"
+  } ],
+  "active" : true,
+  "verified" : true,
+  "origin" : "google",
   "zoneId" : "uaa",
   "passwordLastModified" : "2018-05-22T23:45:25.000Z",
   "previousLogonTime" : 1527032725655,

--- a/src/lib/uaa/uaa.test.data.ts
+++ b/src/lib/uaa/uaa.test.data.ts
@@ -1,4 +1,4 @@
-export const userId = "47ea627c-45b4-4b2b-ab76-3683068fdc89";
+export const userId = '47ea627c-45b4-4b2b-ab76-3683068fdc89';
 
 export const usersByEmail = `{
   "resources" : [ {

--- a/src/lib/uaa/uaa.test.ts
+++ b/src/lib/uaa/uaa.test.ts
@@ -1,6 +1,6 @@
 import nock, {RequestBodyMatcher} from 'nock';
 
-import UAAClient, {authenticateUser, UaaOrigin} from './uaa';
+import UAAClient, {authenticateUser} from './uaa';
 import * as data from './uaa.test.data';
 
 const config = {
@@ -58,7 +58,9 @@ describe('lib/uaa test suite', () => {
 
   it('should invite a user by email', async () => {
     nock('https://example.com/uaa').persist()
-      .post('/invite_users?redirect_uri=https://example.com/&client_id=client-id').times(1).reply(200, data.invite)
+      .post('/invite_users?redirect_uri=https://example.com/&client_id=client-id')
+      .times(1)
+      .reply(200, data.invite);
 
     const client = new UAAClient(config);
     const invitation = await client.inviteUser('user1@71xl2o.com', 'client-id', 'https://example.com/');
@@ -131,14 +133,14 @@ describe('lib/uaa test suite', () => {
   });
 
   it('should set the user\'s origin', async () => {
-    let isCorrectPatchBody: RequestBodyMatcher = (body) => body.origin == "google";
+    const isCorrectPatchBody: RequestBodyMatcher = (body) => body.origin === 'google';
 
     nock(config.apiEndpoint)
       .get(`/Users/${data.userId}`).reply(200, data.user)
       .put(`/Users/${data.userId}`, isCorrectPatchBody).reply(200, data.user);
 
     const client = new UAAClient(config);
-    const updatedUser = await client.setUserOrigin(data.userId, "google");
+    const updatedUser = await client.setUserOrigin(data.userId, 'google');
     expect(updatedUser.id).toEqual(data.userId);
-  })
+  });
 });

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import {IUaaUser} from './uaa.types';
 import * as types from './uaa.types';
 
 const DEFAULT_TIMEOUT = 1000;
@@ -91,9 +90,9 @@ export default class UAAClient {
 
   public async request(method: string, url: string, opts: any = {}) {
     const token = await this.getAccessToken();
-    let requiredHeaders = {Authorization: `Bearer ${token}`};
+    const requiredHeaders = {Authorization: `Bearer ${token}`};
 
-    opts.headers = { ...(opts.headers||{}), ...requiredHeaders };
+    opts.headers = { ...(opts.headers || {}), ...requiredHeaders };
     return request(this.apiEndpoint, method, url, {
       ...opts,
     });
@@ -101,13 +100,13 @@ export default class UAAClient {
 
   public async getUser(userGUID: string): Promise<types.IUaaUser> {
     const response = await this.request('get', `/Users/${userGUID}`);
-    return <types.IUaaUser> response.data;
+    return response.data as types.IUaaUser;
   }
 
   public async findUser(email: string): Promise<types.IUaaUser> {
     const params = {filter: `email eq ${JSON.stringify(email)}`};
     const response = await this.request('get', '/Users', {params});
-    return <types.IUaaUser> response.data.resources[0];
+    return response.data.resources[0] as types.IUaaUser;
   }
 
   public async inviteUser(email: string, clientID: string, redirectURI: string): Promise<IUaaInvitation> {
@@ -146,16 +145,16 @@ export default class UAAClient {
   }
 
   public async setUserOrigin(userId: string, origin: UaaOrigin): Promise<types.IUaaUser> {
-    let user = await this.getUser(userId);
+    const user = await this.getUser(userId);
     user.origin = origin;
     const reqOpts = {
       data: user,
       headers: {
-        "If-Match": "*"
-      }
+        'If-Match': '*',
+      },
     };
     const response = await this.request('put', `/Users/${userId}`, reqOpts);
-    return <IUaaUser>response.data;
+    return response.data as types.IUaaUser;
   }
 }
 
@@ -195,7 +194,7 @@ export async function authenticate(endpoint: string, clientCredentials: IClientC
     params: {
       grant_type: 'client_credentials',
     },
-    // TODO: I think this might be leaking the auth details in the url - consider using header directly?
+
     withCredentials: true,
     auth: {
       username: clientCredentials.clientID,

--- a/src/lib/uaa/uaa.types.ts
+++ b/src/lib/uaa/uaa.types.ts
@@ -14,7 +14,7 @@ export interface IUaaEmail {
 
 export interface IUaaGroup {
   display: string;
-  type: string;
+  'type': string;
   value: string;
 }
 
@@ -43,10 +43,10 @@ export interface IUaaUser {
   meta: IUaaUserMeta;
   userName: string;
   name: IUaaName;
-  emails: IUaaEmail[];
-  groups: IUaaGroup[];
-  approvals: IUaaApproval[];
-  phoneNumbers: IUaaPhoneNumber[];
+  emails: readonly IUaaEmail[];
+  groups: readonly IUaaGroup[];
+  approvals: readonly IUaaApproval[];
+  phoneNumbers: readonly IUaaPhoneNumber[];
   active: boolean;
   verified: boolean;
   origin: string;
@@ -54,5 +54,5 @@ export interface IUaaUser {
   passwordLastModified: string;
   previousLogonTime: number;
   lastLogonTime: number;
-  schemas: string[];
+  schemas: readonly string[];
 }

--- a/src/lib/uaa/uaa.types.ts
+++ b/src/lib/uaa/uaa.types.ts
@@ -1,0 +1,58 @@
+// These interfaces are extracted
+// from the example payloads given
+// by the UAA API documentation
+
+export interface IUaaName {
+  familyName: string;
+  givenName: string;
+}
+
+export interface IUaaEmail {
+  value: string;
+  primary: boolean;
+}
+
+export interface IUaaGroup {
+  display: string;
+  type: string;
+  value: string;
+}
+
+export interface IUaaApproval {
+  clientId: string;
+  lastUpdatedAt: string;
+  scope: string;
+  userId: string;
+  expiresAt: string;
+  status: string;
+}
+
+export interface IUaaPhoneNumber {
+  value: string;
+}
+
+export interface IUaaUserMeta {
+  created: string;
+  lastModified: string;
+  version: number;
+}
+
+export interface IUaaUser {
+  id: string;
+  externalId: string;
+  meta: IUaaUserMeta;
+  userName: string;
+  name: IUaaName;
+  emails: IUaaEmail[];
+  groups: IUaaGroup[];
+  approvals: IUaaApproval[];
+  phoneNumbers: IUaaPhoneNumber[];
+  active: boolean;
+  verified: boolean;
+  origin: string;
+  zoneId: string;
+  passwordLastModified: string;
+  previousLogonTime: number;
+  lastLogonTime: number;
+  schemas: string[];
+}

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -1,14 +1,46 @@
 import express from 'express';
 import jwt from 'jsonwebtoken';
+import {IUaaEmail, IUaaGroup, IUaaName, IUaaPhoneNumber, IUaaUser} from '../src/lib/uaa';
+import * as uaa from '../src/lib/uaa';
 
 const tokenKey = 'tokensecret';
+const userId = '99022be6-feb8-4f78-96f3-7d11f4d476f1';
 function mockUAA(app: express.Application, config: {stubApiPort: string, adminPort: string}) {
   const { adminPort } = config;
   const fakeJwt = jwt.sign({
-    user_id: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
+    user_id: userId,
     scope: [],
     exp: 2535018460,
   }, tokenKey);
+
+  const userPayload: IUaaUser = {
+    meta: {
+      version: 0,
+      created: "2019-01-01T00:00:00",
+      lastModified: "2019-01-02T00:00:00",
+    },
+    id: userId,
+    externalId: 'stub-user',
+    userName: 'stub-user@digital.cabinet-office.gov.uk',
+    origin: 'uaa',
+    active: true,
+    verified: true,
+    zoneId: 'uaa',
+    name: {
+      familyName: 'User',
+      givenName: 'Stub',
+    },
+    emails: [
+      { value: 'stub-user@digital.cabinet-office.gov.uk', primary: true },
+    ],
+    schemas: [ 'urn:scim:schemas:core:1.0' ],
+    groups: [],
+    phoneNumbers: [],
+    approvals: [],
+    passwordLastModified: '2019-01-01T00:00:00',
+    previousLogonTime: 1546300800,
+    lastLogonTime: 1546300800,
+  };
 
   app.post(
     '/oauth/token',
@@ -28,6 +60,18 @@ function mockUAA(app: express.Application, config: {stubApiPort: string, adminPo
     (_req, res) => res.send(JSON.stringify({keys: [{value: tokenKey}]}))
   );
 
+  app.get(
+    `/Users/${userId}`,
+    (_req, res) => {
+      res.send(JSON.stringify(userPayload));
+    });
+
+  app.put(
+    `/Users/${userId}`,
+    (_req, res) => {
+      res.send(JSON.stringify(userPayload));
+    }
+  )
 }
 
 export default mockUAA;

--- a/tslint.json
+++ b/tslint.json
@@ -87,7 +87,7 @@
     "no-document-write": true,
     "no-eval": true,
     "no-exec-script": true,
-    "no-function-constructor-with-string-args": true,
+    "function-constructor": true,
     "no-http-string": [
       true,
       "http://www.example.com/?.*",
@@ -96,7 +96,6 @@
     ],
     "no-inner-html": true,
     "no-octal-literal": true,
-    "no-reserved-keywords": true,
     "non-literal-require": true,
     "possible-timing-attack": true,
     "react-anchor-blank-noopener": true,


### PR DESCRIPTION
What
----
Google SSO is currently only available to GDS users. This commit implements a user journey to allow eligible users to enable SSO for their account for themselves, rather than by contacting support.


How to review
-------------
Code review

When your environment is running...
1. Checkout this branch in `paas-admin`
2. `cf t -o admin -s public`
3. `npm run push` to push over the existing app in your space.

When the app is deployed...
1. Create a new user in CF with the uaa origin (default)
2. Sign in to paas-admin as that user
3. Run through the journey.

Who can review
---------------
Not @AP-Hunt 
Journey reviewed by Debs Durojaiye