### PR TITLE
[#166116777] Link region name to the multi-region sign-in page

### DIFF
--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -41,9 +41,17 @@
   }
 }
 
-.paas-govuk-tag {
+a.paas-govuk-tag {
   @extend .govuk-tag;
   float: right;
+
+  &:visited, &:hover, &:link {
+    color: #fff;
+  }
+  
+  &:hover {
+    border-bottom: 3px solid #fff;
+  }
 }
 
 .paas-govuk-tag-london {

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -59,7 +59,7 @@
       <a href="https://www.cloud.service.gov.uk/" class="govuk-header__link govuk-header__link--service-name">
         Platform as a Service
       </a>
-      <span class="paas-govuk-tag paas-govuk-tag-{{location.toLowerCase()}}">{{location}}</span>
+      <a href="https://www.cloud.service.gov.uk/sign-in" title="Switch region" class="paas-govuk-tag paas-govuk-tag-{{location.toLowerCase()}}">{{location}}</a>
 
       <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
       <nav>
@@ -109,7 +109,7 @@
 {% endblock %}
 
 {% block content %}
-  
+
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
What
----

It is helpful that the admin panel says "IRELAND" or "LONDON" in the top-right. But users did not have a readily available way to change environment.

This commit makes the "IRELAND" or "LONDON" text a link leading to the page on our product page which gives users a choice of which environment to sign into [1].

[1] https://www.cloud.service.gov.uk/sign-in

How to review
-------------

Code review.

Who can review
--------------

Not @46bit