### PR TITLE
Allow the filtering of cost reports by service

### DIFF
--- a/src/components/reports/cost.ts
+++ b/src/components/reports/cost.ts
@@ -40,6 +40,13 @@ export async function viewCostReport(
   const rangeStart = moment(params.rangeStart, 'YYYY-MM-DD').toDate();
   const rangeStop  = moment(rangeStart).add(1, 'month').toDate();
 
+  let serviceFilter = (_: IBillableEvent) => true;
+  if (params.service) {
+    serviceFilter = (billableEvent: IBillableEvent) => billableEvent.price.details.some(
+      details => details.planName.includes(params.service),
+    );
+  }
+
   const billingClient = new BillingClient({
     apiEndpoint: ctx.app.billingAPI,
     accessToken: ctx.token.accessToken,
@@ -61,7 +68,7 @@ export async function viewCostReport(
 
   const billableEvents = await billingClient.getBillableEvents({
     rangeStart, rangeStop, orgGUIDs,
-  });
+  }).then(events => events.filter(serviceFilter));
 
   const orgBillableEvents = aggregateBillingEvents(billableEvents);
 

--- a/stub-api/stub-billing.ts
+++ b/stub-api/stub-billing.ts
@@ -41,27 +41,27 @@ function mockBilling(app: express.Application, _config: { stubApiPort: string, a
       {
         ...defaultBillingEvent,
         resource_name: 'down',
-        price: {inc_vat: "334.00", ex_vat: "314.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+        price: {inc_vat: "334.00", ex_vat: "314.00", details: [{...defaultPriceDetails, plan_name: "fantastical-plan"}]}
       },
       {
         ...defaultBillingEvent,
         resource_name: 'strange',
-        price: {inc_vat: "10.00", ex_vat: "8.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+        price: {inc_vat: "10.00", ex_vat: "8.00", details: [{...defaultPriceDetails, plan_name: "wizardly-plan"}]}
       },
       {
         ...defaultBillingEvent,
         resource_name: 'charm',
-        price: {inc_vat: "532.00", ex_vat: "512.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+        price: {inc_vat: "532.00", ex_vat: "512.00", details: [{...defaultPriceDetails, plan_name: "witching-plan"}]}
       },
       {
         ...defaultBillingEvent,
         resource_name: 'bottom',
-        price: {inc_vat: "100.00", ex_vat: "80.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+        price: {inc_vat: "100.00", ex_vat: "80.00", details: [{...defaultPriceDetails, plan_name: "sorcerous-plan"}]}
       },
       {
         ...defaultBillingEvent,
         resource_name: 'top',
-        price: {inc_vat: "100.00", ex_vat: "80.00", details: [{...defaultPriceDetails, plan_name: "magical-plan"}]}
+        price: {inc_vat: "100.00", ex_vat: "80.00", details: [{...defaultPriceDetails, plan_name: "supernatural-plan"}]}
       },
     ]));
   });


### PR DESCRIPTION
What
----

This allows you to go to `/reports/cost/2019-03-01?service=blah` and see
only the bills for that particular service.

The particular use case for this is to see how much we've billed for
elasticsearch.

It works in a pretty hacky way, using the query param as a substring to
search through all the plan names.

How to review
-------------

* Code review
* Run with stub api and visit `localhost:3000/reports/cost/2019-03-01?service=wizarding-plan` (or one of the other magical plans) and confirm that the bills change as expected

Who can review
---------------

Not @richardTowers