### PR TITLE
Remove blue theme color

### DIFF
--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -5,7 +5,6 @@
 {% extends "govuk-frontend/template.njk" %}
 
 {% set htmlLang = "en" %}
-{% set themeColor = "blue" %}
 {% set bodyClasses = "govuk-body" %}
 
 {% block pageTitle %}PaaS Administration Tool{% endblock %}


### PR DESCRIPTION
What
----

Back in https://github.com/alphagov/paas-admin/pull/76/files#diff-a6f85c1191fe205b2ba09f3405e041a6R8 Rafal roguishly snuck a themeColor of `blue` into the template. The themeColor is used by chrome mobile to set the colour of the URL bar, but [`blue` is a gross color](https://html-color.codes/hex/0000ff).

We should remove the themeColor and let chrome do whatever the default is.

How to review
-------------

* Code review
* Look how gross this theme colour is!

![image](https://user-images.githubusercontent.com/1696784/61142616-1983e700-a4c8-11e9-8756-a055250c6a1d.png)

Who can review
---------------

Not @richardTowers 