### PR TITLE
Prevent double update of username in MS SSO uplift journey

### DIFF
--- a/src/components/account/oidc.ts
+++ b/src/components/account/oidc.ts
@@ -54,16 +54,22 @@ export default class OIDC {
         {state, response_type},
       );
 
+      let newUsername;
       switch (providerName) {
         case 'microsoft': {
-          const oid = tokenSet.claims[KEY_OID] as string;
-          await uaa.setUserOrigin(ctx.token.userID, providerName, oid);
+          newUsername = tokenSet.claims[KEY_OID] as string;
+          break;
         }
         case 'google': {
-          const sub = tokenSet.claims[KEY_SUB] as string;
-          await uaa.setUserOrigin(ctx.token.userID, providerName, sub);
+          newUsername = tokenSet.claims[KEY_SUB] as string;
+          break;
+        }
+        /* istanbul ignore next */
+        default: {
+          throw new Error(`Provider name "${providerName}" is not recognised`);
         }
       }
+      await uaa.setUserOrigin(ctx.token.userID, providerName, newUsername);
 
       ctx.session[KEY_STATE] = null;
       ctx.session.save();


### PR DESCRIPTION
What
----
When performing a Microsoft SSO uplift journey, the user's username was being
updated twice because of a missing break statement. First, it was updated to
the value of the `oid` claim (correctly), it was then falling through and being
updated to the value of the `sub` claim (incorrectly).

Added a pair of expectations to the tests to verify that only one call is
happening, and refactored the code to remove the possibility of a second call
to `uaa.setUserOrigin`.

This _may_ have been happening for Google users too, but I haven't verified
that. If it was, the code path was leaving the account in the right state
because `google` was the second and last, case.

To see a quick demo of how/why this was happening, run the following code sample. It's a minimum recreation of the setup prior to the PR

```typescript
type UaaOrigin = 'uaa' | 'google' | 'microsoft';

function T(str: UaaOrigin) {
    switch(str) {
        case 'uaa':
            console.log("I am UAA");
        case 'google':
            console.log("I am Google");
        case 'microsoft':
            console.log("I am Microsoft");
    }
}

const s = 'google';
T(s as UaaOrigin);
```

How to review
-------------

1. Code review
2. Perform an `npm run push` on this branch (in the right org and space), and perform an MS SSO uplift journey. The resulting username should be the value of the `oid` claim, and not the `sub`.

Who can review
---------------
Anyone