### PR TITLE
Include protocol in `linkify` links

### DIFF
--- a/config/nunjucks.config.js
+++ b/config/nunjucks.config.js
@@ -60,8 +60,7 @@ function configure(env) {
       if (link.match(/apps[.]internal/)) {
         return link
       }
-
-      return `<a href="${link}" class="govuk-link">${link}</a>`;
+      return `<a href="https://${link}" class="govuk-link">${link}</a>`;
     });
   });
 }


### PR DESCRIPTION
What
----

At the moment links don't have the protocol on them, so they're treated
as relative (i.e. they link to
https://admin.cloud.service.gov.uk/blah/your-link)

Currently linkify is never called with anything that already has a
protocol, so there's no need to handle that case (although this is quite
lazy, admittedly).

How to review
-------------

* Code review
* Is it too lazy not to handle links that already have protocols?

Who can review
---------------

@tlwr