### PR TITLE
[#165440687] Google analytics on paas admin

### DIFF
--- a/src/components/app/app.csp.ts
+++ b/src/components/app/app.csp.ts
@@ -9,9 +9,12 @@ export default {
     ],
     scriptSrc: [
       `'self'`,
-      'www.google-analytics.com',
       `'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='`, // Inline script tag in govuk_template
       `'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='`, // Inline script tag in govuk_template
+      'www.google-analytics.com',
+      'www.googletagmanager.com',
+      // Inline script tag for Google Analytics
+      `'sha256-3PKQVkjJP08zzrQZEDAfQN6ScCpPnpo3b3VEocvDsdg='`,
     ],
     imgSrc: [
       `'self'`,

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -170,8 +170,10 @@ describe('app test suite', () => {
       it('should have a Content Security Policy set', () => {
         expect(response.header['content-security-policy']).toContain(
           `default-src 'none'; style-src 'self' 'unsafe-inline'; ` +
-          `script-src 'self' www.google-analytics.com 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' ` +
-          `'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='; img-src 'self' www.google-analytics.com; ` +
+          `script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' ` +
+          `'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' www.google-analytics.com ` +
+          `www.googletagmanager.com 'sha256-3PKQVkjJP08zzrQZEDAfQN6ScCpPnpo3b3VEocvDsdg='; ` +
+          `img-src 'self' www.google-analytics.com; ` +
           `connect-src 'self' www.google-analytics.com; frame-src 'self'; font-src 'self' data:; ` +
           `object-src 'self'; media-src 'self'`,
         );

--- a/src/components/spaces/spaces.njk
+++ b/src/components/spaces/spaces.njk
@@ -6,7 +6,7 @@
 {% from "govuk-frontend/components/details/macro.njk" import govukDetails %}
 
 {% block pageTitle %}
-  Spaces
+  {{ organization.entity.name }} – Spaces
 {% endblock %}
 
 {% block content %}

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -14,6 +14,16 @@
 {% endblock %}
 
 {% block head %}
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-43115970-5"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-43115970-5');
+  </script>
+
   <meta name="csrf-token" content="{{csrf}}" />
 
   <!--[if !IE 8]><!-->


### PR DESCRIPTION
What
----

This PR adds Google Analytics to `paas-admin`. See commit messages for full details.

How to review
-------------

* Code review;
* See if the build goes green;
* Go into Google Analytics and observe that you can see traffic to `paas-admin` in real-time.

Who can review
---------------

Not @46bit