### PR TITLE
Linkify external routes on application page

### DIFF
--- a/config/nunjucks.config.js
+++ b/config/nunjucks.config.js
@@ -54,6 +54,16 @@ function configure(env) {
     }
     return future
   });
+
+  env.addFilter('linkify', (links) => {
+    return links.map(link => {
+      if (link.match(/apps[.]internal/)) {
+        return link
+      }
+
+      return `<a href="${link}" class="govuk-link">${link}</a>`;
+    });
+  });
 }
 
 module.exports = configure;

--- a/src/components/applications/overview.njk
+++ b/src/components/applications/overview.njk
@@ -90,7 +90,7 @@
               text: 'URLs'
             },
             {
-              text: application.entity.urls | join(", ")
+              text: application.entity.urls | linkify | join(", ") | safe
             }
           ],
           [

--- a/src/components/spaces/applications.njk
+++ b/src/components/spaces/applications.njk
@@ -77,7 +77,7 @@
               {{ application.entity.state | lower }}
             </td>
             <td class="govuk-table__cell ">
-              {{ application.entity.urls | join(", ") }}
+              {{ application.entity.urls | linkify | join(", ") | safe }}
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
What
----

Adds links to the external routes of applications in the two places where we show routes, using a new nunjucks filter.

![Screen Shot 2019-08-05 at 10 03 35](https://user-images.githubusercontent.com/1482692/62452380-f6b3be00-b767-11e9-9e17-3831fd885c19.png)
_Image of linked routes on the spaces page_

![Screen Shot 2019-08-05 at 10 04 39](https://user-images.githubusercontent.com/1482692/62452440-19de6d80-b768-11e9-8462-e096fdb23f9c.png)

_Image of linked routes on the app overview page_

How to review
-------------

Code review

Who can review
---------------

Not @tlwr
