### PR TITLE
Put Origin in GA

### DIFF
--- a/src/components/account/account.test.ts
+++ b/src/components/account/account.test.ts
@@ -246,6 +246,7 @@ function setUpUAA(userData: string): IContext {
   const token = jwt.sign({
     user_id: uaaData.userId,
     scope: [],
+    origin: 'uaa',
     exp: 2535018460,
   }, 'secret');
 

--- a/src/components/app/app.csp.ts
+++ b/src/components/app/app.csp.ts
@@ -14,7 +14,7 @@ export default {
       'www.google-analytics.com',
       'www.googletagmanager.com',
       // Inline script tag for Google Analytics
-      `'sha256-3PKQVkjJP08zzrQZEDAfQN6ScCpPnpo3b3VEocvDsdg='`,
+      `'sha256-JcBlICm6OEcFiWPFdHSsGDody7xi9jgOetfKR1FhO7Y='`,
     ],
     imgSrc: [
       `'self'`,

--- a/src/components/app/app.csp.ts
+++ b/src/components/app/app.csp.ts
@@ -14,7 +14,7 @@ export default {
       'www.google-analytics.com',
       'www.googletagmanager.com',
       // Inline script tag for Google Analytics
-      `'sha256-JcBlICm6OEcFiWPFdHSsGDody7xi9jgOetfKR1FhO7Y='`,
+      `'sha256-H7q7hXqike7Yb27lFO21Pk6233UiAy/pJJ9TDT6RrBM='`,
     ],
     imgSrc: [
       `'self'`,

--- a/src/components/app/app.test-helpers.ts
+++ b/src/components/app/app.test-helpers.ts
@@ -34,6 +34,7 @@ export function createTestContext(ctx?: {}): IContext {
       jwt.sign({
         user_id: 'uaa-user-123',
         exp: 2535018460,
+        origin: 'uaa',
         scope: [],
       }, 'secret'), ['secret'],
     ),

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -173,7 +173,7 @@ describe('app test suite', () => {
           `default-src 'none'; style-src 'self' 'unsafe-inline'; ` +
           `script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' ` +
           `'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' www.google-analytics.com ` +
-          `www.googletagmanager.com 'sha256-3PKQVkjJP08zzrQZEDAfQN6ScCpPnpo3b3VEocvDsdg='; ` +
+          `www.googletagmanager.com 'sha256-JcBlICm6OEcFiWPFdHSsGDody7xi9jgOetfKR1FhO7Y='; ` +
           `img-src 'self' www.google-analytics.com; ` +
           `connect-src 'self' www.google-analytics.com; frame-src 'self'; font-src 'self' data:; ` +
           `object-src 'self'; media-src 'self'`,
@@ -208,6 +208,14 @@ describe('app test suite', () => {
       }, {});
 
       expect(response.redirect).toEqual(orgs.definition.path);
+    });
+
+    it('should add a meta tag for origin', async () => {
+      const orgs = router.findByName('admin.organizations');
+      const response = await agent.get(orgs.definition.path);
+
+      expect(response.status).toEqual(200);
+      expect(response.text).toMatch('<meta name="origin" content="uaa" />');
     });
   });
 

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -173,7 +173,7 @@ describe('app test suite', () => {
           `default-src 'none'; style-src 'self' 'unsafe-inline'; ` +
           `script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' ` +
           `'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' www.google-analytics.com ` +
-          `www.googletagmanager.com 'sha256-JcBlICm6OEcFiWPFdHSsGDody7xi9jgOetfKR1FhO7Y='; ` +
+          `www.googletagmanager.com 'sha256-H7q7hXqike7Yb27lFO21Pk6233UiAy/pJJ9TDT6RrBM='; ` +
           `img-src 'self' www.google-analytics.com; ` +
           `connect-src 'self' www.google-analytics.com; frame-src 'self'; font-src 'self' data:; ` +
           `object-src 'self'; media-src 'self'`,
@@ -215,7 +215,7 @@ describe('app test suite', () => {
       const response = await agent.get(orgs.definition.path);
 
       expect(response.status).toEqual(200);
-      expect(response.text).toMatch('<meta name="origin" content="uaa" />');
+      expect(response.text).toMatch('<meta name="x-user-identity-origin" content="uaa" />');
     });
   });
 

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -115,6 +115,7 @@ describe('app test suite', () => {
       user_id: 'uaa-user-123',
       scope: [],
       exp: (time + (24 * 60 * 60)),
+      origin: 'uaa',
     }, tokenKey);
 
     nock('https://example.com/uaa')

--- a/src/components/app/context.ts
+++ b/src/components/app/context.ts
@@ -12,6 +12,7 @@ export interface IRawToken {
 export interface IViewContext {
   readonly csrf: string;
   readonly location: string;
+  readonly origin?: string;
 }
 
 export interface IContext {
@@ -26,6 +27,8 @@ export interface IContext {
 }
 
 export function initContext(req: any, router: Router, route: Route, config: IAppConfig): IContext {
+  const origin = req.token && req.token.origin;
+
   return {
     app: config,
     routePartOf: (name: string) => route.definition.name === name || route.definition.name.startsWith(name),
@@ -40,6 +43,7 @@ export function initContext(req: any, router: Router, route: Route, config: IApp
     viewContext: {
       location: config.location,
       csrf: req.csrfToken(),
+      origin,
     },
     session: req.session,
   };

--- a/src/components/auth/auth.test.ts
+++ b/src/components/auth/auth.test.ts
@@ -56,6 +56,7 @@ describe('auth test suite', () => {
         user_id: 'uaa-user-123',
         scope: [],
         exp: (time + (24 * 60 * 60)),
+        origin: 'uaa',
       }, tokenKey);
 
       // Capture the request to the given URL and prepare a response.
@@ -148,6 +149,7 @@ describe('auth test suite', () => {
       user_id: 'uaa-user-123',
       scope: [],
       exp: (time + (24 * 60 * 60)),
+      origin: 'uaa',
     }, tokenKey);
 
     beforeAll(() => {

--- a/src/components/auth/has-role.test.ts
+++ b/src/components/auth/has-role.test.ts
@@ -22,15 +22,23 @@ it('should throw error if signed token is a string', async () => {
 });
 
 it('should throw error if expiry is missing', async () => {
-  const accessToken = jwt.sign({}, tokenKeys[0]);
+  const accessToken = jwt.sign({origin: 'uaa'}, tokenKeys[0]);
   expect(() => {
     const token = new Token(accessToken, tokenKeys);
     expect(token).not.toBeTruthy();
-  }).toThrow(/could not verify the token as no exp have been decoded/);
+  }).toThrow(/could not verify the token as no exp has been decoded/);
+});
+
+it('should throw error if origin is missing', async () => {
+  const accessToken = jwt.sign({exp: (time + (24 * 60 * 60))}, tokenKeys[0]);
+  expect(() => {
+    const token = new Token(accessToken, tokenKeys);
+    expect(token).not.toBeTruthy();
+  }).toThrow(/could not verify the token as no origin has been decoded/);
 });
 
 it('should throw error if scope is not an array', async () => {
-  const accessToken = jwt.sign({exp: (time + (24 * 60 * 60)), scope: 'not-an-array'}, tokenKeys[0]);
+  const accessToken = jwt.sign({origin: 'uaa', exp: (time + (24 * 60 * 60)), scope: 'not-an-array'}, tokenKeys[0]);
   expect(() => {
     const token = new Token(accessToken, tokenKeys);
     expect(token).not.toBeTruthy();
@@ -38,34 +46,34 @@ it('should throw error if scope is not an array', async () => {
 });
 
 it('should have expiry', async () => {
-  const accessToken = jwt.sign({exp: (time + (24 * 60 * 60)), scope: []}, tokenKeys[0]);
+  const accessToken = jwt.sign({origin: 'uaa', exp: (time + (24 * 60 * 60)), scope: []}, tokenKeys[0]);
   const token = new Token(accessToken, tokenKeys);
   expect(token.expiry).toBeDefined();
   expect(typeof token.expiry).toEqual('number');
 });
 
 it('should have scopes', async () => {
-  const accessToken = jwt.sign({exp: (time + (24 * 60 * 60)), scope: ['read-write']}, tokenKeys[0]);
+  const accessToken = jwt.sign({origin: 'uaa', exp: (time + (24 * 60 * 60)), scope: ['read-write']}, tokenKeys[0]);
   const token = new Token(accessToken, tokenKeys);
   expect(token.scopes).toBeDefined();
   expect(token.scopes[0]).toEqual('read-write');
 });
 
 it('should have scopes', async () => {
-  const accessToken = jwt.sign({exp: (time + (24 * 60 * 60)), scope: ['read-write']}, tokenKeys[0]);
+  const accessToken = jwt.sign({origin: 'uaa', exp: (time + (24 * 60 * 60)), scope: ['read-write']}, tokenKeys[0]);
   const token = new Token(accessToken, tokenKeys);
   expect(token.hasScope('read-write')).toBeTruthy();
 });
 
 it('should have scopes', async () => {
-  const accessToken = jwt.sign({exp: (time + (24 * 60 * 60)), scope: ['read-write', 'write-read']}, tokenKeys[0]);
+  const accessToken = jwt.sign({origin: 'uaa', exp: (time + (24 * 60 * 60)), scope: ['read-write', 'write-read']}, tokenKeys[0]);
   const token = new Token(accessToken, tokenKeys);
   expect(token.hasAnyScope('write-read')).toBeTruthy();
   expect(token.hasAnyScope('admin')).toBeFalsy();
 });
 
 it('should succeed when verifying with older key', async () => {
-  const accessToken = jwt.sign({exp: (time + (24 * 60 * 60)), scope: ['read-write']}, tokenKeys[1]);
+  const accessToken = jwt.sign({origin: 'uaa', exp: (time + (24 * 60 * 60)), scope: ['read-write']}, tokenKeys[1]);
   const token = new Token(accessToken, tokenKeys);
   expect(token.expiry).toBeDefined();
 });

--- a/src/components/auth/has-role.test.ts
+++ b/src/components/auth/has-role.test.ts
@@ -66,7 +66,13 @@ it('should have scopes', async () => {
 });
 
 it('should have scopes', async () => {
-  const accessToken = jwt.sign({origin: 'uaa', exp: (time + (24 * 60 * 60)), scope: ['read-write', 'write-read']}, tokenKeys[0]);
+  const accessToken = jwt.sign({
+    origin: 'uaa',
+    exp: (time + (24 * 60 * 60)),
+    scope: ['read-write', 'write-read']},
+    tokenKeys[0],
+  );
+
   const token = new Token(accessToken, tokenKeys);
   expect(token.hasAnyScope('write-read')).toBeTruthy();
   expect(token.hasAnyScope('admin')).toBeFalsy();

--- a/src/components/auth/has-role.ts
+++ b/src/components/auth/has-role.ts
@@ -8,12 +8,14 @@ interface IToken {
   readonly exp: number;
   readonly scope: ReadonlyArray<string>;
   readonly user_id: string;
+  readonly origin: string;
 }
 
 export class Token {
   public readonly expiry: number;
   public readonly scopes: ReadonlyArray<string>;
   public readonly userID: string;
+  public readonly origin: string;
 
   constructor(public readonly accessToken: string, public readonly signingKeys: ReadonlyArray<string>) {
     const rawToken = verify(accessToken, signingKeys);
@@ -21,6 +23,7 @@ export class Token {
     this.expiry = rawToken.exp;
     this.scopes = rawToken.scope;
     this.userID = rawToken.user_id;
+    this.origin = rawToken.origin;
   }
 
   public hasScope(scope: string): boolean {
@@ -62,16 +65,21 @@ function verify(accessToken: string, signingKeys: ReadonlyArray<string>): IToken
   }
 
   if (!rawToken.exp) {
-    throw new Error('jwt: could not verify the token as no exp have been decoded');
+    throw new Error('jwt: could not verify the token as no exp has been decoded');
+  }
+
+  if (!rawToken.origin) {
+    throw new Error('jwt: could not verify the token as no origin has been decoded');
   }
 
   if (!Array.isArray(rawToken.scope)) {
-    throw new Error('jwt: could not verify the token as no scope(s) have been decoded');
+    throw new Error('jwt: could not verify the token as no scope(s) has been decoded');
   }
 
   return {
     exp: rawToken.exp,
     scope: rawToken.scope,
     user_id: rawToken.user_id,
+    origin: rawToken.origin,
   };
 }

--- a/src/components/org-users/org-users.test.ts
+++ b/src/components/org-users/org-users.test.ts
@@ -14,7 +14,7 @@ import {Token} from '../auth';
 const tokenKey = 'secret';
 
 const time = Math.floor(Date.now() / 1000);
-const rawToken = {user_id: 'uaa-id-253', scope: [], exp: (time + (24 * 60 * 60))};
+const rawToken = {user_id: 'uaa-id-253', scope: [], origin: 'uaa', exp: (time + (24 * 60 * 60))};
 const accessToken = jwt.sign(rawToken, tokenKey);
 
 const ctx: IContext = createTestContext({

--- a/src/components/statements/statements.test.ts
+++ b/src/components/statements/statements.test.ts
@@ -43,6 +43,7 @@ const token = jwt.sign({
   user_id: 'uaa-id-253',
   scope: [],
   exp: 2535018460,
+  origin: 'uaa',
 }, tokenKey);
 const ctx: IContext = createTestContext({
   linkTo: (name: any, params: any) => `${name}/${params ? params.rangeStart : ''}`,

--- a/src/components/terms/middleware.test.ts
+++ b/src/components/terms/middleware.test.ts
@@ -24,6 +24,7 @@ app.use((req: any, _res: any, next: any) => {
   }
   const accessToken = jwt.sign({
     exp: (now + (24 * 60 * 60)),
+    origin: 'uaa',
     scope: [],
     user_id: fakeUserID,
   }, tokenKeys[0]);

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -15,7 +15,7 @@
 
 {% block head %}
   <meta name="csrf-token" content="{{context.csrf}}" />
-  <meta name="origin" content="{{context.origin}}" />
+  <meta name="x-user-identity-origin" content="{{context.origin}}" />
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-43115970-5"></script>
 
@@ -27,7 +27,7 @@
 
     var dimensions = {};
 
-    var originTag = document.querySelector('meta[name="origin"]')
+    var originTag = document.querySelector('meta[name="x-user-identity-origin"]')
     if (originTag && originTag.content) {
       dimensions['dimension1'] = originTag.content;
     }

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -14,17 +14,26 @@
 {% endblock %}
 
 {% block head %}
+  <meta name="csrf-token" content="{{context.csrf}}" />
+  <meta name="origin" content="{{context.origin}}" />
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-43115970-5"></script>
+
+  <!-- Pull dimensions vals from meta ; else all script/origin combinations have to be in the CSP -->
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-43115970-5');
-  </script>
+    var dimensions = {};
 
-  <meta name="csrf-token" content="{{context.csrf.toString()}}" />
+    var originTag = document.querySelector('meta[name="origin"]')
+    if (originTag && originTag.content) {
+      dimensions['dimension1'] = originTag.content;
+    }
+
+    gtag('config', 'UA-43115970-5', dimensions);
+  </script>
 
   <!--[if !IE 8]><!-->
     <link href="./govuk.screen.scss" media="screen" rel="stylesheet" />

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -13,6 +13,7 @@ function mockUAA(app: express.Application, config: IStubServerPorts): express.Ap
     user_id: userId,
     scope: [],
     exp: 2535018460,
+    origin: 'uaa',
   }, tokenKey);
 
   const userPayload: IUaaUser = {


### PR DESCRIPTION
This PR is branched off #337 - review that first

What
----

Put the authenticated user's `origin` from UAA in a Google analytics dimension, if it exists.

How to review
-------------

Code review

[Read](https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets) on how `gtag` deals with custom dimensions

See Concourse

Who can review
---------------

@richardTowers 
