### PR TITLE
[#166335176] Use paas-accounts for username data

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "fix:vulnerabilities": "npm audit fix --update-binary",
     "start": "export PORT=${PORT-3000}; export LOG_LEVEL=${LOG_LEVEL-warn}; if [ \"$NODE_ENV\" = 'production' ]; then npm run -s start:production; else npm run -s start:dev; fi",
     "start:dev": "NODE_ENV=development ENABLE_WATCH=true ENABLE_SERVER=true ALLOW_INSECURE_SESSION=true npm run -s build",
-    "start:stub-api": "STUB_API_PORT=${STUB_API_PORT-1337} PORT=${PORT-3000} ts-node stub-api/index.ts",
-    "start:with-stub-api": "STUB_API_PORT=${STUB_API_PORT-1337}; API_URL=http://0:${STUB_API_PORT} BILLING_URL=http://0:${STUB_API_PORT} ACCOUNTS_URL=http://0:${STUB_API_PORT} UAA_URL=http://0:${STUB_API_PORT} OAUTH_CLIENT_ID=my-client-id OAUTH_CLIENT_SECRET=my-secret ACCOUNTS_SECRET=my-accounts-secret NOTIFY_API_KEY=qwerty123456 NOTIFY_WELCOME_TEMPLATE_ID=qwerty123456 AWS_REGION=eu-west-2 npm start",
+    "start:stub-api": "source ./stub-api/stub-apis-env.sh; ts-node stub-api/index.ts",
+    "start:with-stub-api": "source ./stub-api/stub-apis-env.sh; npm start",
     "start:production": "NODE_ENV=production ALLOW_INSECURE_SESSION=true npm run -s build && node dist/main.js",
     "push": "NODE_ENV=production npm run -s build && cf push",
     "clean": "rm -rf dist/* || echo 'already clean'"

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -30,6 +30,13 @@ nock('https://example.com/api').persist()
   .get('/v2/stacks').reply(200, data.spaces)
   .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3').reply(200, data.space)
   .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').reply(200, data.spaceQuota);
+
+nock('https://example.com/accounts').persist()
+  .get('/users/uaa-id-253').reply(200, JSON.stringify({
+    user_uuid: 'uaa-id-253',
+    username: 'uaa-id-253@fake.digital.cabinet-office.gov.uk',
+    user_email: 'uaa-id-253@fake.digital.cabinet-office.gov.uk',
+  }));
 // tslint:enable:max-line-length
 
 const tokenKey = 'secret';

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -198,7 +198,7 @@ async function request(req: AxiosRequestConfig, logger: BaseLogger): Promise<Axi
     ...req,
   };
   const instance = axios.create();
