### PR TITLE
Add origin to Org / Users / Team members

### DIFF
--- a/src/components/org-users/_org-users.scss
+++ b/src/components/org-users/_org-users.scss
@@ -22,6 +22,10 @@ table.user-list {
     width: 35%;
   }
 
+  .authentication {
+    width: 15%;
+  }
+
   th.is-billing-manager {
     width: 15%;
   }

--- a/src/components/org-users/org-users.njk
+++ b/src/components/org-users/org-users.njk
@@ -63,7 +63,12 @@
 <table class="govuk-table user-list">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header name" scope="col">Name</th>
+      <th class="govuk-table__header name" scope="col">Email address</th>
+      <th class="govuk-table__header authentication" scope="col">
+        {% if isAdmin or isManager %}
+          Authentication
+        {% endif %}
+      </th>
       <th class="govuk-table__header is-org-manager" scope="col">Org manager</th>
       <th class="govuk-table__header is-billing-manager" scope="col">Org billing manager</th>
       <th class="govuk-table__header is-org-auditor" scope="col">Org auditor</th>
@@ -83,6 +88,15 @@
         {% endif%}
       </td>
       <td class="govuk-table__cell">
+        {% if isAdmin or isManager %}
+          {% if userOriginMapping[guid] == 'uaa' %}
+            Password
+          {% else %}
+            {{ userOriginMapping[guid] | capitalize }}
+          {% endif %}
+        {% endif %}
+      </td>
+      <td class="govuk-table__cell">
         {% if 'org_manager' in user.orgRoles %}
           <img class="tick" alt="Yes" src="./tick.png">
         {% endif %}
@@ -98,14 +112,16 @@
         {% endif %}
       </td>
       <td class="govuk-table__cell">
-        {% set comma = joiner(", ") %}
-        {% for space in user.spaces %}
-          {{ comma() }}
-          <a href="{{ linkTo('admin.organizations.spaces.applications.list', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid}) }}"
-            class="govuk-link">
-            {{ space.entity.name }}
-          </a>
-        {% endfor %}
+        <ul class="plain">
+          {% for space in user.spaces %}
+            <li>
+              <a href="{{ linkTo('admin.organizations.spaces.applications.list', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid}) }}"
+                class="govuk-link">
+                {{ space.entity.name }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
       </td>
     </tr>
     {% endfor %}

--- a/src/components/org-users/org-users.test.ts
+++ b/src/components/org-users/org-users.test.ts
@@ -65,11 +65,48 @@ describe('org-users test suite', () => {
       .reply(200, cfData.userRolesForOrg)
     ;
 
+    nockUAA
+      .post('/oauth/token?grant_type=client_credentials')
+      .times(4)
+      .reply(200, `{"access_token": "FAKE_ACCESS_TOKEN"}`)
+
+      .get('/Users/uaa-id-253')
+      .reply(200, JSON.stringify({
+        ...JSON.parse(uaaData.user),
+        id: 'uaa-id-253',
+      }))
+
+      .get('/Users/uaa-user-edit-123456')
+      .reply(200, JSON.stringify({
+        ...JSON.parse(uaaData.user),
+        id: 'uaa-user-edit-123456',
+        origin: 'custom-origin-1',
+      }))
+
+      .get('/Users/uaa-user-changeperms-123456')
+      .reply(200, JSON.stringify({
+        ...JSON.parse(uaaData.user),
+        id: 'uaa-user-changeperms-123456',
+        origin: 'custom-origin-2',
+      }))
+
+      .get('/Users/99022be6-feb8-4f78-96f3-7d11f4d476f1')
+      .reply(200, JSON.stringify({
+        ...JSON.parse(uaaData.user),
+        id: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
+        origin: 'custom-origin-3',
+      }))
+    ;
+
     const response = await orgUsers.listUsers(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
     });
 
     expect(response.body).toContain('Team members');
+    expect(response.body).toContain('uaa');
+    expect(response.body).toContain('Custom-origin-1');
+    expect(response.body).toContain('Custom-origin-2');
+    expect(response.body).toContain('Custom-origin-3');
   });
 
   it('should show the invite page', async () => {

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -25,3 +25,8 @@ $govuk-global-styles: true;
 a {
  text-decoration: none;
 }
+
+ul.plain {
+  list-style: none;
+  padding-left: inherit;
+}


### PR DESCRIPTION
What
----

As an org manager or org auditor of an organisation I want to be able to
see who in my organisation has enabled single sign on, so I can enforce
a security policy.

I chose to introduce `ul.plain` because the regular `govuk-list` class
looks very strange on this page, when we move to GOV.UK Frontend 3.0 we
can address this page a bit more. I applied this class to the list of spaces because it was getting very messy for organisations with many spaces.

![image](https://user-images.githubusercontent.com/1482692/62477296-9b51f200-b7a0-11e9-9621-aab17a197278.png)
_Image of the updated Org / Users / Team Members page_

How to review
-------------

Code review

Concourse

[Preview](https://admin.tlwr.dev.cloudpipeline.digital/organisations/0fc56d0f-f83b-406c-bdca-953917911ba0/users)

Who can review
---------------

Not @tlwr
