### PR TITLE
Remove repeated "on" from SSO copy

### DIFF
--- a/src/components/account/use-google-sso.njk
+++ b/src/components/account/use-google-sso.njk
@@ -23,7 +23,7 @@
           <p>
             You will also need to
             <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
-              use single sign-on on at the command line
+              use single sign-on at the command line
             </a>.
           </p>
         </section>
@@ -43,7 +43,7 @@
             You are currently set-up to use Google single sign-on.
             You will also need to
             <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
-              use single sign-on on at the command line
+              use single sign-on at the command line
             </a>.
           </p>
           <p>


### PR DESCRIPTION
What
----

"Use single sign-on on at the command line" has too many ons. Thanks @bravegrape for pointing this out.

How to review
-------------

Code review is enough

Who can review
--------------

Not @richardtowers or @bravegrape
