### PR TITLE
[#167835719] Increase google analytics site speed sample rate

### DIFF
--- a/config/nunjucks.config.js
+++ b/config/nunjucks.config.js
@@ -67,11 +67,6 @@ function configure(env) {
       return `<a href="${protocolOrEmpty}${link}" class="govuk-link">${link}</a>`;
     });
   });
-
-  env.addFilter("inlinejs", (path) => {
-    const content = fs.readFileSync(path);
-    return `<script>${content}</script>`;
-  });
 }
 
 module.exports = configure;

--- a/config/nunjucks.config.js
+++ b/config/nunjucks.config.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const jmespath = require('jmespath');
 const showdown = require('showdown');
 const moment = require('moment');
@@ -38,7 +39,7 @@ function configure(env) {
       return singular;
     }
     return plural;
-  })
+  });
 
   env.addFilter('nicedate', (date) => {
     return moment(date).format('MMMM Do YYYY');
@@ -65,6 +66,11 @@ function configure(env) {
 
       return `<a href="${protocolOrEmpty}${link}" class="govuk-link">${link}</a>`;
     });
+  });
+
+  env.addFilter("inlinejs", (path) => {
+    const content = fs.readFileSync(path);
+    return `<script>${content}</script>`;
   });
 }
 

--- a/src/components/app/app.csp.ts
+++ b/src/components/app/app.csp.ts
@@ -1,13 +1,3 @@
-import crypto from 'crypto';
-import fs from 'fs';
-
-function hashOfFile(path: string): string {
-  const hasher = crypto.createHash('sha256');
-  const content = fs.readFileSync(path, {encoding: 'utf-8'});
-  hasher.update(content);
-  return `'sha256-${hasher.digest('base64')}'`;
-}
-
 export default {
   directives: {
     defaultSrc: [
@@ -23,8 +13,6 @@ export default {
       `'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='`,
       'www.google-analytics.com',
       'www.googletagmanager.com',
-      // this file is inlined by Nunjucks, but we keep it external to make hashing it easier
-      hashOfFile('./src/frontend/javascript/analytics.js'),
     ],
     imgSrc: [
       `'self'`,

--- a/src/components/app/app.csp.ts
+++ b/src/components/app/app.csp.ts
@@ -14,7 +14,7 @@ export default {
       'www.google-analytics.com',
       'www.googletagmanager.com',
       // Inline script tag for Google Analytics
-      `'sha256-H7q7hXqike7Yb27lFO21Pk6233UiAy/pJJ9TDT6RrBM='`,
+      `'sha256-R72vvzs/ra+fVicBe+lyndYF4e3bdTEHbbV03txBUtc='`, // Inline script tag in page head
     ],
     imgSrc: [
       `'self'`,

--- a/src/components/app/app.csp.ts
+++ b/src/components/app/app.csp.ts
@@ -1,3 +1,13 @@
+import crypto from 'crypto';
+import fs from 'fs';
+
+function hashOfFile(path: string): string {
+  const hasher = crypto.createHash('sha256');
+  const content = fs.readFileSync(path, {encoding: 'utf-8'});
+  hasher.update(content);
+  return `'sha256-${hasher.digest('base64')}'`;
+}
+
 export default {
   directives: {
     defaultSrc: [
@@ -9,12 +19,12 @@ export default {
     ],
     scriptSrc: [
       `'self'`,
-      `'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='`, // Inline script tag in govuk_template
-      `'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='`, // Inline script tag in govuk_template
+      // node_modules/govuk-frontend/template.njk, xpath: //html/body/script[1]
+      `'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='`,
       'www.google-analytics.com',
       'www.googletagmanager.com',
-      // Inline script tag for Google Analytics
-      `'sha256-R72vvzs/ra+fVicBe+lyndYF4e3bdTEHbbV03txBUtc='`, // Inline script tag in page head
+      // this file is inlined by Nunjucks, but we keep it external to make hashing it easier
+      hashOfFile('./src/frontend/javascript/analytics.js'),
     ],
     imgSrc: [
       `'self'`,

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -8,6 +8,7 @@ import Router, { IParameters } from '../../lib/router';
 import * as uaaData from '../../lib/uaa/uaa.test.data';
 
 import init from './app';
+import csp from './app.csp';
 import { config } from './app.test.config';
 import { IContext, initContext } from './context';
 import router from './router';
@@ -170,13 +171,38 @@ describe('app test suite', () => {
 
       it('should have a Content Security Policy set', () => {
         expect(response.header['content-security-policy']).toContain(
-          `default-src 'none'; style-src 'self' 'unsafe-inline'; ` +
-          `script-src 'self' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' ` +
-          `'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' www.google-analytics.com ` +
-          `www.googletagmanager.com 'sha256-H7q7hXqike7Yb27lFO21Pk6233UiAy/pJJ9TDT6RrBM='; ` +
-          `img-src 'self' www.google-analytics.com; ` +
-          `connect-src 'self' www.google-analytics.com; frame-src 'self'; font-src 'self' data:; ` +
-          `object-src 'self'; media-src 'self'`,
+          `default-src ${csp.directives.defaultSrc.join(' ')}`,
+        );
+        expect(response.header['content-security-policy']).toContain(
+          `style-src ${csp.directives.styleSrc.join(' ')}`,
+        );
+
+        expect(response.header['content-security-policy']).toContain(
+          `script-src ${csp.directives.scriptSrc.join(' ')}`,
+        );
+
+        expect(response.header['content-security-policy']).toContain(
+          `img-src ${csp.directives.imgSrc.join(' ')}`,
+        );
+
+        expect(response.header['content-security-policy']).toContain(
+          `connect-src ${csp.directives.connectSrc.join(' ')}`,
+        );
+
+        expect(response.header['content-security-policy']).toContain(
+          `frame-src ${csp.directives.frameSrc.join(' ')}`,
+        );
+
+        expect(response.header['content-security-policy']).toContain(
+          `font-src ${csp.directives.fontSrc.join(' ')}`,
+        );
+
+        expect(response.header['content-security-policy']).toContain(
+          `object-src ${csp.directives.objectSrc.join(' ')}`,
+        );
+
+        expect(response.header['content-security-policy']).toContain(
+          `media-src ${csp.directives.mediaSrc.join(' ')}`,
         );
       });
 

--- a/src/frontend/javascript/analytics.js
+++ b/src/frontend/javascript/analytics.js
@@ -1,0 +1,19 @@
+// Pull dimensions vals from meta ; else all script/origin combinations have to be in the CSP
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+var config = {
+  // Paas-admin gets a relatively small number
+  // of visits daily, so the default site speed
+  // sample rate of 1% gives us too few data points.
+  // Settings it to 30% gives us more data.
+  siteSpeedSampleRate: 30
+};
+
+var originTag = document.querySelector('meta[name="x-user-identity-origin"]')
+if (originTag && originTag.content) {
+  config['dimension1'] = originTag.content;
+}
+
+gtag('config', 'UA-43115970-5', config);

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -25,14 +25,20 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    var dimensions = {};
+    var config = {
+        // Paas-admin gets a relatively small number
+        // of visits daily, so the default site speed
+        // sample rate of 1% gives us too few data points.
+        // Settings it to 30% gives us more data.
+        siteSpeedSampleRate: 30
+    };
 
     var originTag = document.querySelector('meta[name="x-user-identity-origin"]')
     if (originTag && originTag.content) {
-      dimensions['dimension1'] = originTag.content;
+        config['dimension1'] = originTag.content;
     }
 
-    gtag('config', 'UA-43115970-5', dimensions);
+    gtag('config', 'UA-43115970-5', config);
   </script>
 
   <!--[if !IE 8]><!-->

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -19,27 +19,9 @@
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-43115970-5"></script>
 
-  <!-- Pull dimensions vals from meta ; else all script/origin combinations have to be in the CSP -->
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    var config = {
-        // Paas-admin gets a relatively small number
-        // of visits daily, so the default site speed
-        // sample rate of 1% gives us too few data points.
-        // Settings it to 30% gives us more data.
-        siteSpeedSampleRate: 30
-    };
-
-    var originTag = document.querySelector('meta[name="x-user-identity-origin"]')
-    if (originTag && originTag.content) {
-        config['dimension1'] = originTag.content;
-    }
-
-    gtag('config', 'UA-43115970-5', config);
-  </script>
+  {# Inlining JS because it should be inline, but we want to be able to easily #}
+  {# generate a SHA-256 hash of its contents to go in the CSP headers #}
+  {{ "./src/frontend/javascript/analytics.js"|inlinejs|safe }}
 
   <!--[if !IE 8]><!-->
     <link href="./govuk.screen.scss" media="screen" rel="stylesheet" />

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -18,10 +18,7 @@
   <meta name="x-user-identity-origin" content="{{context.origin}}" />
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-43115970-5"></script>
-
-  {# Inlining JS because it should be inline, but we want to be able to easily #}
-  {# generate a SHA-256 hash of its contents to go in the CSP headers #}
-  {{ "./src/frontend/javascript/analytics.js"|inlinejs|safe }}
+  <script async src="/assets/analytics.js"></script>
 
   <!--[if !IE 8]><!-->
     <link href="./govuk.screen.scss" media="screen" rel="stylesheet" />


### PR DESCRIPTION
What
----
Adds the `siteSpeedSampleRate` to the Google Analytics config. Also improves how we generate the CSP.

How to review
-------------

1. Code review
2. Deploy and check I didn't break the CSP. 

We can't really review the impact of the config change immediately. We'll have to wait a little to test that.

Who can review
---------------
Anyone