-  intercept(instance, 'billing', logger);
+  intercept(instance, 'accounts', logger);
   const response = await instance.request(reqWithDefaults);
   if (response.status < 200 || response.status >= 300) {
     let msg = `AccountsClient: ${reqWithDefaults.method} ${reqWithDefaults.url} failed with status ${response.status}`;

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -936,7 +936,7 @@ export const users = `{
         "admin": false,
         "active": false,
         "default_space_guid": null,
-        "username": "user@example.com",
+        "username": "user@uaa.example.com",
         "organization_roles": [
           "org_user",
           "org_manager",
@@ -1018,7 +1018,7 @@ export const userRolesForOrg = `{
         "admin": false,
         "active": false,
         "default_space_guid": null,
-        "username": "user@example.com",
+        "username": "user@uaa.example.com",
         "organization_roles": [
           "org_user",
           "org_manager",
@@ -1045,7 +1045,7 @@ export const userRolesForOrg = `{
         "admin": false,
         "active": false,
         "default_space_guid": null,
-        "username": "user@example.com",
+        "username": "user@uaa.example.com",
         "organization_roles": [
           "org_user",
           "org_manager",
@@ -1072,7 +1072,7 @@ export const userRolesForOrg = `{
         "admin": false,
         "active": false,
         "default_space_guid": null,
-        "username": "user@example.com",
+        "username": "user@uaa.example.com",
         "organization_roles": [
           "org_user",
           "org_manager",
@@ -1099,7 +1099,7 @@ export const userRolesForOrg = `{
         "admin": false,
         "active": false,
         "default_space_guid": null,
-        "username": "user@example.com",
+        "username": "user@uaa.example.com",
         "organization_roles": [
           "org_user",
           "org_manager",

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -951,6 +951,33 @@ export const users = `{
         "managed_spaces_url": "/v2/users/uaa-id-253/managed_spaces",
         "audited_spaces_url": "/v2/users/uaa-id-253/audited_spaces"
       }
+    },
+    {
+      "metadata": {
+        "guid": "uaa-id-879",
+        "url": "/v2/users/uaa-id-879",
+        "created_at": "2016-06-08T16:41:35Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "admin": false,
+        "active": false,
+        "default_space_guid": null,
+        "username": "user@uaa.example.com",
+        "organization_roles": [
+          "org_user",
+          "org_manager",
+          "org_auditor",
+          "billing_manager"
+        ],
+        "spaces_url": "/v2/users/uaa-id-879/spaces",
+        "organizations_url": "/v2/users/uaa-id-879/organizations",
+        "managed_organizations_url": "/v2/users/uaa-id-879/managed_organizations",
+        "billing_managed_organizations_url": "/v2/users/uaa-id-879/billing_managed_organizations",
+        "audited_organizations_url": "/v2/users/uaa-id-879/audited_organizations",
+        "managed_spaces_url": "/v2/users/uaa-id-879/managed_spaces",
+        "audited_spaces_url": "/v2/users/uaa-id-879/audited_spaces"
+      }
     }
   ]
 }`;

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -273,7 +273,7 @@ describe('lib/cf test suite', () => {
     const users = await client.usersForOrganization('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
 
     expect(users.length > 0).toBeTruthy();
-    expect(users[0].entity.username).toEqual('user@example.com');
+    expect(users[0].entity.username).toEqual('user@uaa.example.com');
     expect(users[0].entity.organization_roles.length).toEqual(4);
   });
 

--- a/stub-api/index.ts
+++ b/stub-api/index.ts
@@ -44,7 +44,7 @@ const apis: readonly IStubServerConfig[] = [
 ];
 
 for (const api of apis) {
-  let app = express();
+  let app: express.Application = express();
   app.use((req, _res, next) => {
     console.log(`${cyan}stub-${api.name}-api${reset} ${req.method} ${req.path}`);
     next();

--- a/stub-api/stub-accounts.ts
+++ b/stub-api/stub-accounts.ts
@@ -1,9 +1,16 @@
 import express from 'express';
+import {IAccountsUserResponse} from '../src/lib/accounts';
+import * as cfStubData from '../src/lib/cf/cf.test.data';
+import * as uaaStubData from '../src/lib/uaa/uaa.test.data';
+import {IStubServerPorts, StubServerFactory} from './index';
 
-function mockAccounts(app: express.Application, _config: { stubApiPort: string, adminPort: string }) {
+function mockAccounts(app: express.Application, _config: IStubServerPorts): express.Application {
+  // All users have no documents
   app.get('/users/:guid/documents', (_req, res) => {
     res.send(JSON.stringify([]));
   });
-};
+
+  return app;
+}
 
 export default mockAccounts;

--- a/stub-api/stub-accounts.ts
+++ b/stub-api/stub-accounts.ts
@@ -15,7 +15,7 @@ function mockAccounts(app: express.Application, _config: IStubServerPorts): expr
   // in our stub data, in order for everything to
   // fit together.
   const cfUsers = JSON.parse(cfStubData.users);
-  const userIds = cfUsers.resources.map(x => x.metadata.guid);
+  const userIds = cfUsers.resources.map((x: any) => x.metadata.guid);
   userIds.push(uaaStubData.userId);
   for (const id of userIds) {
     app.get(`/users/${id}`, (_req, res) => {

--- a/stub-api/stub-accounts.ts
+++ b/stub-api/stub-accounts.ts
@@ -10,6 +10,25 @@ function mockAccounts(app: express.Application, _config: IStubServerPorts): expr
     res.send(JSON.stringify([]));
   });
 
+  // All users should have a paas-accounts entry.
+  // We need to gather the IDs from different places
+  // in our stub data, in order for everything to
+  // fit together.
+  const cfUsers = JSON.parse(cfStubData.users);
+  const userIds = cfUsers.resources.map(x => x.metadata.guid);
+  userIds.push(uaaStubData.userId);
+  for (const id of userIds) {
+    app.get(`/users/${id}`, (_req, res) => {
+        const userBody: IAccountsUserResponse = {
+          user_uuid: id,
+          username: `${id}@fake.cabinet-office.gov.uk`,
+          user_email: `${id}@fake.cabinet-office.gov.uk`,
+        };
+
+        res.send(JSON.stringify(userBody));
+    });
+  }
+
   return app;
 }
 

--- a/stub-api/stub-apis-env.sh
+++ b/stub-api/stub-apis-env.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+export PORT=${PORT-3000}
+
+export STUB_ACCOUNTS_PORT=${STUB_ACCOUNTS_PORT-1337}
+export STUB_BILLING_PORT=${STUB_BILLING_PORT-1338}
+export STUB_CF_PORT=${STUB_CF_PORT-1339}
+export STUB_UAA_PORT=${STUB_UAA_PORT-1340}
+
+
+export ACCOUNTS_URL=http://0:${STUB_ACCOUNTS_PORT}
+export BILLING_URL=http://0:${STUB_BILLING_PORT}
+export API_URL=http://0:${STUB_CF_PORT}
+export UAA_URL=http://0:${STUB_UAA_PORT}
+export AUTHORIZATION_URL=http://0:${STUB_UAA_PORT}
+
+export OAUTH_CLIENT_ID=my-client-id
+export OAUTH_CLIENT_SECRET=my-secret
+export ACCOUNTS_SECRET=my-accounts-secret
+export NOTIFY_API_KEY=qwerty123456
+export NOTIFY_WELCOME_TEMPLATE_ID=qwerty123456
+export AWS_REGION=eu-west-2

--- a/stub-api/stub-billing.ts
+++ b/stub-api/stub-billing.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import {IStubServerPorts} from './index';
 
 const defaultPriceDetails = {
   name: "default-price-name",
@@ -30,7 +31,7 @@ const defaultBillingEvent = {
   storage_in_mb: 0,
   price: {}
 };
-function mockBilling(app: express.Application, _config: { stubApiPort: string, adminPort: string }) {
+function mockBilling(app: express.Application, _config: IStubServerPorts): express.Application {
   app.get('/billable_events', (_req, res) => {
     res.send(JSON.stringify([
       {
@@ -195,6 +196,8 @@ function mockBilling(app: express.Application, _config: { stubApiPort: string, a
       rate: 0.0,
     }]))
   });
+
+  return app;
 };
 
 export default mockBilling;

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -1,8 +1,9 @@
 import express from 'express';
 import * as testData from '../src/lib/cf/cf.test.data';
+import {IStubServerPorts} from './index';
 
-function mockCF(app: express.Application, config: {stubApiPort: string, adminPort: string}) {
-  const { stubApiPort } = config;
+function mockCF(app: express.Application, config: IStubServerPorts): express.Application {
+  const { apiPort } = config;
 
   const info = JSON.stringify({
     name: "",
@@ -10,8 +11,8 @@ function mockCF(app: express.Application, config: {stubApiPort: string, adminPor
     support: "https://youtu.be/ZZ5LpwO-An4",
     version: 0,
     description: "",
-    authorization_endpoint: `http://0:${stubApiPort}`,
-    token_endpoint: `http://0:${stubApiPort}`,
+    authorization_endpoint: `http://0:${apiPort}`,
+    token_endpoint: `http://0:${apiPort}`,
     min_cli_version: null,
     min_recommended_cli_version: null,
     app_ssh_endpoint: null,
@@ -47,6 +48,8 @@ function mockCF(app: express.Application, config: {stubApiPort: string, adminPor
   app.get('/v2/spaces/:guid/user_roles'              , (_, res) => res.send(testData.userRolesForSpace));
   app.get('/v2/stacks'                               , (_, res) => res.send(testData.stacks));
   app.get('/v2/stacks/:guid'                         , (_, res) => res.send(testData.stack));
+
+  return app;
 };
 
 export default mockCF;

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -1,11 +1,13 @@
 import express from 'express';
 import jwt from 'jsonwebtoken';
-import {IUaaEmail, IUaaGroup, IUaaName, IUaaPhoneNumber, IUaaUser} from '../src/lib/uaa';
-import * as uaa from '../src/lib/uaa';
+import {IUaaUser} from '../src/lib/uaa';
+import {IStubServerPorts} from './index';
+
+;
 
 const tokenKey = 'tokensecret';
 const userId = '99022be6-feb8-4f78-96f3-7d11f4d476f1';
-function mockUAA(app: express.Application, config: {stubApiPort: string, adminPort: string}) {
+function mockUAA(app: express.Application, config: IStubServerPorts): express.Application {
   const { adminPort } = config;
   const fakeJwt = jwt.sign({
     user_id: userId,
@@ -16,8 +18,8 @@ function mockUAA(app: express.Application, config: {stubApiPort: string, adminPo
   const userPayload: IUaaUser = {
     meta: {
       version: 0,
-      created: "2019-01-01T00:00:00",
-      lastModified: "2019-01-02T00:00:00",
+      created: '2019-01-01T00:00:00',
+      lastModified: '2019-01-02T00:00:00',
     },
     id: userId,
     externalId: 'stub-user',
@@ -44,20 +46,21 @@ function mockUAA(app: express.Application, config: {stubApiPort: string, adminPo
 
   app.post(
     '/oauth/token',
-    (_req, res) => res.send(JSON.stringify({access_token: fakeJwt}))
+    (_req, res) => res.send(JSON.stringify({access_token: fakeJwt})),
   );
 
   app.get(
     '/oauth/authorize',
     (_req, res) => {
+      // tslint:disable-next-line:no-http-string
       const location = `http://0:${adminPort}/auth/login/callback?code=some-code`;
       res.redirect(301, location);
-    }
+    },
   );
 
   app.get(
     '/token_keys',
-    (_req, res) => res.send(JSON.stringify({keys: [{value: tokenKey}]}))
+    (_req, res) => res.send(JSON.stringify({keys: [{value: tokenKey}]})),
   );
 
   app.get(
@@ -70,8 +73,10 @@ function mockUAA(app: express.Application, config: {stubApiPort: string, adminPo
     `/Users/${userId}`,
     (_req, res) => {
       res.send(JSON.stringify(userPayload));
-    }
-  )
+    },
+  );
+
+  return app;
 }
 
 export default mockUAA;


### PR DESCRIPTION
What
----
Two major things in this PR

## Thing the first
Expanding which endpoints we cover in our stubbing of the different APIs means we've run in to conflicts, where two distinct APIs have the same path component and different responses. This commit spins up the different stub APIs on different ports so that those conflicts don't happen.

It also extracts setting the required environment variables in to a script, so as not to pollute `package.json`.

## Thing the second
Querying `paas-accounts` for a user's username, and falling back to the username stored in UAA.

Usernames are only shown in 2 places in `paas-admin` right now, and other than that what's introduced here, we only use `paas-accounts` for agreements-related actions. For that reason, I've added the fetching of the username from `paas-accounts` to the 2 places it's needed. 

If we begin doing more with `paas-accounts`, I think we should move it to be part of the library code under `src/lib/`

How to review
-------------
**But wait!** If https://github.com/alphagov/paas-cf/pull/1952 hasn't been merged when you come to review this, you'll need to deploy it first. Or use the stub APIs to test. Probably a good idea to do both.


1. Code review `8852fccb1774a1e60d3a8e1c8483e53d6e620e9f`
2. Code review `51203b803dba1a4a82912ffe276c51653b1cdea1` and `2138fd6493f2fecdb1626a5b3122193b4c129b47`
3. Deploy `paas-admin` from this branch and test it.

Who can review
---------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
