### PR TITLE
Make session available on IContext

### DIFF
--- a/src/components/account/account.test.ts
+++ b/src/components/account/account.test.ts
@@ -1,10 +1,8 @@
 import jwt from 'jsonwebtoken';
 import nock, {RequestBodyMatcher} from 'nock';
-
-import pino = require('pino');
 import * as uaaData from '../../lib/uaa/uaa.test.data';
 import {IContext} from '../app';
-import {config} from '../app/app.test.config';
+import {createTestContext} from '../app/app.test-helpers';
 import {Token} from '../auth';
 import * as account from './account';
 
@@ -157,14 +155,10 @@ function setUpUAA(userData: string): IContext {
     exp: 2535018460,
   }, 'secret');
 
-  const ctx = {
-    app: config,
-    routePartOf: () => false,
+  const ctx = createTestContext({
     linkTo: (routeName: string) => routeName,
-    log: pino({level: 'silent'}),
     token: new Token(token, ['secret']),
-    csrf: ' ',
-  };
+  });
 
   nock.cleanAll();
   nock(ctx.app.uaaAPI)

--- a/src/components/app/app.test-helpers.ts
+++ b/src/components/app/app.test-helpers.ts
@@ -1,0 +1,38 @@
+import jwt from 'jsonwebtoken';
+import pino from 'pino';
+import {Token} from '../auth';
+import {config} from './app.test.config';
+import {IContext} from './context';
+
+class FakeSession implements CookieSessionInterfaces.CookieSessionObject {
+  public isChanged: boolean;
+  public isNew: boolean;
+  public isPopulated: boolean;
+
+  constructor() {
+    this.isChanged = false;
+    this.isNew = true;
+    this.isPopulated = true;
+  }
+
+  readonly [propertyName: string]: any
+}
+
+export function createTestContext(ctx?: {}): IContext {
+  return {
+    app: config,
+    routePartOf: () => false,
+    linkTo: () => '__LINKED_TO__',
+    log: pino({level: 'silent'}),
+    token: new Token(
+      jwt.sign({
+        user_id: 'uaa-user-123',
+        exp: 2535018460,
+        scope: [],
+      }, 'secret'), ['secret'],
+    ),
+    csrf: '',
+    session: new FakeSession(),
+    ...ctx,
+  };
+}

--- a/src/components/app/context.ts
+++ b/src/components/app/context.ts
@@ -16,6 +16,7 @@ export interface IContext {
   readonly log: Logger;
   readonly token: Token;
   readonly csrf: string;
+  readonly session: CookieSessionInterfaces.CookieSessionObject;
 }
 
 export function initContext(req: any, router: Router, route: Route, config: IAppConfig): IContext {
@@ -26,5 +27,6 @@ export function initContext(req: any, router: Router, route: Route, config: IApp
     log: req.log,
     token: req.token,
     csrf: req.csrfToken(),
+    session: req.session,
   };
 }

--- a/src/components/applications/applications.test.ts
+++ b/src/components/applications/applications.test.ts
@@ -1,14 +1,10 @@
-import jwt from 'jsonwebtoken';
 import nock from 'nock';
-import pino from 'pino';
+
+import {viewApplication} from '.';
 
 import * as data from '../../lib/cf/cf.test.data';
