### PR TITLE
Fix colour of the ireland tag

### DIFF
--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -52,12 +52,12 @@ a.paas-govuk-tag {
   &:hover {
     border-bottom: 3px solid #fff;
   }
-}
 
-.paas-govuk-tag-london {
-  background-color: #005ea5;
-}
+  &.paas-govuk-tag-london {
+    background-color: #005ea5;
+  }
 
-.paas-govuk-tag-ireland {
-  background-color: #006435;
+  &.paas-govuk-tag-ireland {
+    background-color: #006435;
+  }
 }


### PR DESCRIPTION
What
----

When we made the region tags into links we broke the specificity, so
Ireland is currently showing as blue. It clearly should be green since
Ireland is the Emerald Isle.

How to review
-------------

* Code review

Who can review
---------------

Not rich