### PR TITLE
Add organisations report

### DIFF
--- a/config/nunjucks.config.js
+++ b/config/nunjucks.config.js
@@ -1,5 +1,6 @@
 const jmespath = require('jmespath');
 const showdown = require('showdown');
+const moment = require('moment');
 
 function configure(env) {
   env.addFilter('query', (data, query) => {
@@ -38,6 +39,21 @@ function configure(env) {
     }
     return plural;
   })
+
+  env.addFilter('nicedate', (date) => {
+    return moment(date).format('MMMM Do YYYY');
+  });
+
+  env.addFilter('relativetime', (date) => {
+    return moment(date).fromNow();
+  });
+
+  env.addFilter('pastorfuture', (date, past, future) => {
+    if (new Date() > date) {
+      return past
+    }
+    return future
+  });
 }
 
 module.exports = configure;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5307,8 +5307,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5326,13 +5325,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5345,18 +5342,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5459,8 +5453,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5470,7 +5463,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5483,20 +5475,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5513,7 +5502,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5586,8 +5574,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5597,7 +5584,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5673,8 +5659,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5704,7 +5689,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5722,7 +5706,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5761,13 +5744,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "jsonwebtoken": "8.5.1",
     "lodash": "^4.17.15",
     "merge-deep": "3.0.2",
