### PR TITLE
Base sankey height on view height

### DIFF
--- a/src/components/reports/visualisation.njk
+++ b/src/components/reports/visualisation.njk
@@ -15,7 +15,7 @@
   <script id="data" type="application/json">
   {{data | dump | safe}}
   </script>
-  <svg id="sankey" style="width: 100%; height: 40vw;"></svg>
+  <svg id="sankey" style="width: 100%; height: 95vh;"></svg>
 
   <script src="/assets/d3.min.js"></script>
   <script src="/assets/d3-sankey.min.js"></script>


### PR DESCRIPTION
What
----

Setting a height of 95% of the view height will mean the diagram is
always just big enough to be seen on one screen. Previously the diagram
would be really really small on mobile because it was based on the view
width.

How to review
-------------

* Code review
* Check out this comparison:

### Before

![0 0 0 0_3000_reports_visualisation_2019-03-01(Pixel 2) (3)](https://user-images.githubusercontent.com/1696784/61139982-754b7180-a4c2-11e9-881b-467f393e96dc.png)

### After

![0 0 0 0_3000_reports_visualisation_2019-03-01(Pixel 2) (2)](https://user-images.githubusercontent.com/1696784/61139998-7c727f80-a4c2-11e9-94f9-f2f5c0f9797a.png)

Who can review
---------------

Not @richardTowers 