-
-import { config } from '../app/app.test.config';
-import { IContext } from '../app/context';
-import { Token } from '../auth';
-
-import { viewApplication } from '.';
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
 
 describe('applications test suite', () => {
   nock('https://example.com/api').persist()
@@ -25,20 +21,7 @@ describe('applications test suite', () => {
     .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728').times(1).reply(200, data.stack)
     .get('/v2/stacks/dd63d39a-85f8-48ef-bb73-89097192cfcb').times(1).reply(200, data.stackCflinuxfs2);
 
-  const tokenKey = 'secret';
-  const token = jwt.sign({
-    user_id: 'uaa-user-123',
-    scope: [],
-    exp: 2535018460,
-  }, tokenKey);
-  const ctx: IContext = {
-    app: config,
-    routePartOf: () => false,
-    linkTo: () => '__LINKED_TO__',
-    log: pino({level: 'silent'}),
-    token: new Token(token, [tokenKey]),
-    csrf: '',
-  };
+  const ctx: IContext = createTestContext();
 
   it('should show the application overview page', async () => {
     const response = await viewApplication(ctx, {

--- a/src/components/calculator/calculator.test.ts
+++ b/src/components/calculator/calculator.test.ts
@@ -1,27 +1,12 @@
-import jwt from 'jsonwebtoken';
 import moment from 'moment';
 import nock from 'nock';
-import pino from 'pino';
+import {createTestContext} from '../app/app.test-helpers';
 
-import { config } from '../app/app.test.config';
-import { IContext } from '../app/context';
-import { Token } from '../auth';
-import { getCalculator } from '../calculator';
+import {config} from '../app/app.test.config';
+import {IContext} from '../app/context';
+import {getCalculator} from '../calculator';
 
-const tokenKey = 'secret';
-const token = jwt.sign({
-  user_id: 'uaa-user-123',
-  scope: [],
-  exp: 2535018460,
-}, tokenKey);
-const ctx: IContext = {
-  app: config,
-  routePartOf: () => false,
-  linkTo: () => '__LINKED_TO__',
-  log: pino({level: 'silent'}),
-  token: new Token(token, [tokenKey]),
-  csrf: '',
-};
+const ctx: IContext = createTestContext();
 
 describe('calculator test suite', () => {
   it('should get calculator', async () => {

--- a/src/components/organizations/organizations.test.ts
+++ b/src/components/organizations/organizations.test.ts
@@ -1,13 +1,9 @@
-import jwt from 'jsonwebtoken';
 import nock from 'nock';
-import pino from 'pino';
+
+import {listOrganizations} from '.';
 import * as uaaData from '../../lib/uaa/uaa.test.data';
-
-import { config } from '../app/app.test.config';
-import { IContext } from '../app/context';
-import { Token } from '../auth';
-
-import { listOrganizations } from '.';
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
 
 const organizationTemplate = (name: string, guid: string) => `{
   "metadata": {
@@ -47,20 +43,7 @@ const organizations = `{
 }`;
 nock('https://example.com/api').get('/v2/organizations').times(2).reply(200, organizations);
 
-const tokenKey = 'secret';
-const token = jwt.sign({
-  user_id: 'uaa-user-123',
-  scope: [],
-  exp: 2535018460,
-}, tokenKey);
-const ctx: IContext = {
-  app: config,
-  routePartOf: () => false,
-  linkTo: () => '__LINKED_TO__',
-  log: pino({level: 'silent'}),
-  token: new Token(token, [tokenKey]),
-  csrf: '',
-};
+const ctx: IContext = createTestContext();
 
 nock(ctx.app.uaaAPI).persist()
   .get(`/Users/uaa-user-123`).reply(200, uaaData.gdsUser)
@@ -86,14 +69,14 @@ describe('organizations test suite', () => {
 });
 
 function extractOrganizations(responseBody: string): ReadonlyArray<string> {
-    const re = /(.-org-name-\d)/g;
-    const matches = [];
-    while (true) {
-      const match = re.exec(responseBody);
-      if (match) {
-        matches.push(match[0]);
-      } else {
-        return matches;
-      }
+  const re = /(.-org-name-\d)/g;
+  const matches = [];
+  while (true) {
+    const match = re.exec(responseBody);
+    if (match) {
+      matches.push(match[0]);
+    } else {
+      return matches;
     }
+  }
 }

--- a/src/components/reports/cost-by-service.test.ts
+++ b/src/components/reports/cost-by-service.test.ts
@@ -1,13 +1,11 @@
-import jwt from 'jsonwebtoken';
 import moment from 'moment';
 import nock from 'nock';
-import pino from 'pino';
+import {createTestContext} from '../app/app.test-helpers';
 
 import * as data from '../../lib/cf/cf.test.data';
 
 import { config } from '../app/app.test.config';
 import { IContext } from '../app/context';
-import { Token } from '../auth';
 import * as reports from '../reports';
 
 describe('html cost report by service test suite', () => {
@@ -18,20 +16,7 @@ describe('html cost report by service test suite', () => {
     .times(5)
     .reply(200, data.organizations);
 
-  const tokenKey = 'secret';
-  const token = jwt.sign({
-    user_id: 'uaa-user-123',
-    scope: [],
-    exp: 2535018460,
-  }, tokenKey);
-  const ctx: IContext = {
-    app: config,
-    routePartOf: () => false,
-    linkTo: () => '__LINKED_TO__',
-    log: pino({level: 'silent'}),
-    token: new Token(token, [tokenKey]),
-    csrf: '',
-  };
+  const ctx: IContext = createTestContext();
 
   it('should show empty report for zero billables', async () => {
     const rangeStart = moment().startOf('month').format('YYYY-MM-DD');

--- a/src/components/reports/cost.test.ts
+++ b/src/components/reports/cost.test.ts
@@ -1,13 +1,11 @@
-import jwt from 'jsonwebtoken';
 import moment from 'moment';
 import nock from 'nock';
-import pino from 'pino';
 
 import * as data from '../../lib/cf/cf.test.data';
+import {createTestContext} from '../app/app.test-helpers';
 
-import { config } from '../app/app.test.config';
-import { IContext } from '../app/context';
-import { Token } from '../auth';
+import {config} from '../app/app.test.config';
+import {IContext} from '../app/context';
 import * as reports from '../reports';
 
 // tslint:disable:max-line-length
@@ -21,20 +19,7 @@ nock(config.cloudFoundryAPI)
   .reply(200, data.organizationQuota)
 ;
 
-const tokenKey = 'secret';
-const token = jwt.sign({
-  user_id: 'uaa-user-123',
-  scope: [],
-  exp: 2535018460,
-}, tokenKey);
-const ctx: IContext = {
-  app: config,
-  routePartOf: () => false,
-  linkTo: () => '__LINKED_TO__',
-  log: pino({level: 'silent'}),
-  token: new Token(token, [tokenKey]),
-  csrf: '',
-};
+const ctx: IContext = createTestContext();
 
 const defaultBillableEvent = {
   eventGUID: '', eventStart: new Date(), eventStop: new Date(),

--- a/src/components/reports/visualisation.test.ts
+++ b/src/components/reports/visualisation.test.ts
@@ -1,13 +1,11 @@
-import jwt from 'jsonwebtoken';
 import moment from 'moment';
 import nock from 'nock';
-import pino from 'pino';
+import {createTestContext} from '../app/app.test-helpers';
 
 import * as data from '../../lib/cf/cf.test.data';
 
 import { config } from '../app/app.test.config';
 import { IContext } from '../app/context';
-import { Token } from '../auth';
 import * as reports from '../reports';
 
 const defaultBillable = {
@@ -25,20 +23,7 @@ describe('html visualisation report test suite', () => {
     .times(5)
     .reply(200, data.organizations);
 
-  const tokenKey = 'secret';
-  const token = jwt.sign({
-    user_id: 'uaa-user-123',
-    scope: [],
-    exp: 2535018460,
-  }, tokenKey);
-  const ctx: IContext = {
-    app: config,
-    routePartOf: () => false,
-    linkTo: () => '__LINKED_TO__',
-    log: pino({level: 'silent'}),
-    token: new Token(token, [tokenKey]),
-    csrf: '',
-  };
+  const ctx: IContext = createTestContext();
 
   it('should show empty report for zero billables', async () => {
     const rangeStart = moment().startOf('month').format('YYYY-MM-DD');

--- a/src/components/services/services.test.ts
+++ b/src/components/services/services.test.ts
@@ -1,14 +1,10 @@
-import jwt from 'jsonwebtoken';
 import nock from 'nock';
-import pino from 'pino';
+
+import {viewService} from '.';
 
 import * as data from '../../lib/cf/cf.test.data';
-
-import { config } from '../app/app.test.config';
-import { IContext } from '../app/context';
-import { Token } from '../auth';
-
-import { viewService } from '.';
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
 
 // tslint:disable:max-line-length
 nock('https://example.com/api')
@@ -22,20 +18,7 @@ nock('https://example.com/api')
   .get('/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee').times(1).reply(200, data.userServiceInstance);
 // tslint:enable:max-line-length
 
-const tokenKey = 'secret';
-const token = jwt.sign({
-  user_id: 'uaa-user-123',
-  scope: [],
-  exp: 2535018460,
-}, tokenKey);
-const ctx: IContext = {
-  app: config,
-  routePartOf: () => false,
-  linkTo: () => '__LINKED_TO__',
-  log: pino({level: 'silent'}),
-  token: new Token(token, [tokenKey]),
-  csrf: '',
-};
+const ctx: IContext = createTestContext();
 
 describe('services test suite', () => {
   it('should show the service overview page', async () => {

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -1,14 +1,10 @@
-import jwt from 'jsonwebtoken';
 import nock from 'nock';
-import pino from 'pino';
-
-import * as data from '../../lib/cf/cf.test.data';
-
-import { config } from '../app/app.test.config';
-import { IContext } from '../app/context';
-import { Token } from '../auth';
 
 import * as spaces from '.';
+
+import * as data from '../../lib/cf/cf.test.data';
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
 
 // tslint:disable:max-line-length
 nock('https://example.com/api').persist()
@@ -39,20 +35,7 @@ nock('https://example.com/accounts').persist()
   }));
 // tslint:enable:max-line-length
 
-const tokenKey = 'secret';
-const token = jwt.sign({
-  user_id: 'uaa-user-123',
-  scope: [],
-  exp: 2535018460,
-}, tokenKey);
-const ctx: IContext = {
-  app: config,
-  routePartOf: () => false,
-  linkTo: () => '__LINKED_TO__',
-  log: pino({level: 'silent'}),
-  token: new Token(token, [tokenKey]),
-  csrf: '',
-};
+const ctx: IContext = createTestContext();
 
 describe('spaces test suite', () => {
   it('should show the spaces pages', async () => {

--- a/src/components/statements/statements.test.ts
+++ b/src/components/statements/statements.test.ts
@@ -1,17 +1,17 @@
 import jwt from 'jsonwebtoken';
 import moment from 'moment';
 import nock from 'nock';
-import pino from 'pino';
+
+import * as statement from '.';
 
 import * as billingData from '../../lib/billing/billing.test.data';
 import * as data from '../../lib/cf/cf.test.data';
+import {createTestContext} from '../app/app.test-helpers';
 
-import { config } from '../app/app.test.config';
-import { IContext } from '../app/context';
-import { Token } from '../auth';
-
-import * as statement from '.';
-import { composeCSV, ISortable, ISortableBy, ISortableDirection, order, sortByName } from './statements';
+import {config} from '../app/app.test.config';
+import {IContext} from '../app/context';
+import {Token} from '../auth';
+import {composeCSV, ISortable, ISortableBy, ISortableDirection, order, sortByName} from './statements';
 
 const resourceTemplate = {
   resourceGUID: '',
@@ -44,14 +44,10 @@ const token = jwt.sign({
   scope: [],
   exp: 2535018460,
 }, tokenKey);
-const ctx: IContext = {
-  app: config,
-  routePartOf: () => false,
-  linkTo: (name, params) => `${name}/${params ? params.rangeStart : ''}`,
-  log: pino({level: 'silent'}),
+const ctx: IContext = createTestContext({
+  linkTo: (name: any, params: any) => `${name}/${params ? params.rangeStart : ''}`,
   token: new Token(token, [tokenKey]),
-  csrf: '',
-};
+});
 
 describe('statements test suite', () => {
 

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -1,14 +1,13 @@
 import jwt from 'jsonwebtoken';
 import nock from 'nock';
-import pino from 'pino';
 
 import * as users from '.';
+
 import {AccountsClient} from '../../lib/accounts';
 
 import * as cfData from '../../lib/cf/cf.test.data';
 import * as uaaData from '../../lib/uaa/uaa.test.data';
-
-import {config} from '../app/app.test.config';
+import {createTestContext} from '../app/app.test-helpers';
 import {IContext} from '../app/context';
 import {Token} from '../auth';
 
@@ -18,14 +17,9 @@ const time = Math.floor(Date.now() / 1000);
 const rawToken = {user_id: 'uaa-id-253', scope: [], exp: (time + (24 * 60 * 60))};
 const accessToken = jwt.sign(rawToken, tokenKey);
 
-const ctx: IContext = {
-  app: config,
-  routePartOf: () => false,
-  linkTo: () => '__LINKED_TO__',
-  log: pino({level: 'silent'}),
+const ctx: IContext = createTestContext({
   token: new Token(accessToken, [tokenKey]),
-  csrf: '',
-};
+});
 
 function composeOrgRoles(setup: object) {
   const defaultRoles = {


### PR DESCRIPTION
What
----

Raising this to make #285 easier to review.

Session access will be required for the OIDC flow. It makes sense to make it
available to HTTP handler implementations via the passed-in IContext
implementation, because the session is part of the context for handling a
request. This commit adds the field, and refactors how tests make their
IContext implementations.

How to review
-------------

* Code review should be enough

Who can review
---------------

* Not @AP-Hunt or @mogds