### PR TITLE
Do not use shared state or shared mocks

### DIFF
--- a/src/components/applications/applications.test.ts
+++ b/src/components/applications/applications.test.ts
@@ -7,23 +7,47 @@ import {createTestContext} from '../app/app.test-helpers';
 import {IContext} from '../app/context';
 
 describe('applications test suite', () => {
-  nock('https://example.com/api').persist()
-    .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9/user_roles').times(1).reply(200, data.userRolesForOrg)
-    .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123').times(1).reply(200, data.app)
-    .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/summary').times(1).reply(200, data.appSummary)
-    .get('/v2/apps/646f636b-6572-0d0a-8697-86641668c123').times(1).reply(200, data.dockerApp)
-    .get('/v2/apps/646f636b-6572-0d0a-8697-86641668c123/summary').times(1).reply(200, data.dockerAppSummary)
-    .get('/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7').times(1).reply(200, data.appUsingCflinuxfs2)
-    .get('/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7/summary').times(1).reply(200, data.appSummaryUsingCflinuxfs2)
-    .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52').times(1).reply(200, data.space)
-    .get('/v2/spaces/1053174d-eb79-4f16-bf82-9f83a52d6e84').times(1).reply(200, data.space)
-    .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9').times(1).reply(200, data.organization)
-    .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728').times(1).reply(200, data.stack)
-    .get('/v2/stacks/dd63d39a-85f8-48ef-bb73-89097192cfcb').times(1).reply(200, data.stackCflinuxfs2);
+
+  let nockCF: nock.Scope;
+
+  beforeEach(() => {
+    nock.cleanAll();
+
+    nockCF = nock('https://example.com/api');
+
+    nockCF
+      .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9/user_roles')
+      .times(2)
+      .reply(200, data.userRolesForOrg)
+
+      .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9')
+      .reply(200, data.organization)
+    ;
+  });
+
+  afterEach(() => {
+    nockCF.done();
+
+    nock.cleanAll();
+  });
 
   const ctx: IContext = createTestContext();
 
   it('should show the application overview page', async () => {
+    nockCF
+      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123')
+      .reply(200, data.app)
+
+      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/summary')
+      .reply(200, data.appSummary)
+
+      .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52')
+      .reply(200, data.space)
+
+      .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728')
+      .reply(200, data.stack)
+    ;
+
     const response = await viewApplication(ctx, {
       applicationGUID: '15b3885d-0351-4b9b-8697-86641668c123',
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
@@ -34,6 +58,20 @@ describe('applications test suite', () => {
   });
 
   it('should say the name of the stack being used', async () => {
+    nockCF
+      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123')
+      .reply(200, data.app)
+
+      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/summary')
+      .reply(200, data.appSummary)
+
+      .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52')
+      .reply(200, data.space)
+
+      .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728')
+      .reply(200, data.stack)
+    ;
+
     const response = await viewApplication(ctx, {
       applicationGUID: '15b3885d-0351-4b9b-8697-86641668c123',
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
@@ -48,6 +86,20 @@ describe('applications test suite', () => {
   });
 
   it('should say the name of the docker image being used', async () => {
+    nockCF
+      .get('/v2/apps/646f636b-6572-0d0a-8697-86641668c123')
+      .reply(200, data.dockerApp)
+
+      .get('/v2/apps/646f636b-6572-0d0a-8697-86641668c123/summary')
+      .reply(200, data.dockerAppSummary)
+
+      .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52')
+      .reply(200, data.space)
+
+      .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728')
+      .reply(200, data.stack)
+    ;
+
     const response = await viewApplication(ctx, {
       applicationGUID: '646f636b-6572-0d0a-8697-86641668c123',
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
@@ -62,6 +114,20 @@ describe('applications test suite', () => {
   });
 
   it('should say a warning if the cflinuxfs2 stack is being used', async () => {
+    nockCF
+      .get('/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7')
+      .reply(200, data.appUsingCflinuxfs2)
+
+      .get('/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7/summary')
+      .reply(200, data.appSummaryUsingCflinuxfs2)
+
+      .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52')
+      .reply(200, data.space)
+
+      .get('/v2/stacks/dd63d39a-85f8-48ef-bb73-89097192cfcb')
+      .reply(200, data.stackCflinuxfs2)
+    ;
+
     const response = await viewApplication(ctx, {
       applicationGUID: 'ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7',
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',

--- a/src/components/org-users/get-user-roles-by-guid.test.ts
+++ b/src/components/org-users/get-user-roles-by-guid.test.ts
@@ -23,22 +23,15 @@ describe('_getUserRolesByGuid', () => {
   let nockAccounts: nock.Scope;
 
   beforeEach(() => {
-    nockAccounts = nock(ctx.app.accountsAPI).persist();
+    nock.cleanAll();
 
-    nockAccounts
-      .get('/users/some-user-guid-0')
-      .reply(200, JSON.stringify({
-        user_uuid: 'some-user-guid-0',
-        user_email: 'some-user-guid-0@fake.digital.cabinet-office.gov.uk',
-        username: 'some-fake-username-from-paas-accounts',
-      }))
+    nockAccounts = nock(ctx.app.accountsAPI);
+  });
 
-      .get('/users/some-user-guid-1')
-      .reply(404)
+  afterEach(() => {
+    nockAccounts.done();
 
-      .get('/users/some-user-guid-2')
-      .reply(404)
-    ;
+    nock.cleanAll();
   });
 
   it('should return an empty map if there are no users', async () => {
@@ -56,6 +49,14 @@ describe('_getUserRolesByGuid', () => {
   });
 
   it('should return org roles of a user that has no space access', async () => {
+    nockAccounts
+      .get('/users/some-user-guid')
+      .reply(200, JSON.stringify({
+        user_uuid: 'some-user-guid',
+        user_email: 'some-user-guid@fake.digital.cabinet-office.gov.uk',
+        username: 'some-user-name',
+      }))
+    ;
     const userOrgRoles: any = [
       {
         metadata: {guid: 'some-user-guid'},
@@ -81,6 +82,14 @@ describe('_getUserRolesByGuid', () => {
   });
 
   it('should return roles and space of a user that has access to one space', async () => {
+    nockAccounts
+      .get('/users/some-user-guid')
+      .reply(200, JSON.stringify({
+        user_uuid: 'some-user-guid',
+        user_email: 'some-user-guid@fake.digital.cabinet-office.gov.uk',
+        username: 'some-user-name',
+      }))
+    ;
     const userOrgRoles: any = [
       {
         metadata: {guid: 'some-user-guid'},
@@ -113,6 +122,14 @@ describe('_getUserRolesByGuid', () => {
   });
 
   it('should return roles and spaces of a user that has access to multiple spaces', async () => {
+    nockAccounts
+      .get('/users/some-user-guid')
+      .reply(200, JSON.stringify({
+        user_uuid: 'some-user-guid',
+        user_email: 'some-user-guid@fake.digital.cabinet-office.gov.uk',
+        username: 'some-user-name',
+      }))
+    ;
     const userOrgRoles: any = [
       {
         metadata: {guid: 'some-user-guid'},
@@ -145,6 +162,20 @@ describe('_getUserRolesByGuid', () => {
   });
 
   it('should return users, roles and spaces of multiple users', async () => {
+    nockAccounts
+      .get('/users/some-user-guid-0')
+      .reply(200, JSON.stringify({
+        user_uuid: 'some-user-guid-0',
+        user_email: 'some-user-guid-0@fake.digital.cabinet-office.gov.uk',
+        username: 'some-fake-username-from-paas-accounts',
+      }))
+
+      .get('/users/some-user-guid-1')
+      .reply(404)
+
+      .get('/users/some-user-guid-2')
+      .reply(404)
+    ;
     const userOrgRoles: any = [0, 1, 2].map(i => (
       {
         metadata: {guid: `some-user-guid-${i}`},
@@ -188,6 +219,17 @@ describe('_getUserRolesByGuid', () => {
   });
 
   it('should get the user\'s username from accounts, falling back to UAA', async () => {
+    nockAccounts
+      .get('/users/some-user-guid-0')
+      .reply(200, JSON.stringify({
+        user_uuid: 'some-user-guid-0',
+        user_email: 'some-user-guid-0@fake.digital.cabinet-office.gov.uk',
+        username: 'some-fake-username-from-paas-accounts',
+      }))
+
+      .get('/users/some-user-guid-1')
+      .reply(404)
+    ;
     const userOrgRoles: any = [0, 1].map(i => (
       {
         metadata: {guid: `some-user-guid-${i}`},

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -9,12 +9,14 @@ import {IContext} from '../app/context';
 const ctx: IContext = createTestContext();
 
 describe('spaces test suite', () => {
+  let nockAccounts: nock.Scope;
   let nockCF: nock.Scope;
 
   beforeEach(() => {
     nock.cleanAll();
 
     nockCF = nock('https://example.com/api');
+    nockAccounts = nock('https://example.com/accounts');
 
     nockCF
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
@@ -23,12 +25,21 @@ describe('spaces test suite', () => {
   });
 
   afterEach(() => {
+    nockAccounts.done();
     nockCF.done();
 
     nock.cleanAll();
   });
 
   it('should show the spaces pages', async () => {
+    nockAccounts
+      .get('/users/uaa-id-253').reply(200, JSON.stringify({
+        user_uuid: 'uaa-id-253',
+        username: 'uaa-id-253@fake.digital.cabinet-office.gov.uk',
+        user_email: 'uaa-id-253@fake.digital.cabinet-office.gov.uk',
+      }))
+    ;
+
     nockCF
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
       .reply(200, data.spaces)

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -6,57 +6,79 @@ import * as data from '../../lib/cf/cf.test.data';
 import {createTestContext} from '../app/app.test-helpers';
 import {IContext} from '../app/context';
 
-// tslint:disable:max-line-length
-nock('https://example.com/api').persist()
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, data.organization)
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').reply(200, data.spaces)
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, data.users)
-  .get('/v2/quota_definitions/dcb680a9-b190-4838-a3d2-b84aa17517a6').reply(200, data.organizationQuota)
-  .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/apps').reply(200, data.apps)
-  .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/summary').reply(200, data.spaceSummary)
-  .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/summary').reply(200, data.spaceSummary)
-  .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9').reply(200, data.organization)
-  .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/apps').reply(200, data.apps)
-  .get('/v2/apps/cd897c8c-3171-456d-b5d7-3c87feeabbd1/summary').reply(200, data.appSummary)
-  .get('/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/summary').reply(200, data.appSummary)
-  .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/service_instances').reply(200, data.services)
-  .get('/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab').reply(200, data.servicePlan)
-  .get('/v2/services/775d0046-7505-40a4-bfad-ca472485e332').reply(200, data.service)
-  .get('/v2/user_provided_service_instances?q=space_guid:bc8d3381-390d-4bd7-8c71-25309900a2e3').reply(200, data.services)
-  .get('/v2/stacks').reply(200, data.spaces)
-  .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3').reply(200, data.space)
-  .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').reply(200, data.spaceQuota);
-
-nock('https://example.com/accounts').persist()
-  .get('/users/uaa-id-253').reply(200, JSON.stringify({
-    user_uuid: 'uaa-id-253',
-    username: 'uaa-id-253@fake.digital.cabinet-office.gov.uk',
-    user_email: 'uaa-id-253@fake.digital.cabinet-office.gov.uk',
-  }));
-// tslint:enable:max-line-length
-
 const ctx: IContext = createTestContext();
 
 describe('spaces test suite', () => {
+  let nockCF: nock.Scope;
+
+  beforeEach(() => {
+    nock.cleanAll();
+
+    nockCF = nock('https://example.com/api');
+
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
+      .reply(200, data.organization)
+    ;
+  });
+
+  afterEach(() => {
+    nockCF.done();
+
+    nock.cleanAll();
+  });
+
   it('should show the spaces pages', async () => {
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
+      .reply(200, data.spaces)
+
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .times(3)
+      .reply(200, data.users)
+
+      .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019')
+      .reply(200, data.spaceQuota)
+
+      .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/apps')
+      .reply(200, data.apps)
+
+      .get('/v2/stacks')
+      .reply(200, data.spaces)
+
+      .get('/v2/quota_definitions/dcb680a9-b190-4838-a3d2-b84aa17517a6')
+      .reply(200, data.organizationQuota)
+
+      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/apps')
+      .reply(200, data.apps)
+    ;
     const response = await spaces.listSpaces(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
     });
 
     expect(response.body).toContain('Spaces');
-  });
-
-  it('should show the spaces page application counter', async () => {
-    const response = await spaces.listSpaces(ctx, {
-      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-    });
-
     expect(response.body).toContain('has 1 apps');
-
     expect(response.body).toContain('2gb');
   });
 
   it('should show list of applications in space', async () => {
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .times(2)
+      .reply(200, data.users)
+
+      .get('/v2/stacks')
+      .reply(200, data.spaces)
+
+      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/apps')
+      .reply(200, data.apps)
+
+      .get('/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/summary')
+      .reply(200, data.appSummary)
+
+      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3')
+      .reply(200, data.space)
+    ;
     const response = await spaces.listApplications(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
       spaceGUID: 'bc8d3381-390d-4bd7-8c71-25309900a2e3',
@@ -66,6 +88,27 @@ describe('spaces test suite', () => {
   });
 
   it('should show list of services in space', async () => {
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .times(2)
+      .reply(200, data.users)
+
+      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/service_instances')
+      .reply(200, data.services)
+
+      .get('/v2/user_provided_service_instances?q=space_guid:bc8d3381-390d-4bd7-8c71-25309900a2e3')
+      .reply(200, data.services)
+
+      .get('/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab')
+      .reply(200, data.servicePlan)
+
+      .get('/v2/services/775d0046-7505-40a4-bfad-ca472485e332')
+      .reply(200, data.service)
+
+      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3')
+      .reply(200, data.space)
+    ;
+
     const response = await spaces.listBackingServices(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
       spaceGUID: 'bc8d3381-390d-4bd7-8c71-25309900a2e3',

--- a/src/components/spaces/spaces.ts
+++ b/src/components/spaces/spaces.ts
@@ -219,6 +219,12 @@ async function hydrateAccountsUsernames(
 
   const users = await Promise.all(userRoles.map(async (user: IOrganizationUserRoles) => {
     const accountsUser = await accountsClient.getUser(user.metadata.guid);
+
+    const username: string = accountsUser && accountsUser.username
+      ? accountsUser.username
+      : user.entity.username
+    ;
+
     return {
       entity: {
         active: user.entity.active,
@@ -232,7 +238,7 @@ async function hydrateAccountsUsernames(
         organization_roles: user.entity.organization_roles,
         organizations_url: user.entity.organizations_url,
         spaces_url: user.entity.spaces_url,
-        username: accountsUser && accountsUser.username ? accountsUser.username : user.entity.username,
+        username,
       },
       metadata: user.metadata,
     };

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -29,7 +29,7 @@ describe('lib/cf test suite', () => {
     nock.cleanAll();
   });
 
-  test('should fail to get token client without accessToken or clientCredentials', async () => {
+  it('should fail to get token client without accessToken or clientCredentials', async () => {
     const client = new CloudFoundryClient({
       apiEndpoint: 'https://example.com/api',
       logger: pino({level: 'silent'}),
@@ -37,7 +37,7 @@ describe('lib/cf test suite', () => {
     await expect(client.getAccessToken()).rejects.toThrow(/accessToken or clientCredentials are required/);
   });
 
-  test('should get token from tokenEndpoint in info', async () => {
+  it('should get token from tokenEndpoint in info', async () => {
     nockCF
       .get('/v2/info')
       .reply(200, data.info)
@@ -58,7 +58,7 @@ describe('lib/cf test suite', () => {
     expect(await client.getAccessToken()).toEqual('TOKEN_FROM_ENDPOINT');
   });
 
-  test('should create a client correctly', async () => {
+  it('should create a client correctly', async () => {
     nockCF
       .get('/v2/info')
       .reply(200, data.info)
@@ -69,7 +69,7 @@ describe('lib/cf test suite', () => {
     expect(info.version).toEqual(2);
   });
 
-  test('should iterate over all pages to gather resources', async () => {
+  it('should iterate over all pages to gather resources', async () => {
     nockCF
       .get('/v2/test')
       .reply(200, `{"next_url":"/v2/test?page=2","resources":["a"]}`)
@@ -85,7 +85,7 @@ describe('lib/cf test suite', () => {
     expect(collection[1]).toEqual('b');
   });
 
-  test('should throw an error when receiving 404', async () => {
+  it('should throw an error when receiving 404', async () => {
     nockCF
       .get('/v2/failure/404')
       .reply(404, `{"error": "FAKE_404"}`)
@@ -95,7 +95,7 @@ describe('lib/cf test suite', () => {
     await expect(client.request('get', '/v2/failure/404')).rejects.toThrow(/FAKE_404/);
   });
 
-  test('should throw an error when encountering unrecognised error', async () => {
+  it('should throw an error when encountering unrecognised error', async () => {
     nockCF
       .get('/v2/failure/500')
       .reply(500, `FAKE_500`)
@@ -105,7 +105,7 @@ describe('lib/cf test suite', () => {
     await expect(client.request('get', '/v2/failure/500')).rejects.toThrow(/status 500/);
   });
 
-  test('should create an organisation', async () => {
+  it('should create an organisation', async () => {
     nockCF
       .post('/v2/organizations')
       .reply(201, data.organization)
@@ -119,7 +119,7 @@ describe('lib/cf test suite', () => {
     expect(organization.entity.name).toEqual('the-system_domain-org-name');
   });
 
-  test('should obtain list of organisations', async () => {
+  it('should obtain list of organisations', async () => {
     nockCF
       .get('/v2/organizations')
       .reply(200, data.organizations)
@@ -132,7 +132,7 @@ describe('lib/cf test suite', () => {
     expect(organizations[0].entity.name).toEqual('the-system_domain-org-name');
   });
 
-  test('should obtain single organisation', async () => {
+  it('should obtain single organisation', async () => {
     nockCF
       .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20')
       .reply(200, data.organization)
@@ -144,7 +144,7 @@ describe('lib/cf test suite', () => {
     expect(organization.entity.name).toEqual('the-system_domain-org-name');
   });
 
-  test('should delete an organisation', async () => {
+  it('should delete an organisation', async () => {
     nockCF
       .delete('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20?recursive=true&async=false')
       .reply(204)
@@ -158,7 +158,7 @@ describe('lib/cf test suite', () => {
     });
   });
 
-  test('should list all quota definitions', async () => {
+  it('should list all quota definitions', async () => {
     nockCF
       .get('/v2/quota_definitions')
       .reply(200, data.organizations)
@@ -171,7 +171,7 @@ describe('lib/cf test suite', () => {
     expect(quotas[0].entity.name).toEqual('the-system_domain-org-name');
   });
 
-  test('should filter quota definitions', async () => {
+  it('should filter quota definitions', async () => {
     nockCF
       .get('/v2/quota_definitions?q=name:the-system_domain-org-name')
       .reply(200, data.organizations)
@@ -184,7 +184,7 @@ describe('lib/cf test suite', () => {
     expect(quotas[0].entity.name).toEqual('the-system_domain-org-name');
   });
 
-  test('should obtain organisation quota', async () => {
+  it('should obtain organisation quota', async () => {
     nockCF
       .get('/v2/quota_definitions/80f3e539-a8c0-4c43-9c72-649df53da8cb')
       .reply(200, data.organizationQuota)
@@ -196,7 +196,7 @@ describe('lib/cf test suite', () => {
     expect(quota.entity.name).toEqual('name-1996');
   });
 
-  test('should obtain list of spaces', async () => {
+  it('should obtain list of spaces', async () => {
     nockCF
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
       .reply(200, data.spaces)
@@ -209,7 +209,7 @@ describe('lib/cf test suite', () => {
     expect(spaces[0].entity.name).toEqual('name-1774');
   });
 
-  test('should obtain single space', async () => {
+  it('should obtain single space', async () => {
     nockCF
       .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3')
       .reply(200, data.space)
@@ -221,7 +221,7 @@ describe('lib/cf test suite', () => {
     expect(space.entity.name).toEqual('name-2064');
   });
 
-  test('should obtain single space', async () => {
+  it('should obtain single space', async () => {
     nockCF
       .get('/v2/spaces/50ae42f6-346d-4eca-9e97-f8c9e04d5fbe/summary')
       .reply(200, data.spaceSummary)
@@ -233,7 +233,7 @@ describe('lib/cf test suite', () => {
     expect(space.name).toEqual('name-1382');
   });
 
-  test('should obtain space quota', async () => {
+  it('should obtain space quota', async () => {
     nockCF
       .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019')
       .reply(200, data.spaceQuota)
@@ -245,7 +245,7 @@ describe('lib/cf test suite', () => {
     expect(quota.entity.name).toEqual('name-1491');
   });
 
-  test('should obtain list of spaces for specific user in given org', async () => {
+  it('should obtain list of spaces for specific user in given org', async () => {
     nockCF
       .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275')
       .reply(200, data.spaces)
@@ -258,7 +258,7 @@ describe('lib/cf test suite', () => {
     expect(spaces[0].entity.name).toEqual('name-1774');
   });
 
-  test('should obtain list of apps', async () => {
+  it('should obtain list of apps', async () => {
     nockCF
       .get('/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps')
       .reply(200, data.apps)
@@ -271,7 +271,7 @@ describe('lib/cf test suite', () => {
     expect(apps[0].entity.name).toEqual('name-2131');
   });
 
-  test('should obtain particular app', async () => {
+  it('should obtain particular app', async () => {
     nockCF
       .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123')
       .reply(200, data.app)
@@ -283,7 +283,7 @@ describe('lib/cf test suite', () => {
     expect(app.entity.name).toEqual('name-2401');
   });
 
-  test('should obtain app summary', async () => {
+  it('should obtain app summary', async () => {
     nockCF
       .get('/v2/apps/cd897c8c-3171-456d-b5d7-3c87feeabbd1/summary')
       .reply(200, data.appSummary)
@@ -295,7 +295,7 @@ describe('lib/cf test suite', () => {
     expect(app.name).toEqual('name-79');
   });
 
-  test('should obtain list of services', async () => {
+  it('should obtain list of services', async () => {
     nockCF
       .get('/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances')
       .reply(200, data.services)
@@ -308,7 +308,7 @@ describe('lib/cf test suite', () => {
     expect(services[0].entity.name).toEqual('name-2104');
   });
 
-  test('should obtain particular service instance', async () => {
+  it('should obtain particular service instance', async () => {
     nockCF
       .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92')
       .reply(200, data.serviceInstance)
@@ -320,7 +320,7 @@ describe('lib/cf test suite', () => {
     expect(serviceInstance.entity.name).toEqual('name-1508');
   });
 
-  test('should obtain particular service plan', async () => {
+  it('should obtain particular service plan', async () => {
     nockCF
       .get('/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332')
       .reply(200, data.servicePlan)
@@ -332,7 +332,7 @@ describe('lib/cf test suite', () => {
     expect(servicePlan.entity.name).toEqual('name-1573');
   });
 
-  test('should obtain particular service', async () => {
+  it('should obtain particular service', async () => {
     nockCF
       .get('/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5')
       .reply(200, data.service)
@@ -344,7 +344,7 @@ describe('lib/cf test suite', () => {
     expect(service.entity.label).toEqual('label-58');
   });
 
-  test('should create a user', async () => {
+  it('should create a user', async () => {
     nockCF
       .post('/v2/users')
       .reply(200, data.user)
@@ -355,7 +355,7 @@ describe('lib/cf test suite', () => {
     expect(user.metadata.guid).toEqual('guid-cb24b36d-4656-468e-a50d-b53113ac6177');
   });
 
-  test('should delete a user', async () => {
+  it('should delete a user', async () => {
     nockCF
       .delete('/v2/users/guid-cb24b36d-4656-468e-a50d-b53113ac6177?async=false')
       .reply(204)
@@ -365,7 +365,7 @@ describe('lib/cf test suite', () => {
     expect(async () => client.deleteUser('guid-cb24b36d-4656-468e-a50d-b53113ac6177')).not.toThrowError();
   });
 
-  test('should obtain a user summary', async () => {
+  it('should obtain a user summary', async () => {
     nockCF
       .get('/v2/users/uaa-id-253/summary')
       .reply(200, data.userSummary)
@@ -380,7 +380,7 @@ describe('lib/cf test suite', () => {
     expect(summary.entity.audited_organizations.length === 1).toBeTruthy();
   });
 
-  test('should obtain list of user roles for organisation', async () => {
+  it('should obtain list of user roles for organisation', async () => {
     nockCF
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
       .reply(200, data.userRolesForOrg)
@@ -394,7 +394,7 @@ describe('lib/cf test suite', () => {
     expect(users[0].entity.organization_roles.length).toEqual(4);
   });
 
-  test('should obtain list of user roles for space', async () => {
+  it('should obtain list of user roles for space', async () => {
     nockCF
       .get('/v2/spaces/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
       .reply(200, data.userRolesForSpace)
@@ -408,7 +408,7 @@ describe('lib/cf test suite', () => {
     expect(users[0].entity.space_roles.length).toEqual(3);
   });
 
-  test('should be able to assign a user to an organisation by username', async () => {
+  it('should be able to assign a user to an organisation by username', async () => {
     nockCF
       .put('/v2/organizations/guid-cb24b36d-4656-468e-a50d-b53113ac6177/users/uaa-id-236')
       .reply(201, {
@@ -425,7 +425,7 @@ describe('lib/cf test suite', () => {
     expect(organization.metadata.guid).toEqual('guid-cb24b36d-4656-468e-a50d-b53113ac6177');
   });
 
-  test('should be able to set user org roles', async () => {
+  it('should be able to set user org roles', async () => {
     nockCF
       .put('/v2/organizations/beb082da-25e1-4329-88c9-bea2d809729d/users/uaa-id-236?recursive=true')
       .reply(201, data.userRoles)
@@ -437,7 +437,7 @@ describe('lib/cf test suite', () => {
     expect(users.entity.name).toEqual('name-1753');
   });
 
-  test('should be able to remove user org roles', async () => {
+  it('should be able to remove user org roles', async () => {
     nockCF
       .delete('/v2/organizations/beb082da-25e1-4329-88c9-bea2d809729d/users/uaa-id-236?recursive=true')
       .reply(204, {})
@@ -450,7 +450,7 @@ describe('lib/cf test suite', () => {
     expect(Object.keys(roles).length).toEqual(0);
   });
 
-  test('should be able to set user space roles', async () => {
+  it('should be able to set user space roles', async () => {
     nockCF
       .put('/v2/spaces/594c1fa9-caed-454b-9ed8-643a093ff91d/developer/uaa-id-381')
       .reply(201, data.userRoles)
@@ -462,7 +462,7 @@ describe('lib/cf test suite', () => {
     expect(users.entity.name).toEqual('name-1753');
   });
 
-  test('should be able to remove user space roles', async () => {
+  it('should be able to remove user space roles', async () => {
     nockCF
       .delete('/v2/spaces/594c1fa9-caed-454b-9ed8-643a093ff91d/developer/uaa-id-381')
       .reply(204, {})
@@ -474,7 +474,7 @@ describe('lib/cf test suite', () => {
     expect(Object.keys(users).length).toEqual(0);
   });
 
-  test('should obtain list of user roles for organisation and not find logged in user', async () => {
+  it('should obtain list of user roles for organisation and not find logged in user', async () => {
     nockCF
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
       .reply(200, data.userRolesForOrg)
@@ -490,7 +490,7 @@ describe('lib/cf test suite', () => {
     expect(hasRole).toBeFalsy();
   });
 
-  test('should obtain list of user provided services', async () => {
+  it('should obtain list of user provided services', async () => {
     nockCF
       .get('/v2/user_provided_service_instances?q=space_guid:594c1fa9-caed-454b-9ed8-643a093ff91d')
       .reply(200, data.userServices)
@@ -503,7 +503,7 @@ describe('lib/cf test suite', () => {
     expect(services[0].entity.name).toEqual('name-1696');
   });
 
-  test('should obtain user provided service', async () => {
+  it('should obtain user provided service', async () => {
     nockCF
       .get('/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87')
       .reply(200, data.userServiceInstance)
@@ -515,7 +515,7 @@ describe('lib/cf test suite', () => {
     expect(service.entity.name).toEqual('name-1700');
   });
 
-  test('should obtain list of stacks', async () => {
+  it('should obtain list of stacks', async () => {
     nockCF
       .get('/v2/stacks')
       .reply(200, data.stacks)
@@ -529,7 +529,7 @@ describe('lib/cf test suite', () => {
     expect(stacks[1].entity.name).toEqual('cflinuxfs3');
   });
 
-  test('should obtain a stack', async () => {
+  it('should obtain a stack', async () => {
     nockCF
       .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728')
       .reply(200, data.stack)
@@ -541,7 +541,7 @@ describe('lib/cf test suite', () => {
     expect(stack.entity.name).toEqual('cflinuxfs3');
   });
 
-  test('should get the GUID of cflinuxfs2', async () => {
+  it('should get the GUID of cflinuxfs2', async () => {
     nockCF
       .get('/v2/stacks')
       .reply(200, data.stacks)
@@ -553,7 +553,7 @@ describe('lib/cf test suite', () => {
     expect(cflinuxfs2StackGUID).toEqual('dd63d39a-85f8-48ef-bb73-89097192cfcb');
   });
 
-  test('should return undefined when cflinuxfs2 is not present', async () => {
+  it('should return undefined when cflinuxfs2 is not present', async () => {
     nock.cleanAll();
     nock('https://example.com/api').get('/v2/stacks').reply(200, data.stacksWithoutCflinuxfs2);
 

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -11,57 +11,24 @@ const config = {
   logger: pino({level: 'silent'}),
 };
 
-// tslint:disable:max-line-length
-nock('https://example.com/api').persist()
-  .get('/v2/info').reply(200, data.info)
-  .post('/v2/organizations').reply(201, data.organization)
-  .get('/v2/organizations').reply(200, data.organizations)
-  .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20').reply(200, data.organization)
-  .delete('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20?recursive=true&async=false').reply(204)
-  .get('/v2/quota_definitions').reply(200, data.organizations)
-  .get('/v2/quota_definitions?q=name:the-system_domain-org-name').reply(200, data.organizations)
-  .get('/v2/quota_definitions/80f3e539-a8c0-4c43-9c72-649df53da8cb').reply(200, data.organizationQuota)
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces').reply(200, data.spaces)
-  .get('/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps').reply(200, data.apps)
-  .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123').times(1).reply(200, data.app)
-  .get('/v2/apps/cd897c8c-3171-456d-b5d7-3c87feeabbd1/summary').times(1).reply(200, data.appSummary)
-  .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3').reply(200, data.space)
-  .get('/v2/spaces/50ae42f6-346d-4eca-9e97-f8c9e04d5fbe/summary').reply(200, data.spaceSummary)
-  .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019').reply(200, data.spaceQuota)
-  .get('/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances').reply(200, data.services)
-  .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92').times(1).reply(200, data.serviceInstance)
-  .get('/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332').times(1).reply(200, data.servicePlan)
-  .get('/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5').times(1).reply(200, data.service)
-  .get('/v2/user_provided_service_instances?q=space_guid:594c1fa9-caed-454b-9ed8-643a093ff91d').times(1).reply(200, data.userServices)
-  .get('/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87').times(1).reply(200, data.userServiceInstance)
-  .post('/v2/users').reply(201, data.user)
-  .delete('/v2/users/guid-cb24b36d-4656-468e-a50d-b53113ac6177?async=false').reply(204)
-  .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275').reply(200, data.spaces)
-  .get('/v2/users/uaa-id-253/summary').reply(200, data.userSummary)
-  .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, data.userRolesForOrg)
-  .get('/v2/spaces/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles').reply(200, data.userRolesForSpace)
-  .post('/v2/users').reply(200, data.user)
-  .put('/v2/organizations/beb082da-25e1-4329-88c9-bea2d809729d/users/uaa-id-236?recursive=true').reply(201, data.userRoles)
-  .delete('/v2/organizations/beb082da-25e1-4329-88c9-bea2d809729d/users/uaa-id-236?recursive=true').reply(204, {})
-  .put('/v2/spaces/594c1fa9-caed-454b-9ed8-643a093ff91d/developer/uaa-id-381').reply(201, data.userRoles)
-  .delete('/v2/spaces/594c1fa9-caed-454b-9ed8-643a093ff91d/developer/uaa-id-381').reply(204, {})
-  .get('/v2/stacks').reply(200, data.stacks)
-  .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728').reply(200, data.stack)
-  .get('/v2/failure/404').reply(404, `{"error": "FAKE_404"}`)
-  .get('/v2/failure/500').reply(500, `FAKE_500`)
-  .get('/v2/test').reply(200, `{"next_url":"/v2/test?page=2","resources":["a"]}`)
-  .get('/v2/test?page=2').reply(200, `{"next_url":null,"resources":["b"]}`)
-  .put('/v2/organizations/guid-cb24b36d-4656-468e-a50d-b53113ac6177/users/uaa-id-236').reply(201, {
-    metadata: {guid: 'guid-cb24b36d-4656-468e-a50d-b53113ac6177'},
-  })
-;
-
-nock('https://example.com/uaa').persist()
-  .post('/oauth/token?grant_type=client_credentials').reply(200, `{"access_token": "TOKEN_FROM_ENDPOINT"}`)
-;
-// tslint:enable:max-line-length
-
 describe('lib/cf test suite', () => {
+  let nockCF: nock.Scope;
+  let nockUAA: nock.Scope;
+
+  beforeEach(() => {
+    nock.cleanAll();
+
+    nockCF = nock(config.apiEndpoint);
+    nockUAA = nock('https://example.com/uaa');
+  });
+
+  afterEach(() => {
+    nockCF.done();
+    nockUAA.done();
+
+    nock.cleanAll();
+  });
+
   test('should fail to get token client without accessToken or clientCredentials', async () => {
     const client = new CloudFoundryClient({
       apiEndpoint: 'https://example.com/api',
@@ -71,6 +38,15 @@ describe('lib/cf test suite', () => {
   });
 
   test('should get token from tokenEndpoint in info', async () => {
+    nockCF
+      .get('/v2/info')
+      .reply(200, data.info)
+    ;
+    nockUAA
+      .post('/oauth/token?grant_type=client_credentials')
+      .reply(200, `{"access_token": "TOKEN_FROM_ENDPOINT"}`)
+    ;
+
     const client = new CloudFoundryClient({
       apiEndpoint: 'https://example.com/api',
       clientCredentials: {clientID: 'my-id', clientSecret: 'my-secret'},
@@ -83,12 +59,24 @@ describe('lib/cf test suite', () => {
   });
 
   test('should create a client correctly', async () => {
+    nockCF
+      .get('/v2/info')
+      .reply(200, data.info)
+    ;
+
     const client = new CloudFoundryClient(config);
     const info = await client.info();
     expect(info.version).toEqual(2);
   });
 
   test('should iterate over all pages to gather resources', async () => {
+    nockCF
+      .get('/v2/test')
+      .reply(200, `{"next_url":"/v2/test?page=2","resources":["a"]}`)
+      .get('/v2/test?page=2')
+      .reply(200, `{"next_url":null,"resources":["b"]}`)
+    ;
+
     const client = new CloudFoundryClient(config);
     const response = await client.request('get', '/v2/test');
     const collection = await client.allResources(response);
@@ -98,16 +86,31 @@ describe('lib/cf test suite', () => {
   });
 
   test('should throw an error when receiving 404', async () => {
+    nockCF
+      .get('/v2/failure/404')
+      .reply(404, `{"error": "FAKE_404"}`)
+    ;
+
     const client = new CloudFoundryClient(config);
     await expect(client.request('get', '/v2/failure/404')).rejects.toThrow(/FAKE_404/);
   });
 
   test('should throw an error when encountering unrecognised error', async () => {
+    nockCF
+      .get('/v2/failure/500')
+      .reply(500, `FAKE_500`)
+    ;
+
     const client = new CloudFoundryClient(config);
     await expect(client.request('get', '/v2/failure/500')).rejects.toThrow(/status 500/);
   });
 
   test('should create an organisation', async () => {
+    nockCF
+      .post('/v2/organizations')
+      .reply(201, data.organization)
+    ;
+
     const client = new CloudFoundryClient(config);
     const organization = await client.createOrganization({
       name: 'some-org-name', quota_definition_guid: 'some-quota-definition-guid',
@@ -117,6 +120,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of organisations', async () => {
+    nockCF
+      .get('/v2/organizations')
+      .reply(200, data.organizations)
+    ;
+
     const client = new CloudFoundryClient(config);
     const organizations = await client.organizations();
 
@@ -125,6 +133,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain single organisation', async () => {
+    nockCF
+      .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20')
+      .reply(200, data.organization)
+    ;
+
     const client = new CloudFoundryClient(config);
     const organization = await client.organization('a7aff246-5f5b-4cf8-87d8-f316053e4a20');
 
@@ -132,6 +145,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should delete an organisation', async () => {
+    nockCF
+      .delete('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20?recursive=true&async=false')
+      .reply(204)
+    ;
+
     const client = new CloudFoundryClient(config);
     await client.deleteOrganization({
       guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
@@ -141,6 +159,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should list all quota definitions', async () => {
+    nockCF
+      .get('/v2/quota_definitions')
+      .reply(200, data.organizations)
+    ;
+
     const client = new CloudFoundryClient(config);
     const quotas = await client.quotaDefinitions();
 
@@ -149,6 +172,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should filter quota definitions', async () => {
+    nockCF
+      .get('/v2/quota_definitions?q=name:the-system_domain-org-name')
+      .reply(200, data.organizations)
+    ;
+
     const client = new CloudFoundryClient(config);
     const quotas = await client.quotaDefinitions({name: 'the-system_domain-org-name'});
 
@@ -157,6 +185,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain organisation quota', async () => {
+    nockCF
+      .get('/v2/quota_definitions/80f3e539-a8c0-4c43-9c72-649df53da8cb')
+      .reply(200, data.organizationQuota)
+    ;
+
     const client = new CloudFoundryClient(config);
     const quota = await client.organizationQuota('80f3e539-a8c0-4c43-9c72-649df53da8cb');
 
@@ -164,6 +197,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of spaces', async () => {
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
+      .reply(200, data.spaces)
+    ;
+
     const client = new CloudFoundryClient(config);
     const spaces = await client.spaces('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
 
@@ -172,6 +210,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain single space', async () => {
+    nockCF
+      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3')
+      .reply(200, data.space)
+    ;
+
     const client = new CloudFoundryClient(config);
     const space = await client.space('bc8d3381-390d-4bd7-8c71-25309900a2e3');
 
@@ -179,6 +222,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain single space', async () => {
+    nockCF
+      .get('/v2/spaces/50ae42f6-346d-4eca-9e97-f8c9e04d5fbe/summary')
+      .reply(200, data.spaceSummary)
+    ;
+
     const client = new CloudFoundryClient(config);
     const space = await client.spaceSummary('50ae42f6-346d-4eca-9e97-f8c9e04d5fbe');
 
@@ -186,6 +234,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain space quota', async () => {
+    nockCF
+      .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019')
+      .reply(200, data.spaceQuota)
+    ;
+
     const client = new CloudFoundryClient(config);
     const quota = await client.spaceQuota('a9097bc8-c6cf-4a8f-bc47-623fa22e8019');
 
@@ -193,6 +246,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of spaces for specific user in given org', async () => {
+    nockCF
+      .get('/v2/users/uaa-id-253/spaces?q=organization_guid:3deb9f04-b449-4f94-b3dd-c73cefe5b275')
+      .reply(200, data.spaces)
+    ;
+
     const client = new CloudFoundryClient(config);
     const spaces = await client.spacesForUserInOrganization('uaa-id-253', '3deb9f04-b449-4f94-b3dd-c73cefe5b275');
 
@@ -201,6 +259,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of apps', async () => {
+    nockCF
+      .get('/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps')
+      .reply(200, data.apps)
+    ;
+
     const client = new CloudFoundryClient(config);
     const apps = await client.applications('be1f9c1d-e629-488e-a560-a35b545f0ad7');
 
@@ -209,6 +272,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain particular app', async () => {
+    nockCF
+      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123')
+      .reply(200, data.app)
+    ;
+
     const client = new CloudFoundryClient(config);
     const app = await client.application('15b3885d-0351-4b9b-8697-86641668c123');
 
@@ -216,13 +284,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain app summary', async () => {
-    const client = new CloudFoundryClient(config);
-    const app = await client.applicationSummary('cd897c8c-3171-456d-b5d7-3c87feeabbd1');
+    nockCF
+      .get('/v2/apps/cd897c8c-3171-456d-b5d7-3c87feeabbd1/summary')
+      .reply(200, data.appSummary)
+    ;
 
-    expect(app.name).toEqual('name-79');
-  });
-
-  test('should obtain app summary', async () => {
     const client = new CloudFoundryClient(config);
     const app = await client.applicationSummary('cd897c8c-3171-456d-b5d7-3c87feeabbd1');
 
@@ -230,6 +296,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of services', async () => {
+    nockCF
+      .get('/v2/spaces/f858c6b3-f6b1-4ae8-81dd-8e8747657fbe/service_instances')
+      .reply(200, data.services)
+    ;
+
     const client = new CloudFoundryClient(config);
     const services = await client.services('f858c6b3-f6b1-4ae8-81dd-8e8747657fbe');
 
@@ -238,6 +309,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain particular service instance', async () => {
+    nockCF
+      .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92')
+      .reply(200, data.serviceInstance)
+    ;
+
     const client = new CloudFoundryClient(config);
     const serviceInstance = await client.serviceInstance('0d632575-bb06-4ea5-bb19-a451a9644d92');
 
@@ -245,6 +321,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain particular service plan', async () => {
+    nockCF
+      .get('/v2/service_plans/775d0046-7505-40a4-bfad-ca472485e332')
+      .reply(200, data.servicePlan)
+    ;
+
     const client = new CloudFoundryClient(config);
     const servicePlan = await client.servicePlan('775d0046-7505-40a4-bfad-ca472485e332');
 
@@ -252,6 +333,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain particular service', async () => {
+    nockCF
+      .get('/v2/services/53f52780-e93c-4af7-a96c-6958311c40e5')
+      .reply(200, data.service)
+    ;
+
     const client = new CloudFoundryClient(config);
     const service = await client.service('53f52780-e93c-4af7-a96c-6958311c40e5');
 
@@ -259,17 +345,32 @@ describe('lib/cf test suite', () => {
   });
 
   test('should create a user', async () => {
+    nockCF
+      .post('/v2/users')
+      .reply(200, data.user)
+    ;
+
     const client = new CloudFoundryClient(config);
     const user = await client.createUser('guid-cb24b36d-4656-468e-a50d-b53113ac6177');
     expect(user.metadata.guid).toEqual('guid-cb24b36d-4656-468e-a50d-b53113ac6177');
   });
 
   test('should delete a user', async () => {
+    nockCF
+      .delete('/v2/users/guid-cb24b36d-4656-468e-a50d-b53113ac6177?async=false')
+      .reply(204)
+    ;
+
     const client = new CloudFoundryClient(config);
     expect(async () => client.deleteUser('guid-cb24b36d-4656-468e-a50d-b53113ac6177')).not.toThrowError();
   });
 
   test('should obtain a user summary', async () => {
+    nockCF
+      .get('/v2/users/uaa-id-253/summary')
+      .reply(200, data.userSummary)
+    ;
+
     const client = new CloudFoundryClient(config);
     const summary = await client.userSummary('uaa-id-253');
 
@@ -280,6 +381,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of user roles for organisation', async () => {
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .reply(200, data.userRolesForOrg)
+    ;
+
     const client = new CloudFoundryClient(config);
     const users = await client.usersForOrganization('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
 
@@ -289,6 +395,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of user roles for space', async () => {
+    nockCF
+      .get('/v2/spaces/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .reply(200, data.userRolesForSpace)
+    ;
+
     const client = new CloudFoundryClient(config);
     const users = await client.usersForSpace('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
 
@@ -298,6 +409,13 @@ describe('lib/cf test suite', () => {
   });
 
   test('should be able to assign a user to an organisation by username', async () => {
+    nockCF
+      .put('/v2/organizations/guid-cb24b36d-4656-468e-a50d-b53113ac6177/users/uaa-id-236')
+      .reply(201, {
+        metadata: {guid: 'guid-cb24b36d-4656-468e-a50d-b53113ac6177'},
+      })
+    ;
+
     const client = new CloudFoundryClient(config);
     const organization = await client.assignUserToOrganization(
       'guid-cb24b36d-4656-468e-a50d-b53113ac6177',
@@ -308,6 +426,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should be able to set user org roles', async () => {
+    nockCF
+      .put('/v2/organizations/beb082da-25e1-4329-88c9-bea2d809729d/users/uaa-id-236?recursive=true')
+      .reply(201, data.userRoles)
+    ;
+
     const client = new CloudFoundryClient(config);
     const users = await client.setOrganizationRole('beb082da-25e1-4329-88c9-bea2d809729d', `uaa-id-236`, 'users', true);
 
@@ -315,6 +438,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should be able to remove user org roles', async () => {
+    nockCF
+      .delete('/v2/organizations/beb082da-25e1-4329-88c9-bea2d809729d/users/uaa-id-236?recursive=true')
+      .reply(204, {})
+    ;
+
     const client = new CloudFoundryClient(config);
     const roles = await client
       .setOrganizationRole('beb082da-25e1-4329-88c9-bea2d809729d', `uaa-id-236`, 'users', false);
@@ -323,6 +451,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should be able to set user space roles', async () => {
+    nockCF
+      .put('/v2/spaces/594c1fa9-caed-454b-9ed8-643a093ff91d/developer/uaa-id-381')
+      .reply(201, data.userRoles)
+    ;
+
     const client = new CloudFoundryClient(config);
     const users = await client.setSpaceRole('594c1fa9-caed-454b-9ed8-643a093ff91d', 'uaa-id-381', 'developer', true);
 
@@ -330,6 +463,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should be able to remove user space roles', async () => {
+    nockCF
+      .delete('/v2/spaces/594c1fa9-caed-454b-9ed8-643a093ff91d/developer/uaa-id-381')
+      .reply(204, {})
+    ;
+
     const client = new CloudFoundryClient(config);
     const users = await client.setSpaceRole('594c1fa9-caed-454b-9ed8-643a093ff91d', 'uaa-id-381', 'developer', false);
 
@@ -337,6 +475,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of user roles for organisation and not find logged in user', async () => {
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .reply(200, data.userRolesForOrg)
+    ;
+
     const client = new CloudFoundryClient(config);
     const hasRole = await client.hasOrganizationRole(
       '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
@@ -348,6 +491,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of user provided services', async () => {
+    nockCF
+      .get('/v2/user_provided_service_instances?q=space_guid:594c1fa9-caed-454b-9ed8-643a093ff91d')
+      .reply(200, data.userServices)
+    ;
+
     const client = new CloudFoundryClient(config);
     const services = await client.userServices('594c1fa9-caed-454b-9ed8-643a093ff91d');
 
@@ -356,6 +504,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain user provided service', async () => {
+    nockCF
+      .get('/v2/user_provided_service_instances/e9358711-0ad9-4f2a-b3dc-289d47c17c87')
+      .reply(200, data.userServiceInstance)
+    ;
+
     const client = new CloudFoundryClient(config);
     const service = await client.userServiceInstance('e9358711-0ad9-4f2a-b3dc-289d47c17c87');
 
@@ -363,6 +516,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain list of stacks', async () => {
+    nockCF
+      .get('/v2/stacks')
+      .reply(200, data.stacks)
+    ;
+
     const client = new CloudFoundryClient(config);
     const stacks = await client.stacks();
 
@@ -372,6 +530,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should obtain a stack', async () => {
+    nockCF
+      .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728')
+      .reply(200, data.stack)
+    ;
+
     const client = new CloudFoundryClient(config);
     const stack = await client.stack('bb9ca94f-b456-4ebd-ab09-eb7987cce728');
 
@@ -379,6 +542,11 @@ describe('lib/cf test suite', () => {
   });
 
   test('should get the GUID of cflinuxfs2', async () => {
+    nockCF
+      .get('/v2/stacks')
+      .reply(200, data.stacks)
+    ;
+
     const client = new CloudFoundryClient(config);
     const cflinuxfs2StackGUID = await client.cflinuxfs2StackGUID();
 

--- a/src/lib/notify/notify.client.test.ts
+++ b/src/lib/notify/notify.client.test.ts
@@ -3,15 +3,42 @@ import nock from 'nock';
 import NotificationClient from '.';
 
 describe('lib/notify test suite', () => {
-  it('notify middleware should include NotifyClient on req', async () => {
-    nock(/api.notifications.service.gov.uk/)
-      .persist()
-      .filteringPath(() => '/')
-      .post('/').reply(200, {content: {body: 'FAKE_NOTIFY_RESPONSE'}});
 
-    const notify = new NotificationClient({apiKey: 'test-key-1234', templates: {welcome: 'WELCOME_ID'}});
-    const personalisation = {url: 'https://default.url', organisation: 'DefaultOrg', location: 'DefaultLocation'};
-    const notifyResponse = await notify.sendWelcomeEmail('jeff@jeff.com', personalisation);
+  let nockNotify: nock.Scope;
+
+  beforeEach(() => {
+    nock.cleanAll();
+
+    nockNotify = nock(/api.notifications.service.gov.uk/);
+  });
+
+  afterEach(() => {
+    nockNotify.done();
+
+    nock.cleanAll();
+  });
+
+  it('notify middleware should include NotifyClient on req', async () => {
+    nockNotify
+      .post('/v2/notifications/email')
+      .reply(200, {content: {body: 'FAKE_NOTIFY_RESPONSE'}})
+    ;
+
+    const notify = new NotificationClient({
+      apiKey: 'test-key-1234',
+      templates: {welcome: 'WELCOME_ID'},
+    });
+
+    const personalisation = {
+      url: 'https://default.url',
+      organisation: 'DefaultOrg',
+      location: 'DefaultLocation',
+    };
+
+    const notifyResponse = await notify.sendWelcomeEmail(
+      'jeff@jeff.com',
+      personalisation,
+    );
 
     expect(notifyResponse.body.content.body).toContain('FAKE_NOTIFY_RESPONSE');
   });


### PR DESCRIPTION
What
----

This is a somewhat large pull request which does absolutely nothing to the behaviour or code of the application.

Previously, in our tests, we were using `nock(...).persist()` which means the mock will return the same response, unless it is overridden by another mock. This made our tests extremely difficult to reason about.

Additionally in our app tests (`app.test.ts`) we had a shared agent which was not torn down, which caused some of our tests to share some state.

This PR goes through and inlines or `beforeEach`s the mocks, and `beforeEach`s the supertest agent. Now ALL of the tests are consistent in how they do mocking, although at the expense of being quite verbose.

I view this step of making all the tests very verbose a necessary pre-req in coming up with some nice test helpers, e.g.: `whenIRequestTheOrganizationsPage(nockAccounts, nockCF, nockUAA).withTheFollowingOrgsAvailableToMe(org1, org2, org3)` etc

How to review
-------------

- Code review commit by commit

- Check only test files were changed `git diff --name-only origin/master` 

- Run the tests

Who can review
---------------

Not @tlwr 
