### PR TITLE
Implement /users/:emailOrUserGUID

### DIFF
--- a/config/nunjucks.config.js
+++ b/config/nunjucks.config.js
@@ -31,6 +31,13 @@ function configure(env) {
     const converter = new showdown.Converter();
     return converter.makeHtml(text);
   });
+
+  env.addFilter('plural', (n, singular, plural) => {
+    if (n === 1) {
+      return singular;
+    }
+    return plural;
+  })
 }
 
 module.exports = configure;

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -8,6 +8,7 @@ import * as reports from '../reports';
 import * as services from '../services';
 import * as spaces from '../spaces';
 import * as statements from '../statements';
+import * as users from '../users';
 import { IContext } from './context';
 
 const router = new Router([
@@ -148,6 +149,11 @@ const router = new Router([
     action: account.getMicrosoftOIDCCallback,
     name: 'account.use-microsoft-sso-callback.get',
     path: '/my-account/use-microsoft-sso/callback',
+  },
+  {
+    action: users.getUser,
+    name: 'users.get',
+    path: '/users/:emailOrUserGUID',
   },
 ]);
 

--- a/src/components/org-users/org-users.test.ts
+++ b/src/components/org-users/org-users.test.ts
@@ -138,6 +138,7 @@ describe('org-users test suite', () => {
     nockCF.done();
     nockUAA.done();
     nockNotify.done();
+    nockAccounts.done();
   });
 
   it('should show the users pages', async () => {

--- a/src/components/org-users/org-users.test.ts
+++ b/src/components/org-users/org-users.test.ts
@@ -59,7 +59,7 @@ function composeSpaceRoles(setup: object) {
   };
 }
 
-describe('users test suite', () => {
+describe('org-users test suite', () => {
   // tslint:disable:max-line-length
   const nockCF = nock(ctx.app.cloudFoundryAPI).persist();
   const nockUAA = nock(ctx.app.uaaAPI).persist();

--- a/src/components/users/index.ts
+++ b/src/components/users/index.ts
@@ -1,0 +1,1 @@
+export * from './users';

--- a/src/components/users/user.njk
+++ b/src/components/users/user.njk
@@ -10,4 +10,30 @@
   <p class="govuk-body">Email: {{ accountsUser.email }}</p>
   <p class="govuk-body">Username: {{ accountsUser.username }}</p>
 
+  <h3 class="govuk-heading-m">Orgs</h3>
+  <p class="govuk-body">This user is a member of {{ orgs.length }} orgs.</p>
+  <ul class="govuk-list">
+    {% for org in orgs %}
+      <li>
+        <a href="{{ linkTo('admin.organizations.view', {organizationGUID: org.metadata.guid}) }}"
+           class="govuk-link">
+          {{ org.entity.name }}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+
+  <h3 class="govuk-heading-m">Managed Orgs</h3>
+  <p class="govuk-body">This user manages {{ managedOrgs.length }} orgs.</p>
+  <ul class="govuk-list">
+    {% for org in orgs %}
+      <li>
+        <a href="{{ linkTo('admin.organizations.view', {organizationGUID: org.metadata.guid}) }}"
+           class="govuk-link">
+          {{ org.entity.name }}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+
 {% endblock %}

--- a/src/components/users/user.njk
+++ b/src/components/users/user.njk
@@ -29,6 +29,18 @@
         </a>
       </dd>
     </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Origin</dt>
+      <dd class="govuk-summary-list__value">
+        <code>{{ origin }}</code>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Last logon</dt>
+      <dd class="govuk-summary-list__value">
+        {{ lastLogonTimestamp }}
+      </dd>
+    </div>
   </dl>
 
   <h3 class="govuk-heading-m">Orgs</h3>
@@ -54,6 +66,13 @@
           {{ org.entity.name }}
         </a>
       </li>
+    {% endfor %}
+  </ul>
+
+  <h3 class="govuk-heading-m">UAA Groups</h3>
+  <ul class="govuk-list">
+    {% for group in uaaGroups %}
+      <li><code>{{ group.display }}</code></li>
     {% endfor %}
   </ul>
 

--- a/src/components/users/user.njk
+++ b/src/components/users/user.njk
@@ -44,7 +44,7 @@
   </dl>
 
   <h3 class="govuk-heading-m">Orgs</h3>
-  <p class="govuk-body">This user is a member of {{ orgs.length }} orgs.</p>
+  <p class="govuk-body">This user is a member of {{ orgs.length }} {{ managedOrgs.length | plural('org', 'orgs') }}.</p>
   <ul class="govuk-list govuk-list--bullet">
     {% for org in orgs %}
       <li>
@@ -57,7 +57,7 @@
   </ul>
 
   <h3 class="govuk-heading-m">Managed Orgs</h3>
-  <p class="govuk-body">This user manages {{ managedOrgs.length }} orgs.</p>
+  <p class="govuk-body">This user manages {{ managedOrgs.length }} {{ managedOrgs.length | plural('org', 'orgs') }}.</p>
   <ul class="govuk-list govuk-list--bullet">
     {% for org in orgs %}
       <li>

--- a/src/components/users/user.njk
+++ b/src/components/users/user.njk
@@ -1,0 +1,13 @@
+{% extends "../../layouts/govuk.njk" %}
+{% block pageTitle %}
+  User
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+
+  <p class="govuk-body">GUID: {{ accountsUser.uuid }}</p>
+  <p class="govuk-body">Email: {{ accountsUser.email }}</p>
+  <p class="govuk-body">Username: {{ accountsUser.username }}</p>
+
+{% endblock %}

--- a/src/components/users/user.njk
+++ b/src/components/users/user.njk
@@ -45,7 +45,7 @@
 
   <h3 class="govuk-heading-m">Orgs</h3>
   <p class="govuk-body">This user is a member of {{ orgs.length }} orgs.</p>
-  <ul class="govuk-list">
+  <ul class="govuk-list govuk-list--bullet">
     {% for org in orgs %}
       <li>
         <a href="{{ linkTo('admin.organizations.view', {organizationGUID: org.metadata.guid}) }}"
@@ -58,7 +58,7 @@
 
   <h3 class="govuk-heading-m">Managed Orgs</h3>
   <p class="govuk-body">This user manages {{ managedOrgs.length }} orgs.</p>
-  <ul class="govuk-list">
+  <ul class="govuk-list govuk-list--bullet">
     {% for org in orgs %}
       <li>
         <a href="{{ linkTo('admin.organizations.view', {organizationGUID: org.metadata.guid}) }}"
@@ -70,7 +70,7 @@
   </ul>
 
   <h3 class="govuk-heading-m">UAA Groups</h3>
-  <ul class="govuk-list">
+  <ul class="govuk-list govuk-list--bullet">
     {% for group in uaaGroups %}
       <li><code>{{ group.display }}</code></li>
     {% endfor %}

--- a/src/components/users/user.njk
+++ b/src/components/users/user.njk
@@ -6,9 +6,30 @@
 {% block content %}
   {{ super() }}
 
-  <p class="govuk-body">GUID: {{ accountsUser.uuid }}</p>
-  <p class="govuk-body">Email: {{ accountsUser.email }}</p>
-  <p class="govuk-body">Username: {{ accountsUser.username }}</p>
+  <h3 class="govuk-heading-m">User</h3>
+  <dl class="govuk-summary-list govuk-summary-list--no-border">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">GUID</dt>
+      <dd class="govuk-summary-list__value">
+        <code>{{ accountsUser.uuid }}</code>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Username</dt>
+      <dd class="govuk-summary-list__value">
+        <code>{{ accountsUser.username }}</code>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Email address</dt>
+      <dd class="govuk-summary-list__value">
+        <a class="govuk-link"
+           href="mailto:{{ accountsUser.email }}">
+          {{ accountsUser.email }}
+        </a>
+      </dd>
+    </div>
+  </dl>
 
   <h3 class="govuk-heading-m">Orgs</h3>
   <p class="govuk-body">This user is a member of {{ orgs.length }} orgs.</p>

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -102,7 +102,7 @@ describe('users test suite', () => {
         emailOrUserGUID: '',
       });
     } catch (e) {
-      expect(e.message).toContain('not found');
+      expect(e.message).toContain('Could not find user');
     }
   });
 });

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -21,6 +21,16 @@ const ctx: IContext = createTestContext({
   token: new Token(accessToken, [tokenKey]),
 });
 
+const rawNonAdminAccessToken = {
+  user_id: 'uaa-id-253',
+  scope: [],
+  exp: (time + (24 * 60 * 60)),
+};
+const nonAdminAccessToken = jwt.sign(rawNonAdminAccessToken, tokenKey);
+const nonAdminCtx: IContext = createTestContext({
+  token: new Token(nonAdminAccessToken, [tokenKey]),
+});
+
 describe('users test suite', () => {
   // tslint:disable:max-line-length
   const nockAccounts = nock(ctx.app.accountsAPI).persist();
@@ -54,6 +64,17 @@ describe('users test suite', () => {
     expect(response.body).toContain('User');
     expect(response.body).toContain('one@user.in.database');
     expect(response.body).toContain('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  });
+
+  it('should return not found for the users pages when not admin', async () => {
+
+    try {
+      await users.getUser(nonAdminCtx, {
+        emailOrUserGUID: 'one@user.in.database',
+      });
+    } catch (e) {
+      expect(e.message).toContain('not found');
+    }
   });
 
   it('should show return an error for an invalid email', async () => {

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -1,0 +1,108 @@
+import jwt from 'jsonwebtoken';
+import nock from 'nock';
+
+import * as users from './users';
+
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
+import {CLOUD_CONTROLLER_ADMIN, Token} from '../auth';
+
+const tokenKey = 'secret';
+
+const time = Math.floor(Date.now() / 1000);
+const rawToken = {
+  user_id: 'uaa-id-253',
+  scope: [CLOUD_CONTROLLER_ADMIN],
+  exp: (time + (24 * 60 * 60)),
+};
+const accessToken = jwt.sign(rawToken, tokenKey);
+
+const ctx: IContext = createTestContext({
+  token: new Token(accessToken, [tokenKey]),
+});
+
+describe('users test suite', () => {
+  // tslint:disable:max-line-length
+  const nockAccounts = nock(ctx.app.accountsAPI).persist();
+
+  nockAccounts
+    .get('/users?email=one@user.in.database').reply(200, `{
+      "users": [{
+        "user_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "user_email": "one@user.in.database",
+        "username": "one@user.in.database"
+      }]
+    }`)
+    .get('/users?email=no@user.in.database').reply(200, `{"users": []}`)
+    .get('/user/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee').reply(200, `{
+      "user_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "user_email": "one@user.in.database",
+      "username": "one@user.in.database"
+    }`)
+    .get('/user/aaaaaaaa-404b-cccc-dddd-eeeeeeeeeeee').reply(404);
+  // tslint:enable:max-line-length
+
+  afterAll(() => {
+    nockAccounts.done();
+  });
+
+  it('should show the users pages for a valid email', async () => {
+    const response = await users.getUser(ctx, {
+      emailOrUserGUID: 'one@user.in.database',
+    });
+
+    expect(response.body).toContain('User');
+    expect(response.body).toContain('one@user.in.database');
+    expect(response.body).toContain('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  });
+
+  it('should show return an error for an invalid email', async () => {
+    try {
+      await users.getUser(ctx, {
+        emailOrUserGUID: 'no@user.in.database',
+      });
+    } catch (e) {
+      expect(e.message).toContain('Could not find user');
+    }
+  });
+
+  it('should show the users pages a valid guid', async () => {
+    const response = await users.getUser(ctx, {
+      emailOrUserGUID: 'one@user.in.database',
+    });
+
+    expect(response.body).toContain('User');
+    expect(response.body).toContain('one@user.in.database');
+    expect(response.body).toContain('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  });
+
+  it('should show return an error for an invalid guid', async () => {
+    try {
+      await users.getUser(ctx, {
+        emailOrUserGUID: 'aaaaaaaa-404b-cccc-dddd-eeeeeeeeeeee',
+      });
+    } catch (e) {
+      expect(e.message).toContain('Could not find user');
+    }
+  });
+
+  it('should show return an error for an undefined param', async () => {
+    try {
+      await users.getUser(ctx, {
+        emailOrUserGUID: undefined,
+      });
+    } catch (e) {
+      expect(e.message).toContain('not found');
+    }
+  });
+
+  it('should show return an error for an empty param', async () => {
+    try {
+      await users.getUser(ctx, {
+        emailOrUserGUID: '',
+      });
+    } catch (e) {
+      expect(e.message).toContain('not found');
+    }
+  });
+});

--- a/src/components/users/users.test.ts
+++ b/src/components/users/users.test.ts
@@ -81,7 +81,7 @@ describe('users test suite', () => {
 
     expect(response.body).toContain('the-system_domain-org-name');
 
-    expect(response.body).toContain('5/22/2018');
+    expect(response.body).toContain('2018');
     expect(response.body).toContain('cloud_controller.read');
   });
 
@@ -118,7 +118,7 @@ describe('users test suite', () => {
 
     expect(response.body).toContain('the-system_domain-org-name');
 
-    expect(response.body).toContain('5/22/2018');
+    expect(response.body).toContain('2018');
     expect(response.body).toContain('cloud_controller.read');
   });
 

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -1,4 +1,5 @@
 import {AccountsClient} from '../../lib/accounts';
+import CloudFoundryClient from '../../lib/cf';
 import {IParameters, IResponse} from '../../lib/router';
 import {NotFoundError} from '../../lib/router/errors';
 import {IContext} from '../app/context';
@@ -38,10 +39,21 @@ export async function getUser(ctx: IContext, params: IParameters): Promise<IResp
     );
   }
 
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const cfUserSummary = await cf.userSummary(accountsUser.uuid);
+
   return {
     body: userTemplate.render({
       context: ctx.viewContext,
       accountsUser,
+      orgs: cfUserSummary.entity.organizations,
+      managedOrgs: cfUserSummary.entity.managed_organizations,
+      linkTo: ctx.linkTo,
     }),
   };
 }

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -1,0 +1,51 @@
+import {AccountsClient} from '../../lib/accounts';
+import {IParameters, IResponse} from '../../lib/router';
+import {NotFoundError} from '../../lib/router/errors';
+import {IContext} from '../app/context';
+import {CLOUD_CONTROLLER_ADMIN} from '../auth';
+
+import userTemplate from './user.njk';
+
+export async function getUser(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const emailOrUserGUID = params.emailOrUserGUID;
+
+  if (typeof emailOrUserGUID === 'undefined') {
+    throw new NotFoundError('not found');
+  }
+
+  if (emailOrUserGUID === '') {
+    throw new NotFoundError('not found');
+  }
+
+  const isAdmin = ctx.token.hasScope(CLOUD_CONTROLLER_ADMIN);
+
+  /* istanbul ignore next */
+  if (!isAdmin) {
+    throw new NotFoundError('not found');
+  }
+
+  const accountsClient = new AccountsClient({
+    apiEndpoint: ctx.app.accountsAPI,
+    secret: ctx.app.accountsSecret,
+    logger: ctx.app.logger,
+  });
+
+  const accountsUser = (
+    (emailOrUserGUID.indexOf('@') >= 0)
+    ? await accountsClient.getUserByEmail(emailOrUserGUID)
+    : await accountsClient.getUser(emailOrUserGUID)
+  );
+
+  if (accountsUser === null) {
+    throw new NotFoundError(
+      `Could not find user for ${emailOrUserGUID} in paas-accounts`,
+    );
+  }
+
+  return {
+    body: userTemplate.render({
+      context: ctx.viewContext,
+      accountsUser,
+    }),
+  };
+}

--- a/src/components/users/users.ts
+++ b/src/components/users/users.ts
@@ -9,11 +9,7 @@ import userTemplate from './user.njk';
 export async function getUser(ctx: IContext, params: IParameters): Promise<IResponse> {
   const emailOrUserGUID = params.emailOrUserGUID;
 
-  if (typeof emailOrUserGUID === 'undefined') {
-    throw new NotFoundError('not found');
-  }
-
-  if (emailOrUserGUID === '') {
+  if (typeof emailOrUserGUID !== 'string') {
     throw new NotFoundError('not found');
   }
 

--- a/src/lib/accounts/accounts.test.ts
+++ b/src/lib/accounts/accounts.test.ts
@@ -77,6 +77,27 @@ nock(cfg.apiEndpoint)
       "username": "many@user.in.database"
     }]
   }`)
+  .get('/users?uuids=aaaaaaaa-404b-cccc-dddd-eeeeeeeeeeee').reply(200, `{
+    "users": []
+  }`)
+  .get('/users?uuids=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee').reply(200, `{
+    "users": [{
+      "user_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "user_email": "one@user.in.database",
+      "username": "one@user.in.database"
+    }]
+  }`)
+  .get('/users?uuids=11111111-bbbb-cccc-dddd-eeeeeeeeeeee,22222222-bbbb-cccc-dddd-eeeeeeeeeeee').reply(200, `{
+    "users": [{
+      "user_uuid": "11111111-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "user_email": "one@user.in.database",
+      "username": "one@user.in.database"
+    },{
+      "user_uuid": "22222222-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "user_email": "two@user.in.database",
+      "username": "two@user.in.database"
+    }]
+  }`)
 ;
 
 describe('lib/accounts test suite', () => {
@@ -183,5 +204,32 @@ describe('lib/accounts test suite', () => {
         'getUserByEmail received more than one result from Accounts API',
       ));
     }
+  });
+
+  it('should respond with an empty list when listing non-existing users by guid', async () => {
+    const ac = new AccountsClient(cfg);
+    const users = await ac.getUsers(['aaaaaaaa-404b-cccc-dddd-eeeeeeeeeeee']);
+    expect(users.length).toEqual(0);
+  });
+
+  it('should respond with a list of one when listing a single user by guid', async () => {
+    const ac = new AccountsClient(cfg);
+    const users = await ac.getUsers(['aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee']);
+    expect(users.length).toEqual(1);
+    expect(users[0].email).toEqual('one@user.in.database');
+    expect(users[0].username).toEqual('one@user.in.database');
+  });
+
+  it('should respond with a list of two when listing multiple users by guid', async () => {
+    const ac = new AccountsClient(cfg);
+    const users = await ac.getUsers([
+      '11111111-bbbb-cccc-dddd-eeeeeeeeeeee',
+      '22222222-bbbb-cccc-dddd-eeeeeeeeeeee',
+    ]);
+    expect(users.length).toEqual(2);
+    expect(users[0].email).toEqual('one@user.in.database');
+    expect(users[0].username).toEqual('one@user.in.database');
+    expect(users[1].email).toEqual('two@user.in.database');
+    expect(users[1].username).toEqual('two@user.in.database');
   });
 });

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -38,6 +38,10 @@ export interface IAccountsUserResponse {
   readonly user_email: string;
 }
 
+export interface IAccountsUsersResponse {
+  readonly users: ReadonlyArray<IAccountsUserResponse>;
+}
+
 export interface IAccountsUser {
   readonly uuid: string;
   readonly username: string;
@@ -125,6 +129,25 @@ export class AccountsClient {
 
       throw err;
     }
+  }
+
+  public async getUserByEmail(email: string): Promise<IAccountsUser | null> {
+    const response = await this.request({
+      url: `/users?email=${email}`,
+      method: 'get',
+    });
+
+    const parsedResponse: IAccountsUsersResponse = response.data;
+
+    if (parsedResponse.users.length === 0) {
+      return null;
+    }
+
+    if (parsedResponse.users.length > 1) {
+      throw new Error('getUserByEmail received more than one result from Accounts API');
+    }
+
+    return parseUser(parsedResponse.users[0]);
   }
 
   public async createUser(uuid: string, username: string, email: string): Promise<boolean> {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -131,6 +131,17 @@ export class AccountsClient {
     }
   }
 
+  public async getUsers(uuids: ReadonlyArray<string>): Promise<ReadonlyArray<IAccountsUser>> {
+    const response = await this.request({
+      url: `/users?uuids=${uuids.join(',')}`,
+      method: 'get',
+    });
+
+    const parsedResponse: IAccountsUsersResponse = response.data;
+
+    return parsedResponse.users.map(parseUser);
+  }
+
   public async getUserByEmail(email: string): Promise<IAccountsUser | null> {
     const response = await this.request({
       url: `/users?email=${email}`,

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -1263,6 +1263,56 @@ export const userServices = `{
   ]
 }`;
 
+export const userSummary = `{
+  "metadata": {
+    "guid": "guid-cb24b36d-4656-468e-a50d-b53113ac6177",
+      "created_at": "2016-06-08T16:41:37Z",
+      "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "organizations": [{
+      "metadata": {
+        "guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+        "created_at": "2016-06-08T16:41:33Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "the-system_domain-org-name"
+      }
+    }],
+    "managed_organizations": [{
+      "metadata": {
+        "guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+        "created_at": "2016-06-08T16:41:33Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "the-system_domain-org-name"
+      }
+    }],
+    "billing_managed_organizations": [{
+      "metadata": {
+        "guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+        "created_at": "2016-06-08T16:41:33Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "the-system_domain-org-name"
+      }
+    }],
+    "audited_organizations": [{
+      "metadata": {
+        "guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+        "created_at": "2016-06-08T16:41:33Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "the-system_domain-org-name"
+      }
+    }]
+  }
+}`;
+
 export const stacks = `{
   "total_results": 2,
   "total_pages": 1,

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -37,6 +37,7 @@ nock('https://example.com/api').persist()
   .post('/v2/users').reply(201, data.user)
   .delete('/v2/users/guid-cb24b36d-4656-468e-a50d-b53113ac6177?async=false').reply(204)
   .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, data.spaces)
+  .get('/v2/users/uaa-id-253/summary').reply(200, data.userSummary)
   .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, data.userRolesForOrg)
   .get('/v2/spaces/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, data.userRolesForSpace)
   .post('/v2/users').reply(200, data.user)
@@ -266,6 +267,16 @@ describe('lib/cf test suite', () => {
   test('should delete a user', async () => {
     const client = new CloudFoundryClient(config);
     expect(async () => client.deleteUser('guid-cb24b36d-4656-468e-a50d-b53113ac6177')).not.toThrowError();
+  });
+
+  test('should obtain a user summary', async () => {
+    const client = new CloudFoundryClient(config);
+    const summary = await client.userSummary('uaa-id-253');
+
+    expect(summary.entity.organizations.length === 1).toBeTruthy();
+    expect(summary.entity.managed_organizations.length === 1).toBeTruthy();
+    expect(summary.entity.billing_managed_organizations.length === 1).toBeTruthy();
+    expect(summary.entity.audited_organizations.length === 1).toBeTruthy();
   });
 
   test('should obtain list of user roles for organisation', async () => {

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -209,6 +209,11 @@ export default class CloudFoundryClient {
     await this.request('delete', `/v2/users/${userId}?async=false`);
   }
 
+  public async userSummary(userId: string): Promise<cf.IUserSummary> {
+    const response = await this.request('get', `/v2/users/${userId}/summary`);
+    return response.data;
+  }
+
   public async usersForOrganization(organizationGUID: string): Promise<ReadonlyArray<cf.IOrganizationUserRoles>> {
     const response = await this.request('get', `/v2/organizations/${organizationGUID}/user_roles`);
     return this.allResources(response);

--- a/src/lib/cf/types.ts
+++ b/src/lib/cf/types.ts
@@ -321,6 +321,24 @@ export interface IUser {
   readonly metadata: IMetadata;
 }
 
+// Partial definition, there are more fields
+export interface IUserSummaryOrganization {
+  readonly entity: {
+    readonly name: string;
+  };
+  readonly metadata: IMetadata;
+}
+
+export interface IUserSummary {
+  readonly entity: {
+    readonly organizations: ReadonlyArray<IUserSummaryOrganization>,
+    readonly managed_organizations: ReadonlyArray<IUserSummaryOrganization>,
+    readonly billing_managed_organizations: ReadonlyArray<IUserSummaryOrganization>,
+    readonly audited_organizations: ReadonlyArray<IUserSummaryOrganization>,
+  };
+  readonly metadata: IMetadata;
+}
+
 export interface IUserServices {
   readonly entity: {
     readonly credentials: {[i: string]: string};

--- a/stub-api/stub-accounts.ts
+++ b/stub-api/stub-accounts.ts
@@ -1,8 +1,16 @@
 import express from 'express';
-import {IAccountsUserResponse} from '../src/lib/accounts';
+import {IAccountsUserResponse, IAccountsUsersResponse} from '../src/lib/accounts';
 import * as cfStubData from '../src/lib/cf/cf.test.data';
 import * as uaaStubData from '../src/lib/uaa/uaa.test.data';
 import {IStubServerPorts} from './index';
+
+function makeUser(id: string): IAccountsUserResponse {
+  return {
+    user_uuid: id,
+    username: `${id}@fake.cabinet-office.gov.uk`,
+    user_email: `${id}@fake.cabinet-office.gov.uk`,
+  };
+}
 
 function mockAccounts(app: express.Application, _config: IStubServerPorts): express.Application {
   // All users have no documents
@@ -23,13 +31,7 @@ function mockAccounts(app: express.Application, _config: IStubServerPorts): expr
 
     const id: string = req.params.guid;
     if (userIds.indexOf(id) >= 0) {
-      const userBody: IAccountsUserResponse = {
-        user_uuid: id,
-        username: `${id}@fake.cabinet-office.gov.uk`,
-        user_email: `${id}@fake.cabinet-office.gov.uk`,
-      };
-
-      res.send(JSON.stringify(userBody));
+      res.send(JSON.stringify(makeUser(id)));
     } else {
       res.status(404).send('Not found');
     }

--- a/stub-api/stub-accounts.ts
+++ b/stub-api/stub-accounts.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import {IAccountsUserResponse} from '../src/lib/accounts';
 import * as cfStubData from '../src/lib/cf/cf.test.data';
 import * as uaaStubData from '../src/lib/uaa/uaa.test.data';
-import {IStubServerPorts, StubServerFactory} from './index';
+import {IStubServerPorts} from './index';
 
 function mockAccounts(app: express.Application, _config: IStubServerPorts): express.Application {
   // All users have no documents

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -44,6 +44,7 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
   app.get('/v2/user_provided_service_instances'      , (_, res) => res.send(testData.userServices));
   app.get('/v2/user_provided_service_instances/:guid', (_, res) => res.send(testData.userServiceInstance));
   app.get('/v2/users/uaa-id-253/spaces'              , (_, res) => res.send(testData.spaces));
+  app.get('/v2/users/uaa-id-253/summary'              , (_, res) => res.send(testData.userSummary));
   app.get('/v2/organizations/:guid/user_roles'       , (_, res) => res.send(testData.userRolesForOrg));
   app.get('/v2/spaces/:guid/user_roles'              , (_, res) => res.send(testData.userRolesForSpace));
   app.get('/v2/stacks'                               , (_, res) => res.send(testData.stacks));

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -5,6 +5,7 @@ import {IStubServerPorts} from './index';
 
 const tokenKey = 'tokensecret';
 const userId = '99022be6-feb8-4f78-96f3-7d11f4d476f1';
+const otherUserId = 'uaa-id-253';
 function mockUAA(app: express.Application, config: IStubServerPorts): express.Application {
   const { adminPort } = config;
   const fakeJwt = jwt.sign({
@@ -63,6 +64,12 @@ function mockUAA(app: express.Application, config: IStubServerPorts): express.Ap
 
   app.get(
     `/Users/${userId}`,
+    (_req, res) => {
+      res.send(JSON.stringify(userPayload));
+    });
+
+  app.get(
+    `/Users/${otherUserId}`,
     (_req, res) => {
       res.send(JSON.stringify(userPayload));
     });

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -3,15 +3,13 @@ import jwt from 'jsonwebtoken';
 import {IUaaUser} from '../src/lib/uaa';
 import {IStubServerPorts} from './index';
 
-;
-
 const tokenKey = 'tokensecret';
 const userId = '99022be6-feb8-4f78-96f3-7d11f4d476f1';
 function mockUAA(app: express.Application, config: IStubServerPorts): express.Application {
   const { adminPort } = config;
   const fakeJwt = jwt.sign({
     user_id: userId,
-    scope: [],
+    scope: ['cloud_controller.admin'],
     exp: 2535018460,
   }, tokenKey);
 

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -43,8 +43,8 @@ function mockUAA(app: express.Application, config: IStubServerPorts): express.Ap
     phoneNumbers: [],
     approvals: [],
     passwordLastModified: '2019-01-01T00:00:00',
-    previousLogonTime: 1546300800,
-    lastLogonTime: 1546300800,
+    previousLogonTime : 1527032725657,
+    lastLogonTime : 1527032725657,
   };
 
   app.post(

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -35,7 +35,11 @@ function mockUAA(app: express.Application, config: IStubServerPorts): express.Ap
       { value: 'stub-user@digital.cabinet-office.gov.uk', primary: true },
     ],
     schemas: [ 'urn:scim:schemas:core:1.0' ],
-    groups: [],
+    groups: [{
+      display: 'cloud_controller.read',
+      type: 'DIRECT',
+      value: '177eb558-5e9a-42a5-9316-438aee2b88a4',
+    }],
     phoneNumbers: [],
     approvals: [],
     passwordLastModified: '2019-01-01T00:00:00',


### PR DESCRIPTION
What
----

As an operator I want to be able to look up a user by their email address or their GUID (without knowing about orgs), so that I can do leavers tickets quickly.

Implements a page which shows data from paas-accounts (canonical source of email address), and CAPI (source of org data).

An admin can go to either `/users/user@example.com` or `/users/aaaabbbb-cccc-dddd-eeee-ffffgggghhhh` to get useful information.

- [x] Add paas-accounts endpoints to paas-accounts client
- [x] Add `/users/:emailOrUserGUID` functionality
- [x] Add endpoint to stub API
- [x] Add useful info:
  - [x] Orgs a user is a member of, Orgs a user manages
  - [x] UAA groups
  - [x] Last logon time
  - [x] Origin

![A screenshot of this page when using the stub API](https://user-images.githubusercontent.com/1482692/61585195-3bc3d780-ab4e-11e9-8a69-a425a7203512.png)
___A screenshot of this page when using the stub API____

How to review
-------------

Code review

Spin it up locally using the stub API

Deploy to your env

Who can review
---------------

Not @tlwr
