### PR TITLE
Limit concurrency when requesting users from UAA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10542,7 +10542,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -10581,8 +10580,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-hash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "notifications-node-client": "^4.6.0",
     "nunjucks": "3.2.0",
     "openid-client": "^2.5.0",
+    "p-limit": "^2.2.0",
     "passport": "0.4.0",
     "passport-local": "1.0.0",
     "passport-oauth2": "1.5.0",

--- a/src/components/org-users/org-users.ts
+++ b/src/components/org-users/org-users.ts
@@ -246,9 +246,7 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
     accountsClient,
   );
 
-  const uaaUsers = await Promise.all(
-    userOrgRoles.map(u => uaa.getUser(u.metadata.guid)),
-  );
+  const uaaUsers = await uaa.getUsers(userOrgRoles.map(u => u.metadata.guid));
 
   const userOriginMapping: {[key: string]: string} = lodash
     .chain(uaaUsers)

--- a/src/lib/uaa/uaa.test.ts
+++ b/src/lib/uaa/uaa.test.ts
@@ -120,6 +120,23 @@ describe('lib/uaa test suite', () => {
     expect(user.id).toEqual(id);
   });
 
+  it('should retrieve multiple users successfully', async () => {
+    const client = new UAAClient(config);
+
+    nock(config.apiEndpoint)
+      .get(`/Users/user-a`)
+      .reply(200, { id: 'user-a' })
+      .get(`/Users/user-b`)
+      .reply(200, { id: 'user-b' })
+    ;
+
+    const users = await client.getUsers(['user-a', 'user-b']);
+
+    expect(users.length).toEqual(2);
+    expect(users[0].id).toEqual('user-a');
+    expect(users[1].id).toEqual('user-b');
+  });
+
   it('should authenticate a user', async () => {
     nock('https://example.com/uaa').persist()
     .post('/oauth/token').query((x: any) => x.grant_type === 'password')


### PR DESCRIPTION
What
----

For orgs with N users, it makes N requests to UAA in parallel, which is
very bursty and causes the page to be flakey. (When N is large)

UAA doesn't have a bulk get users function for multiple GUIDs, we have
to fetch each one individually.

Add a helper function to get multiple users, which uses the p-limit
library to limit promise concurrency, which I have arbitrarily set to 5.

How to review
-------------

Tests

Code review

[Preview](https://admin.tlwr.dev.cloudpipeline.digital/organisations/85a9bbf2-4d62-479c-a97b-ac3295a659cb/users)

Who can review
---------------

Not @tlwr
