### PR TITLE
Fix team member table

### DIFF
--- a/src/components/org-users/_org-users.scss
+++ b/src/components/org-users/_org-users.scss
@@ -19,7 +19,7 @@ table.user-list {
   }
   .name {
     min-width: 280px;
-    width: 35%;
+    width: 20%;
   }
 
   .authentication {

--- a/stub-api/stub-apis-env.sh
+++ b/stub-api/stub-apis-env.sh
@@ -24,3 +24,5 @@ export AWS_REGION=eu-west-2
 export MS_CLIENT_ID=clientid
 export MS_CLIENT_SECRET=clientsecret
 export MS_TENANT_ID=tenantid
+export GOOGLE_CLIENT_ID=googleclientid
+export GOOGLE_CLIENT_SECRET=googleclientsecret

--- a/stub-api/stub-uaa.ts
+++ b/stub-api/stub-uaa.ts
@@ -68,13 +68,7 @@ function mockUAA(app: express.Application, config: IStubServerPorts): express.Ap
   );
 
   app.get(
-    `/Users/${userId}`,
-    (_req, res) => {
-      res.send(JSON.stringify(userPayload));
-    });
-
-  app.get(
-    `/Users/${otherUserId}`,
+    /\/Users\/[-a-z0-9]+/,
     (_req, res) => {
       res.send(JSON.stringify(userPayload));
     });


### PR DESCRIPTION
What
----

Fix table width CSS math on Team members page

I did not add numbers correctly so the sizing was off. The sizing is better now.

I also fixed the stub UAA server to return a UAA user payload for any guid, so you could actually view this page with the stub.

How to review
-------------

Code review

Maybe look at it using the stub?

[Preview](https://admin.tlwr.dev.cloudpipeline.digital/organisations/85a9bbf2-4d62-479c-a97b-ac3295a659cb/users)

Who can review
---------------

Not @tlwr