-    "moment": "2.24.0",
+    "moment": "^2.24.0",
     "nanoid": "^2.0.3",
     "node-jose": "^1.1.3",
     "notifications-node-client": "^4.6.0",

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -115,12 +115,12 @@ const router = new Router([
   },
   {
     action: reports.viewCostReport,
-    name: 'admin.reports.view',
+    name: 'admin.reports.cost',
     path: '/reports/cost/:rangeStart',
   },
   {
     action: reports.viewCostByServiceReport,
-    name: 'admin.reports.viewbyservice',
+    name: 'admin.reports.costbyservice',
     path: '/reports/cost-by-service/:rangeStart',
   },
   {

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -109,6 +109,11 @@ const router = new Router([
     path: '/organisations/:organizationGUID/statements',
   },
   {
+    action: reports.viewOrganizationsReport,
+    name: 'admin.reports.organizations',
+    path: '/reports/organisations',
+  },
+  {
     action: reports.viewCostReport,
     name: 'admin.reports.view',
     path: '/reports/cost/:rangeStart',

--- a/src/components/reports/index.ts
+++ b/src/components/reports/index.ts
@@ -1,3 +1,4 @@
 export * from './cost';
 export * from './cost-by-service';
+export * from './organizations';
 export * from './visualisation';

--- a/src/components/reports/organizations.njk
+++ b/src/components/reports/organizations.njk
@@ -1,0 +1,112 @@
+{% extends "../../layouts/govuk.njk" %}
+{% from "govuk-frontend/components/input/macro.njk" import govukInput %}
+{% from "govuk-frontend/components/button/macro.njk" import govukButton %}
+{% from "govuk-frontend/components/panel/macro.njk" import govukPanel %}
+{% from "govuk-frontend/components/back-link/macro.njk" import govukBackLink %}
+
+{% block pageTitle %}
+  Organisations
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+
+  <h1 class="govuk-heading-l">Organisations</h1>
+
+  <p class="govuk-body">
+    There
+    {{ organizations.length | plural('is', 'are') }}
+    {{ organizations.length }}
+    {{ organizations.length | plural('organisation', 'organisations') }}.
+  </p>
+
+  <h2 class="govuk-heading-m">Trial accounts</h2>
+
+  <p class="govuk-body">
+    There
+    {{ trialOrgs.length | plural('is', 'are') }}
+    {{ trialOrgs.length }}
+    trial {{ trialOrgs.length | plural('organisation', 'organisations') }}.
+  </p>
+
+  <p class="govuk-body">
+    Sorted by age; oldest first.
+  </p>
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Organisation</th>
+        <th class="govuk-table__header">Quota</th>
+        <th class="govuk-table__header">Creation date</th>
+        <th class="govuk-table__header">Status</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    {% for organization in trialOrgs %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <a href="{{linkTo('admin.organizations.view', {organizationGUID: organization.metadata.guid})}}" class="govuk-link">
+            {{ organization.entity.name }}
+          </a>
+        </td>
+        <td class="govuk-table__cell">
+          {{orgQuotaMapping[organization.entity.quota_definition_guid].entity.name}}
+        </td>
+        <td class="govuk-table__cell">
+          {{organization.metadata.created_at | nicedate}}
+        </td>
+        <td class="govuk-table__cell">
+					{{orgTrialExpirys[organization.metadata.guid] | pastorfuture('Expired', 'Expires') -}}
+          {{- ' ' -}}
+          {{orgTrialExpirys[organization.metadata.guid] | relativetime}}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  <h2 class="govuk-heading-m">Billable accounts</h2>
+
+  <p class="govuk-body">
+    There
+    {{ billableOrgs.length | plural('is', 'are') }}
+    {{ billableOrgs.length }}
+    billable {{ billable.length | plural('organisation', 'organisations') }}.
+  </p>
+
+  <p class="govuk-body">
+    Sorted by age; newest first.
+  </p>
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Organisation</th>
+        <th class="govuk-table__header">Quota</th>
+        <th class="govuk-table__header">Creation date</th>
+        <th class="govuk-table__header">Time since creation</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    {% for organization in billableOrgs %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <a href="{{linkTo('admin.organizations.view', {organizationGUID: organization.metadata.guid})}}" class="govuk-link">
+            {{ organization.entity.name }}
+          </a>
+        </td>
+        <td class="govuk-table__cell">
+          {{orgQuotaMapping[organization.entity.quota_definition_guid].entity.name}}
+        </td>
+        <td class="govuk-table__cell">
+          {{organization.metadata.created_at | nicedate}}
+        </td>
+        <td class="govuk-table__cell">
+          Created {{organization.metadata.created_at | relativetime}}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/src/components/reports/organizations.test.ts
+++ b/src/components/reports/organizations.test.ts
@@ -1,0 +1,212 @@
+import jwt from 'jsonwebtoken';
+import lodash from 'lodash';
+import moment from 'moment';
+import nock from 'nock';
+
+import * as cf from '../../lib/cf/cf.test.data';
+import {testable as t, viewOrganizationsReport} from './organizations';
+
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
+import {Token} from '../auth';
+
+const tokenKey = 'secret';
+
+const time = Math.floor(Date.now() / 1000);
+const rawToken = {user_id: 'uaa-id-253', scope: [], origin: 'uaa', exp: (time + (24 * 60 * 60))};
+const accessToken = jwt.sign(rawToken, tokenKey);
+
+const ctx: IContext = createTestContext({
+  token: new Token(accessToken, [tokenKey]),
+});
+
+describe('organisations report helpers', () => {
+  let nockCF: nock.Scope;
+
+  beforeEach(() => {
+    nock.cleanAll();
+
+    nockCF = nock(ctx.app.cloudFoundryAPI);
+  });
+
+  afterEach(() => {
+    nockCF.done();
+
+    nock.cleanAll();
+  });
+
+  it('trialExpiryDate should compute trial expiry correctly', () => {
+    const creationDate = new Date('2019-08-01T16:25:59.254Z');
+    const beforeExpiredDate = new Date('2019-10-29T17:25:59.254Z');
+    const afterExpiredDate = new Date('2019-10-31T17:25:59.254Z');
+
+    expect(
+      t.trialExpiryDate(creationDate).getTime(),
+    ).toBeGreaterThan(beforeExpiredDate.getTime());
+
+    expect(
+      t.trialExpiryDate(creationDate).getTime(),
+    ).toBeLessThan(afterExpiredDate.getTime());
+  });
+
+  it('filterRealOrgs should filter out tests and admin', () => {
+    const baseOrg = cf.organization;
+
+    const anOrg = (name: string) => lodash.merge(
+      JSON.parse(baseOrg), { entity: { name } },
+    );
+
+    const orgs = [
+        anOrg('govuk-doggos'), anOrg('admin'), anOrg('ACC-123'),
+        anOrg('BACC-123'), anOrg('CATS-123'), anOrg('department-for-coffee'),
+        anOrg('SMOKE-'),
+    ];
+
+    const filteredOrgs = t.filterRealOrgs(orgs);
+
+    expect(filteredOrgs.length).toEqual(2);
+    expect(filteredOrgs[0].entity.name).toEqual('govuk-doggos');
+    expect(filteredOrgs[1].entity.name).toEqual('department-for-coffee');
+  });
+
+  it('filterTrialOrgs should filter out billable orgs and sort asc', () => {
+    const baseOrg = cf.organization;
+
+    const anOrg = (name: string, quotaGUID: string, d: Date) => lodash.merge(
+      JSON.parse(baseOrg), {
+        entity: { name , quota_definition_guid: quotaGUID },
+        metadata: { created_at: d },
+      },
+    );
+
+    const trialGUID = 'trial-guid';
+    const paidGUID = 'expensive-guid';
+
+    const orgs = [
+        anOrg('1-trial-org', trialGUID, moment().toDate()),
+        anOrg('1-paid-org', paidGUID, moment().toDate()),
+        anOrg('2-trial-org', trialGUID, moment().subtract(1, 'days').toDate()),
+        anOrg('2-paid-org', paidGUID, moment().subtract(1, 'days').toDate()),
+    ];
+
+    const trialOrgs = t.filterTrialOrgs(trialGUID, orgs);
+
+    expect(trialOrgs.length).toEqual(2);
+    expect(trialOrgs[0].entity.name).toEqual('2-trial-org');
+    expect(trialOrgs[1].entity.name).toEqual('1-trial-org');
+  });
+
+  it('filterBillabeOrgs should filter out trial orgs and sort desc', () => {
+    const baseOrg = cf.organization;
+
+    const anOrg = (name: string, quotaGUID: string, d: Date) => lodash.merge(
+      JSON.parse(baseOrg), {
+        entity: { name , quota_definition_guid: quotaGUID },
+        metadata: { created_at: d },
+      },
+    );
+
+    const trialGUID = 'trial-guid';
+    const paidGUID = 'expensive-guid';
+
+    const orgs = [
+        anOrg('1-trial-org', trialGUID, moment().toDate()),
+        anOrg('1-paid-org', paidGUID, moment().toDate()),
+        anOrg('2-trial-org', trialGUID, moment().subtract(1, 'days').toDate()),
+        anOrg('2-paid-org', paidGUID, moment().subtract(1, 'days').toDate()),
+    ];
+
+    const billableOrgs = t.filterBillableOrgs(trialGUID, orgs);
+
+    expect(billableOrgs.length).toEqual(2);
+    expect(billableOrgs[0].entity.name).toEqual('1-paid-org');
+    expect(billableOrgs[1].entity.name).toEqual('2-paid-org');
+  });
+
+  it('should render the page correctly', async () => {
+    const baseOrg = cf.organization;
+    const baseQuota = cf.organizationQuota;
+
+    const anOrg = (name: string, quotaGUID: string, d: Date) => lodash.merge(
+      JSON.parse(baseOrg), {
+        entity: { name , quota_definition_guid: quotaGUID },
+        metadata: { created_at: d, guid: name },
+      },
+    );
+
+    const aQuota = (name: string, quotaGUID: string) => lodash.merge(
+      JSON.parse(baseQuota), {
+        entity: { name },
+        metadata: { guid: quotaGUID },
+      },
+    );
+
+    const trialGUID = 'default';
+    const cheapGUID = 'cheap-guid';
+    const expensiveGUID = 'expensive-guid';
+
+    const orgs = lodash.merge(JSON.parse(cf.organizations), { resources: [
+      anOrg('current-trial-org', trialGUID, moment().toDate()),
+      anOrg('expiring-trial-org', trialGUID, moment().subtract(100, 'days').toDate()),
+      anOrg('cheap-org', cheapGUID, moment().subtract(365, 'days').toDate()),
+      anOrg('expensive-org', expensiveGUID, moment().subtract(730, 'days').toDate()),
+    ]});
+
+    nockCF
+      .get(`/v2/quota_definitions?q=name:${trialGUID}`)
+      .reply(200, JSON.stringify(lodash.merge(
+        JSON.parse(cf.organizationQuotas),
+        {resources: [aQuota('Trial', trialGUID)]},
+      )))
+
+      .get(`/v2/quota_definitions/${trialGUID}`)
+      .reply(200, JSON.stringify(aQuota('Trial', trialGUID)))
+
+      .get(`/v2/quota_definitions/${cheapGUID}`)
+      .reply(200, JSON.stringify(aQuota('Cheap', cheapGUID)))
+
+      .get(`/v2/quota_definitions/${expensiveGUID}`)
+      .reply(200, JSON.stringify(aQuota('Expensive', expensiveGUID)))
+
+      .get('/v2/organizations')
+      .reply(200, JSON.stringify(orgs))
+    ;
+
+    const response = await viewOrganizationsReport(ctx, {});
+
+    // When trial accounts are expiring
+    expect(response.body).toContain('Expired 10 days ago');
+    expect(response.body).toContain('Expires in 3 months');
+
+    // When billabe accounts were created approximately
+    expect(response.body).toContain('Created a year ago');
+    expect(response.body).toContain('Created 2 years ago');
+
+    // Should show the quota names
+    expect(response.body).toContain('Trial');
+    expect(response.body).toContain('Cheap');
+    expect(response.body).toContain('Expensive');
+
+    // Should show the org names
+    expect(response.body).toContain('current-trial-org');
+    expect(response.body).toContain('expiring-trial-org');
+    expect(response.body).toContain('cheap-org');
+    expect(response.body).toContain('expensive-org');
+  });
+
+  it('should return an error when the default quota is not found', async () => {
+    const quotaDefinitionsResponse = JSON.parse(cf.organizationQuotas);
+    quotaDefinitionsResponse.resources = [];
+
+    nockCF
+      .get(`/v2/quota_definitions?q=name:default`)
+      .reply(200, JSON.stringify(quotaDefinitionsResponse))
+    ;
+
+    try {
+      await viewOrganizationsReport(ctx, {});
+    } catch (e) {
+      expect(e.message).toContain('Could not find default quota');
+    }
+  });
+});

--- a/src/components/reports/organizations.ts
+++ b/src/components/reports/organizations.ts
@@ -1,0 +1,126 @@
+import lodash from 'lodash';
+import moment from 'moment';
+
+import CloudFoundryClient from '../../lib/cf';
+import { IOrganization, IOrganizationQuota } from '../../lib/cf/types';
+import { IParameters, IResponse } from '../../lib/router';
+import { IContext } from '../app/context';
+
+import organizationsTemplate from './organizations.njk';
+
+function trialExpiryDate(creation: Date): Date {
+  return moment(creation).add(90, 'days').toDate();
+}
+
+function filterRealOrgs(
+  orgs: ReadonlyArray<IOrganization>,
+): ReadonlyArray<IOrganization> {
+  return orgs
+  .filter(org => {
+    const name = org.entity.name;
+
+    if (name.match(/^(CATS|ACC|BACC|SMOKE)-/)) {
+      return false;
+    }
+
+    if (name === 'admin') {
+      return false;
+    }
+
+    return true;
+  })
+  ;
+}
+
+function filterTrialOrgs(
+  trialQuotaGUID: string,
+  orgs: ReadonlyArray<IOrganization>,
+): ReadonlyArray<IOrganization> {
+  const trialOrgs = orgs.filter(
+    o => o.entity.quota_definition_guid === trialQuotaGUID,
+  );
+
+  // return the oldest orgs first
+  return lodash
+    .sortBy(trialOrgs, o => new Date(o.metadata.created_at))
+  ;
+}
+
+function filterBillableOrgs(
+  trialQuotaGUID: string,
+  orgs: ReadonlyArray<IOrganization>,
+): ReadonlyArray<IOrganization> {
+  const billableOrgs = orgs .filter(
+    o => o.entity.quota_definition_guid !== trialQuotaGUID,
+  );
+
+  // return the newest orgs first (reverse)
+  return lodash
+    .sortBy(billableOrgs, o => new Date(o.metadata.created_at))
+    .reverse()
+  ;
+}
+
+export const testable = {
+  trialExpiryDate,
+  filterRealOrgs, filterTrialOrgs, filterBillableOrgs,
+};
+
+export async function viewOrganizationsReport(ctx: IContext, _params: IParameters): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const trialQuotaCandidates = await cf.quotaDefinitions({ name: 'default'});
+
+  if (trialQuotaCandidates.length !== 1) {
+    throw new Error('Could not find default quota');
+  }
+
+  const organizations = filterRealOrgs(await cf.organizations());
+
+  const orgQuotaGUIDs = lodash.uniq(
+    organizations.map(o => o.entity.quota_definition_guid),
+  );
+
+  const orgQuotas = await Promise.all(
+    orgQuotaGUIDs.map(g => cf.organizationQuota(g)),
+  );
+
+  const trialQuotaGUID = trialQuotaCandidates[0].metadata.guid;
+  const trialOrgs = filterTrialOrgs(trialQuotaGUID, organizations);
+  const billableOrgs = filterBillableOrgs(trialQuotaGUID, organizations);
+
+  const orgQuotaMapping = orgQuotas.reduce((
+    mapping: {[key: string]: IOrganizationQuota},
+    orgQuota: IOrganizationQuota,
+  ) => {
+    mapping[orgQuota.metadata.guid] = orgQuota;
+    return mapping;
+  }, {});
+
+  const orgTrialExpirys = trialOrgs.reduce((
+    mapping: {[key: string]: Date}, org: IOrganization,
+  ) => {
+    mapping[org.metadata.guid] = trialExpiryDate(
+      new Date(org.metadata.created_at),
+    );
+
+    return mapping;
+  }, {});
+
+  return {
+    body: organizationsTemplate.render({
+      routePartOf: ctx.routePartOf,
+      linkTo: ctx.linkTo,
+      context: ctx.viewContext,
+      trialOrgs,
+      billableOrgs,
+      orgQuotaMapping,
+      orgTrialExpirys,
+      organizations,
+    }),
+  };
+}

--- a/src/components/reports/organizations.ts
+++ b/src/components/reports/organizations.ts
@@ -93,23 +93,16 @@ export async function viewOrganizationsReport(ctx: IContext, _params: IParameter
   const trialOrgs = filterTrialOrgs(trialQuotaGUID, organizations);
   const billableOrgs = filterBillableOrgs(trialQuotaGUID, organizations);
 
-  const orgQuotaMapping = orgQuotas.reduce((
-    mapping: {[key: string]: IOrganizationQuota},
-    orgQuota: IOrganizationQuota,
-  ) => {
-    mapping[orgQuota.metadata.guid] = orgQuota;
-    return mapping;
-  }, {});
+  const orgQuotaMapping: {[key: string]: IOrganizationQuota} = lodash
+    .keyBy(orgQuotas, q => q.metadata.guid)
+  ;
 
-  const orgTrialExpirys = trialOrgs.reduce((
-    mapping: {[key: string]: Date}, org: IOrganization,
-  ) => {
-    mapping[org.metadata.guid] = trialExpiryDate(
-      new Date(org.metadata.created_at),
-    );
-
-    return mapping;
-  }, {});
+  const orgTrialExpirys: {[key: string]: Date} = lodash
+    .chain(trialOrgs)
+    .keyBy(org => org.metadata.guid)
+    .mapValues(org => trialExpiryDate(new Date(org.metadata.created_at)))
+    .value()
+  ;
 
   return {
     body: organizationsTemplate.render({

--- a/src/components/reports/subnav/element.njk
+++ b/src/components/reports/subnav/element.njk
@@ -4,11 +4,11 @@
   </div>
 
   <nav class="govuk-grid-column-two-thirds">
-    <a href="{{ linkTo('admin.reports.view', { rangeStart: rangeStart }) }}" class="govuk-link {% if report === 'cost' %} active {% endif %}" class="govuk-link">
+    <a href="{{ linkTo('admin.reports.cost', { rangeStart: rangeStart }) }}" class="govuk-link {% if report === 'cost' %} active {% endif %}" class="govuk-link">
       Summary
     </a>
 
-    <a href="{{ linkTo('admin.reports.viewbyservice', { rangeStart: rangeStart }) }}" class="govuk-link {% if report === 'cost-by-service' %} active {% endif %}" class="govuk-link">
+    <a href="{{ linkTo('admin.reports.costbyservice', { rangeStart: rangeStart }) }}" class="govuk-link {% if report === 'cost-by-service' %} active {% endif %}" class="govuk-link">
       By service
     </a>
 


### PR DESCRIPTION
Context
----

We have [a gross script in paas-cf](https://github.com/alphagov/paas-cf/blob/master/scripts/org-usage-report.rb) for working out which organisations are expiring or abandoned, the business process is as follows:

- On the first of each month, we are told by IFTTT to run the script
- The support engineer clones the previous Pivotal Tracker story
- The support engineer runs the script in London and in Ireland
- The outputs of the script are copied into Pivotal Tracker
- The engagement team and the product manager review the output usually via a CSV

This is pointless bureaucracy / "busy work", the actual user need is to be effectively able to explore organisations currently on the platform.

This PR adds a new report which adds a new report, for organisation usage across the platform. It does not replicate the output of the script exactly, but other parts of PaaSmin can provide the same functionality.

The report is available on `/reports/organisations` and shows all orgs which aren't test generated and segregates them approximately according to billability.

⬇️ Shows a screenshot

![Screen Shot 2019-08-01 at 19 46 03](https://user-images.githubusercontent.com/1482692/62319193-57f03e80-b495-11e9-827f-a4cd2aa9233c.png)
_An image of the new organisations report_


How to review
-------------

Code review

`cf push` to your dev environment and do some clickops

[tlwr preview](https://admin.tlwr.dev.cloudpipeline.digital/reports/organisations)

Who can review
---------------

Not @tlwr
