### PR TITLE
Do not use username to add user to org

### DIFF
--- a/src/components/org-users/org-users.test.ts
+++ b/src/components/org-users/org-users.test.ts
@@ -245,7 +245,7 @@ describe('org-users test suite', () => {
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
       .reply(200, cfData.organization)
 
-      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users')
+      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
       .reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
 
       .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8?recursive=true')
@@ -304,7 +304,7 @@ describe('org-users test suite', () => {
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
       .reply(200, cfData.organization)
 
-      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users')
+      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
       .reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
 
       .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8?recursive=true')
@@ -361,7 +361,7 @@ describe('org-users test suite', () => {
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
       .reply(200, cfData.organization)
 
-      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users')
+      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
       .reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
 
       .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8?recursive=true')
@@ -416,7 +416,7 @@ describe('org-users test suite', () => {
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
       .reply(200, cfData.organization)
 
-      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users')
+      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
       .reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
 
       .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
@@ -471,7 +471,7 @@ describe('org-users test suite', () => {
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
       .reply(200, cfData.organization)
 
-      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users')
+      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
       .reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
 
       .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/developers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
@@ -526,7 +526,7 @@ describe('org-users test suite', () => {
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
       .reply(200, cfData.organization)
 
-      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users')
+      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
       .reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
 
       .put('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/auditors/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
@@ -582,7 +582,7 @@ describe('org-users test suite', () => {
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
       .reply(200, cfData.organization)
 
-      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users')
+      .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/users/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8')
       .reply(201, `{"metadata": {"guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275"}}`)
 
       .put('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/billing_managers/5ff19d4c-8fa0-4d74-94e0-52eac86d55a8?recursive=true')

--- a/src/components/org-users/org-users.ts
+++ b/src/components/org-users/org-users.ts
@@ -420,7 +420,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
       throw new ValidationError([{field: 'email', message: 'user is already a member of the organisation'}]);
     }
 
-    await cf.assignUserToOrganizationByUsername(params.organizationGUID, values.email);
+    await cf.assignUserToOrganization(params.organizationGUID, userGUID);
 
     await setAllUserRolesForOrg(
       cf,

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -51,7 +51,7 @@ nock('https://example.com/api').persist()
   .get('/v2/failure/500').reply(500, `FAKE_500`)
   .get('/v2/test').reply(200, `{"next_url":"/v2/test?page=2","resources":["a"]}`)
   .get('/v2/test?page=2').reply(200, `{"next_url":null,"resources":["b"]}`)
-  .put('/v2/organizations/guid-cb24b36d-4656-468e-a50d-b53113ac6177/users').reply(201, {
+  .put('/v2/organizations/guid-cb24b36d-4656-468e-a50d-b53113ac6177/users/uaa-id-236').reply(201, {
     metadata: {guid: 'guid-cb24b36d-4656-468e-a50d-b53113ac6177'},
   })
 ;
@@ -299,9 +299,9 @@ describe('lib/cf test suite', () => {
 
   test('should be able to assign a user to an organisation by username', async () => {
     const client = new CloudFoundryClient(config);
-    const organization = await client.assignUserToOrganizationByUsername(
+    const organization = await client.assignUserToOrganization(
       'guid-cb24b36d-4656-468e-a50d-b53113ac6177',
-      'user@example.com',
+      'uaa-id-236',
     );
 
     expect(organization.metadata.guid).toEqual('guid-cb24b36d-4656-468e-a50d-b53113ac6177');

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -268,8 +268,14 @@ export default class CloudFoundryClient {
     return response.data;
   }
 
-  public async assignUserToOrganizationByUsername(organizationGUID: string, username: string): Promise<cf.IResource> {
-    const response = await this.request('put', `/v2/organizations/${organizationGUID}/users`, {username});
+  public async assignUserToOrganization(
+    organizationGUID: string,
+    userGUID: string,
+  ): Promise<cf.IResource> {
+    const response = await this.request(
+      'put',
+      `/v2/organizations/${organizationGUID}/users/${userGUID}`,
+    );
     return response.data;
   }
 


### PR DESCRIPTION

What
----

We were using the username of the user to add them to the organisation.

We cannot do this in a single sign-on world

We should use the user GUID instead.

How to review
-------------

Code review

Concourse

Who can review
---------------

Not @tlwr
