### PR TITLE
App test builder

### DIFF
--- a/src/components/applications/applications.test.ts
+++ b/src/components/applications/applications.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock';
 import {viewApplication} from '.';
 
 import * as data from '../../lib/cf/cf.test.data';
-import anApp from '../../lib/cf/test-data/app';
+import {anApp} from '../../lib/cf/test-data/app';
 import {createTestContext} from '../app/app.test-helpers';
 import {IContext} from '../app/context';
 

--- a/src/components/applications/applications.test.ts
+++ b/src/components/applications/applications.test.ts
@@ -3,6 +3,7 @@ import nock from 'nock';
 import {viewApplication} from '.';
 
 import * as data from '../../lib/cf/cf.test.data';
+import anApp from '../../lib/cf/test-data/app';
 import {createTestContext} from '../app/app.test-helpers';
 import {IContext} from '../app/context';
 
@@ -32,50 +33,54 @@ describe('applications test suite', () => {
   });
 
   const ctx: IContext = createTestContext();
+  const name = 'name-79';
+  const guid = '15b3885d-0351-4b9b-8697-86641668c123';
+  const spaceGuid = '7846301e-c84c-4ba9-9c6a-2dfdae948d52';
+  const stackGuid = 'bb9ca94f-b456-4ebd-ab09-eb7987cce728';
 
   it('should show the application overview page', async () => {
     nockCF
-      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123')
-      .reply(200, data.app)
+      .get(`/v2/apps/${guid}`)
+      .reply(200, anApp().withName(name).withGuid(guid).inSpace(spaceGuid).withStack(stackGuid).build())
 
-      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/summary')
+      .get(`/v2/apps/${guid}/summary`)
       .reply(200, data.appSummary)
 
-      .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52')
+      .get(`/v2/spaces/${spaceGuid}`)
       .reply(200, data.space)
 
-      .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728')
+      .get(`/v2/stacks/${stackGuid}`)
       .reply(200, data.stack)
     ;
 
     const response = await viewApplication(ctx, {
-      applicationGUID: '15b3885d-0351-4b9b-8697-86641668c123',
+      applicationGUID: guid,
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
-      spaceGUID: '7846301e-c84c-4ba9-9c6a-2dfdae948d52',
+      spaceGUID: spaceGuid,
     });
 
-    expect(response.body).toMatch(/name-79 - Application Overview/);
+    expect(response.body).toMatch(new RegExp(`${name} - Application Overview`));
   });
 
   it('should say the name of the stack being used', async () => {
     nockCF
-      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123')
-      .reply(200, data.app)
+      .get(`/v2/apps/${guid}`)
+      .reply(200, anApp().withName(name).withGuid(guid).inSpace(spaceGuid).withStack(stackGuid).build())
 
-      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/summary')
+      .get(`/v2/apps/${guid}/summary`)
       .reply(200, data.appSummary)
 
-      .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52')
+      .get(`/v2/spaces/${spaceGuid}`)
       .reply(200, data.space)
 
-      .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728')
+      .get(`/v2/stacks/${stackGuid}`)
       .reply(200, data.stack)
     ;
 
     const response = await viewApplication(ctx, {
-      applicationGUID: '15b3885d-0351-4b9b-8697-86641668c123',
+      applicationGUID: guid,
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
-      spaceGUID: '7846301e-c84c-4ba9-9c6a-2dfdae948d52',
+      spaceGUID: spaceGuid,
     });
 
     expect(response.body).toMatch(/Stack/);
@@ -86,24 +91,30 @@ describe('applications test suite', () => {
   });
 
   it('should say the name of the docker image being used', async () => {
+    const dockerGuid = '646f636b-6572-0d0a-8697-86641668c123';
     nockCF
-      .get('/v2/apps/646f636b-6572-0d0a-8697-86641668c123')
-      .reply(200, data.dockerApp)
+      .get(`/v2/apps/${dockerGuid}`)
+      .reply(200, anApp()
+                    .withName(name)
+                    .withGuid(dockerGuid)
+                    .withStack(stackGuid)
+                    .usingDocker()
+                    .build())
 
-      .get('/v2/apps/646f636b-6572-0d0a-8697-86641668c123/summary')
+      .get(`/v2/apps/${dockerGuid}/summary`)
       .reply(200, data.dockerAppSummary)
 
-      .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52')
+      .get(`/v2/spaces/${spaceGuid}`)
       .reply(200, data.space)
 
-      .get('/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728')
+      .get(`/v2/stacks/${stackGuid}`)
       .reply(200, data.stack)
     ;
 
     const response = await viewApplication(ctx, {
-      applicationGUID: '646f636b-6572-0d0a-8697-86641668c123',
+      applicationGUID: dockerGuid,
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
-      spaceGUID: '7846301e-c84c-4ba9-9c6a-2dfdae948d52',
+      spaceGUID: spaceGuid,
     });
 
     expect(response.body).not.toMatch(/Stack/);
@@ -114,24 +125,31 @@ describe('applications test suite', () => {
   });
 
   it('should say a warning if the cflinuxfs2 stack is being used', async () => {
+    const cflinuxfs2Guid = 'ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7';
+    const cflinuxfs2StackGuid = 'dd63d39a-85f8-48ef-bb73-89097192cfcb';
     nockCF
-      .get('/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7')
-      .reply(200, data.appUsingCflinuxfs2)
+      .get(`/v2/apps/${cflinuxfs2Guid}`)
+      .reply(200, anApp()
+                    .withName(name)
+                    .withGuid(cflinuxfs2Guid)
+                    .inSpace(spaceGuid)
+                    .withStack(cflinuxfs2StackGuid)
+                    .build())
 
-      .get('/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7/summary')
+      .get(`/v2/apps/${cflinuxfs2Guid}/summary`)
       .reply(200, data.appSummaryUsingCflinuxfs2)
 
-      .get('/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52')
+      .get(`/v2/spaces/${spaceGuid}`)
       .reply(200, data.space)
 
-      .get('/v2/stacks/dd63d39a-85f8-48ef-bb73-89097192cfcb')
+      .get(`/v2/stacks/${cflinuxfs2StackGuid}`)
       .reply(200, data.stackCflinuxfs2)
     ;
 
     const response = await viewApplication(ctx, {
-      applicationGUID: 'ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7',
+      applicationGUID: cflinuxfs2Guid,
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
-      spaceGUID: '7846301e-c84c-4ba9-9c6a-2dfdae948d52',
+      spaceGUID: spaceGuid,
     });
 
     expect(response.body).toMatch(/Stack/);

--- a/src/components/spaces/spaces.test.ts
+++ b/src/components/spaces/spaces.test.ts
@@ -3,10 +3,12 @@ import nock from 'nock';
 import * as spaces from '.';
 
 import * as data from '../../lib/cf/cf.test.data';
+import {anApp, someApps} from '../../lib/cf/test-data/app';
 import {createTestContext} from '../app/app.test-helpers';
 import {IContext} from '../app/context';
 
 const ctx: IContext = createTestContext();
+const spaceGuid = 'bc8d3381-390d-4bd7-8c71-25309900a2e3';
 
 describe('spaces test suite', () => {
   let nockAccounts: nock.Scope;
@@ -32,6 +34,7 @@ describe('spaces test suite', () => {
   });
 
   it('should show the spaces pages', async () => {
+    const secondSpace = '5489e195-c42b-4e61-bf30-323c331ecc01';
     nockAccounts
       .get('/users/uaa-id-253').reply(200, JSON.stringify({
         user_uuid: 'uaa-id-253',
@@ -51,8 +54,11 @@ describe('spaces test suite', () => {
       .get('/v2/space_quota_definitions/a9097bc8-c6cf-4a8f-bc47-623fa22e8019')
       .reply(200, data.spaceQuota)
 
-      .get('/v2/spaces/5489e195-c42b-4e61-bf30-323c331ecc01/apps')
-      .reply(200, data.apps)
+      .get(`/v2/spaces/${spaceGuid}/apps`)
+      .reply(200, someApps(
+        anApp().withName('first-app').build(),
+        anApp().withName('second-app').build(),
+      ))
 
       .get('/v2/stacks')
       .reply(200, data.spaces)
@@ -60,19 +66,24 @@ describe('spaces test suite', () => {
       .get('/v2/quota_definitions/dcb680a9-b190-4838-a3d2-b84aa17517a6')
       .reply(200, data.organizationQuota)
 
-      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/apps')
-      .reply(200, data.apps)
+      .get(`/v2/spaces/${secondSpace}/apps`)
+      .reply(200, someApps(
+        anApp().withName('second-space-app').build(),
+      ))
     ;
     const response = await spaces.listSpaces(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
     });
 
     expect(response.body).toContain('Spaces');
-    expect(response.body).toContain('has 1 apps');
+    expect(response.body).toContain('The space has 2 apps');
+    expect(response.body).toContain('The space has 1 apps');
     expect(response.body).toContain('2gb');
   });
 
   it('should show list of applications in space', async () => {
+    const appGuid = 'efd23111-72d1-481e-8168-d5395e0ea5f0';
+    const appName = 'name-2064';
     nockCF
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
       .times(2)
@@ -81,21 +92,23 @@ describe('spaces test suite', () => {
       .get('/v2/stacks')
       .reply(200, data.spaces)
 
-      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/apps')
-      .reply(200, data.apps)
+      .get(`/v2/spaces/${spaceGuid}/apps`)
+      .reply(200, someApps(
+        anApp().withGuid(appGuid).withName(appName).build(),
+      ))
 
-      .get('/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/summary')
+      .get(`/v2/apps/${appGuid}/summary`)
       .reply(200, data.appSummary)
 
-      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3')
+      .get(`/v2/spaces/${spaceGuid}`)
       .reply(200, data.space)
     ;
     const response = await spaces.listApplications(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-      spaceGUID: 'bc8d3381-390d-4bd7-8c71-25309900a2e3',
+      spaceGUID: spaceGuid,
     });
 
-    expect(response.body).toContain('name-2064 - Overview');
+    expect(response.body).toContain(`${appName} - Overview`);
   });
 
   it('should show list of services in space', async () => {
@@ -104,10 +117,10 @@ describe('spaces test suite', () => {
       .times(2)
       .reply(200, data.users)
 
-      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/service_instances')
+      .get(`/v2/spaces/${spaceGuid}/service_instances`)
       .reply(200, data.services)
 
-      .get('/v2/user_provided_service_instances?q=space_guid:bc8d3381-390d-4bd7-8c71-25309900a2e3')
+      .get(`/v2/user_provided_service_instances?q=space_guid:${spaceGuid}`)
       .reply(200, data.services)
 
       .get('/v2/service_plans/fcf57f7f-3c51-49b2-b252-dc24e0f7dcab')
@@ -116,13 +129,13 @@ describe('spaces test suite', () => {
       .get('/v2/services/775d0046-7505-40a4-bfad-ca472485e332')
       .reply(200, data.service)
 
-      .get('/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3')
+      .get(`/v2/spaces/${spaceGuid}`)
       .reply(200, data.space)
     ;
 
     const response = await spaces.listBackingServices(ctx, {
       organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
-      spaceGUID: 'bc8d3381-390d-4bd7-8c71-25309900a2e3',
+      spaceGUID: spaceGuid,
     });
 
     expect(response.body).toContain('name-2064 - Overview');

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -366,56 +366,6 @@ export const apps = `{
   ]
 }`;
 
-export const app = `{
-  "metadata": {
-    "guid": "15b3885d-0351-4b9b-8697-86641668c123",
-    "url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123",
-    "created_at": "2016-06-08T16:41:44Z",
-    "updated_at": "2016-06-08T16:41:44Z"
-  },
-  "entity": {
-    "name": "name-2401",
-    "production": false,
-    "space_guid": "7846301e-c84c-4ba9-9c6a-2dfdae948d52",
-    "stack_guid": "bb9ca94f-b456-4ebd-ab09-eb7987cce728",
-    "buildpack": null,
-    "detected_buildpack": null,
-    "detected_buildpack_guid": null,
-    "environment_json": null,
-    "memory": 1024,
-    "instances": 1,
-    "disk_quota": 1024,
-    "state": "STOPPED",
-    "version": "df19a7ea-2003-4ecb-a909-e630e43f2719",
-    "command": null,
-    "console": false,
-    "debug": null,
-    "staging_task_id": null,
-    "package_state": "PENDING",
-    "health_check_http_endpoint": "",
-    "health_check_type": "port",
-    "health_check_timeout": null,
-    "staging_failed_reason": null,
-    "staging_failed_description": null,
-    "diego": false,
-    "docker_image": null,
-    "docker_credentials": {
-      "username": null,
-      "password": null
-    },
-    "package_updated_at": "2016-06-08T16:41:45Z",
-    "detected_start_command": "",
-    "enable_ssh": true,
-    "ports": null,
-    "space_url": "/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52",
-    "stack_url": "/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728",
-    "routes_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/routes",
-    "events_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/events",
-    "service_bindings_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/service_bindings",
-    "route_mappings_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/route_mappings"
-  }
-}`;
-
 export const appSummary = `{
   "guid": "cd897c8c-3171-456d-b5d7-3c87feeabbd1",
   "name": "name-79",
@@ -504,56 +454,6 @@ export const appSummary = `{
   "ports": null
 }`;
 
-export const dockerApp = `{
-  "metadata": {
-    "guid": "646f636b-6572-0d0a-8697-86641668c123",
-    "url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123",
-    "created_at": "2016-06-08T16:41:44Z",
-    "updated_at": "2016-06-08T16:41:44Z"
-  },
-  "entity": {
-    "name": "name-1337",
-    "production": false,
-    "space_guid": "7846301e-c84c-4ba9-9c6a-2dfdae948d52",
-    "stack_guid": "bb9ca94f-b456-4ebd-ab09-eb7987cce728",
-    "buildpack": null,
-    "detected_buildpack": null,
-    "detected_buildpack_guid": null,
-    "environment_json": null,
-    "memory": 1024,
-    "instances": 1,
-    "disk_quota": 1024,
-    "state": "STOPPED",
-    "version": "df19a7ea-2003-4ecb-a909-e630e43f2719",
-    "command": null,
-    "console": false,
-    "debug": null,
-    "staging_task_id": null,
-    "package_state": "PENDING",
-    "health_check_http_endpoint": "",
-    "health_check_type": "port",
-    "health_check_timeout": null,
-    "staging_failed_reason": null,
-    "staging_failed_description": null,
-    "diego": false,
-    "docker_image": "governmentpaas/is-cool",
-    "docker_credentials": {
-      "username": null,
-      "password": null
-    },
-    "package_updated_at": "2016-06-08T16:41:45Z",
-    "detected_start_command": "",
-    "enable_ssh": true,
-    "ports": null,
-    "space_url": "/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52",
-    "stack_url": "/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728",
-    "routes_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/routes",
-    "events_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/events",
-    "service_bindings_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/service_bindings",
-    "route_mappings_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/route_mappings"
-  }
-}`;
-
 export const dockerAppSummary = `{
   "guid": "646f636b-6572-0d0a-8697-86641668c123",
   "name": "name-1337",
@@ -640,56 +540,6 @@ export const dockerAppSummary = `{
   "detected_start_command": "",
   "enable_ssh": true,
   "ports": null
-}`;
-
-export const appUsingCflinuxfs2 = `{
-  "metadata": {
-    "guid": "ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7",
-    "url": "/v2/apps/ebbcb962-8e5d-444d-a8fb-6f3b31fe99c7",
-    "created_at": "2016-06-08T16:41:44Z",
-    "updated_at": "2016-06-08T16:41:44Z"
-  },
-  "entity": {
-    "name": "name-2401",
-    "production": false,
-    "space_guid": "7846301e-c84c-4ba9-9c6a-2dfdae948d52",
-    "stack_guid": "dd63d39a-85f8-48ef-bb73-89097192cfcb",
-    "buildpack": null,
-    "detected_buildpack": null,
-    "detected_buildpack_guid": null,
-    "environment_json": null,
-    "memory": 1024,
-    "instances": 1,
-    "disk_quota": 1024,
-    "state": "STOPPED",
-    "version": "df19a7ea-2003-4ecb-a909-e630e43f2719",
-    "command": null,
-    "console": false,
-    "debug": null,
-    "staging_task_id": null,
-    "package_state": "PENDING",
-    "health_check_http_endpoint": "",
-    "health_check_type": "port",
-    "health_check_timeout": null,
-    "staging_failed_reason": null,
-    "staging_failed_description": null,
-    "diego": false,
-    "docker_image": null,
-    "docker_credentials": {
-      "username": null,
-      "password": null
-    },
-    "package_updated_at": "2016-06-08T16:41:45Z",
-    "detected_start_command": "",
-    "enable_ssh": true,
-    "ports": null,
-    "space_url": "/v2/spaces/7846301e-c84c-4ba9-9c6a-2dfdae948d52",
-    "stack_url": "/v2/stacks/dd63d39a-85f8-48ef-bb73-89097192cfcb",
-    "routes_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/routes",
-    "events_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/events",
-    "service_bindings_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/service_bindings",
-    "route_mappings_url": "/v2/apps/15b3885d-0351-4b9b-8697-86641668c123/route_mappings"
-  }
 }`;
 
 export const appSummaryUsingCflinuxfs2 = `{

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -310,62 +310,6 @@ export const spaceQuota = `{
   }
 }`;
 
-export const apps = `{
-  "total_results": 1,
-  "total_pages": 1,
-  "prev_url": null,
-  "next_url": null,
-  "resources": [
-    {
-      "metadata": {
-        "guid": "efd23111-72d1-481e-8168-d5395e0ea5f0",
-        "url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0",
-        "created_at": "2016-06-08T16:41:41Z",
-        "updated_at": "2016-06-08T16:41:41Z"
-      },
-      "entity": {
-        "name": "name-2131",
-        "production": false,
-        "space_guid": "be1f9c1d-e629-488e-a560-a35b545f0ad7",
-        "stack_guid": "bb9ca94f-b456-4ebd-ab09-eb7987cce728",
-        "buildpack": null,
-        "detected_buildpack": null,
-        "environment_json": null,
-        "memory": 1024,
-        "instances": 1,
-        "disk_quota": 1024,
-        "state": "STOPPED",
-        "version": "43abf29f-1ad1-46d0-bf08-991946e218fa",
-        "command": null,
-        "console": false,
-        "debug": null,
-        "staging_task_id": null,
-        "package_state": "PENDING",
-        "health_check_type": "port",
-        "health_check_timeout": null,
-        "staging_failed_reason": null,
-        "staging_failed_description": null,
-        "diego": false,
-        "docker_image": null,
-        "docker_credentials": {
-          "username": null,
-          "password": null
-        },
-        "package_updated_at": "2016-06-08T16:41:41Z",
-        "detected_start_command": "",
-        "enable_ssh": true,
-        "ports": null,
-        "space_url": "/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7",
-        "stack_url": "/v2/stacks/bb9ca94f-b456-4ebd-ab09-eb7987cce728",
-        "routes_url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/routes",
-        "events_url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/events",
-        "service_bindings_url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/service_bindings",
-        "route_mappings_url": "/v2/apps/efd23111-72d1-481e-8168-d5395e0ea5f0/route_mappings"
-      }
-    }
-  ]
-}`;
-
 export const appSummary = `{
   "guid": "cd897c8c-3171-456d-b5d7-3c87feeabbd1",
   "name": "name-79",

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock';
 import pino from 'pino';
 
 import * as data from './cf.test.data';
-import {anApp} from './test-data/app';
+import {anApp, someApps} from './test-data/app';
 
 import CloudFoundryClient from '.';
 
@@ -260,16 +260,20 @@ describe('lib/cf test suite', () => {
   });
 
   it('should obtain list of apps', async () => {
+    const spaceGuid = 'be1f9c1d-e629-488e-a560-a35b545f0ad7';
+    const name = 'name-2131';
     nockCF
-      .get('/v2/spaces/be1f9c1d-e629-488e-a560-a35b545f0ad7/apps')
-      .reply(200, data.apps)
+      .get(`/v2/spaces/${spaceGuid}/apps`)
+      .reply(200, someApps(
+        anApp().withName(name).build(),
+      ))
     ;
 
     const client = new CloudFoundryClient(config);
-    const apps = await client.applications('be1f9c1d-e629-488e-a560-a35b545f0ad7');
+    const apps = await client.applications(spaceGuid);
 
     expect(apps.length > 0).toBeTruthy();
-    expect(apps[0].entity.name).toEqual('name-2131');
+    expect(apps[0].entity.name).toEqual(name);
   });
 
   it('should obtain particular app', async () => {

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock';
 import pino from 'pino';
 
 import * as data from './cf.test.data';
-import anApp from './test-data/app';
+import {anApp} from './test-data/app';
 
 import CloudFoundryClient from '.';
 

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock';
 import pino from 'pino';
 
 import * as data from './cf.test.data';
+import anApp from './test-data/app';
 
 import CloudFoundryClient from '.';
 
@@ -272,15 +273,17 @@ describe('lib/cf test suite', () => {
   });
 
   it('should obtain particular app', async () => {
+    const guid = '15b3885d-0351-4b9b-8697-86641668c123';
+    const name = 'particular-app';
     nockCF
-      .get('/v2/apps/15b3885d-0351-4b9b-8697-86641668c123')
-      .reply(200, data.app)
+      .get(`/v2/apps/${guid}`)
+      .reply(200, anApp().withName(name).withGuid(guid).build())
     ;
 
     const client = new CloudFoundryClient(config);
-    const app = await client.application('15b3885d-0351-4b9b-8697-86641668c123');
+    const app = await client.application(guid);
 
-    expect(app.entity.name).toEqual('name-2401');
+    expect(app.entity.name).toEqual(name);
   });
 
   it('should obtain app summary', async () => {

--- a/src/lib/cf/test-data/app.ts
+++ b/src/lib/cf/test-data/app.ts
@@ -1,0 +1,84 @@
+export default function anApp(): AppBuilder {
+  return new AppBuilder();
+}
+
+class AppBuilder {
+  private name = 'name-2401';
+  private guid = '15b3885d-0351-4b9b-8697-86641668c123';
+  private spaceGuid = '7846301e-c84c-4ba9-9c6a-2dfdae948d52';
+  private stackGuid = 'bb9ca94f-b456-4ebd-ab09-eb7987cce728';
+  private lifecyle = '"buildpack": "python_buildpack", "docker-image": null';
+
+  public withName(name: string) {
+    this.name = name;
+    return this;
+  }
+
+  public withGuid(guid: string) {
+    this.guid = guid;
+    return this;
+  }
+
+  public inSpace(spaceGuid: string) {
+    this.spaceGuid = spaceGuid;
+    return this;
+  }
+
+  public usingDocker() {
+    this.lifecyle = '"buildpack": null, "docker_image": "governmentpaas/is-cool"';
+    return this;
+  }
+
+  public withStack(stackGuid: string) {
+    this.stackGuid = stackGuid;
+    return this;
+  }
+
+  public build(): string {
+    return `
+    {
+      "metadata": {
+        "guid": "${this.guid}",
+        "url": "/v2/apps/${this.guid}",
+        "created_at": "2016-06-08T16:41:44Z",
+        "updated_at": "2016-06-08T16:41:44Z"
+      },
+      "entity": {
+        "name": "${this.name}",
+        "production": false,
+        "space_guid": "${this.spaceGuid}",
+        "stack_guid": "${this.stackGuid}",
+        ${this.lifecyle},
+        "detected_buildpack": null,
+        "detected_buildpack_guid": null,
+        "environment_json": null,
+        "memory": 1024,
+        "instances": 1,
+        "disk_quota": 1024,
+        "state": "STOPPED",
+        "version": "df19a7ea-2003-4ecb-a909-e630e43f2719",
+        "command": null,
+        "console": false,
+        "debug": null,
+        "staging_task_id": null,
+        "package_state": "PENDING",
+        "health_check_http_endpoint": "",
+        "health_check_type": "port",
+        "health_check_timeout": null,
+        "staging_failed_reason": null,
+        "staging_failed_description": null,
+        "diego": false,
+        "package_updated_at": "2016-06-08T16:41:45Z",
+        "detected_start_command": "",
+        "enable_ssh": true,
+        "ports": null,
+        "space_url": "/v2/spaces/${this.spaceGuid}",
+        "stack_url": "/v2/stacks/${this.stackGuid}",
+        "routes_url": "/v2/apps/${this.guid}/routes",
+        "events_url": "/v2/apps/${this.guid}/events",
+        "service_bindings_url": "/v2/apps/${this.guid}/service_bindings",
+        "route_mappings_url": "/v2/apps/${this.guid}/route_mappings"
+      }
+    }`;
+  }
+}

--- a/src/lib/cf/test-data/app.ts
+++ b/src/lib/cf/test-data/app.ts
@@ -1,5 +1,20 @@
-export default function anApp(): AppBuilder {
+/* istanbul ignore next */
+export function anApp(): AppBuilder {
   return new AppBuilder();
+}
+
+/* istanbul ignore next */
+export function someApps(...apps: ReadonlyArray<string>) {
+  return `
+  {
+    "total_results": ${apps.length},
+    "total_pages": 1,
+    "prev_url": null,
+    "next_url": null,
+    "resources": [
+      ${apps.join(',')}
+    ]
+  }`;
 }
 
 class AppBuilder {

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import * as testData from '../src/lib/cf/cf.test.data';
+import anApp from '../src/lib/cf/test-data/app';
 import {IStubServerPorts} from './index';
 
 function mockCF(app: express.Application, config: IStubServerPorts): express.Application {
@@ -32,7 +33,7 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
   app.get('/v2/quota_definitions/:guid'              , (_, res) => res.send(testData.organizationQuota));
   app.get('/v2/organizations/:guid/spaces'           , (_, res) => res.send(testData.spaces));
   app.get('/v2/spaces/:guid/apps'                    , (_, res) => res.send(testData.apps));
-  app.get('/v2/apps/:guid'                           , (_, res) => res.send(testData.app));
+  app.get('/v2/apps/:guid'                           , (_, res) => res.send(anApp().build()));
   app.get('/v2/apps/:guid/summary'                   , (_, res) => res.send(testData.appSummary));
   app.get('/v2/spaces/:guid'                         , (_, res) => res.send(testData.space));
   app.get('/v2/spaces/:guid/summary'                 , (_, res) => res.send(testData.spaceSummary));

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import * as testData from '../src/lib/cf/cf.test.data';
-import anApp from '../src/lib/cf/test-data/app';
+import {anApp} from '../src/lib/cf/test-data/app';
 import {IStubServerPorts} from './index';
 
 function mockCF(app: express.Application, config: IStubServerPorts): express.Application {

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -32,7 +32,7 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
   app.get('/v2/quota_definitions'                    , (_, res) => res.send(testData.organizations));
   app.get('/v2/quota_definitions/:guid'              , (_, res) => res.send(testData.organizationQuota));
   app.get('/v2/organizations/:guid/spaces'           , (_, res) => res.send(testData.spaces));
-  app.get('/v2/spaces/:guid/apps'                    , (_, res) => res.send(testData.apps));
+  app.get('/v2/spaces/:guid/apps'                    , (_, res) => res.send(someApps(anApp().build())));
   app.get('/v2/apps/:guid'                           , (_, res) => res.send(anApp().build()));
   app.get('/v2/apps/:guid/summary'                   , (_, res) => res.send(testData.appSummary));
   app.get('/v2/spaces/:guid'                         , (_, res) => res.send(testData.space));


### PR DESCRIPTION
What
----

Remove the big JSON blobs for the CF `/v2/apps/:guid` API endpoints in tests/stub-api.
Replace instead with a fluent builder so that tests are more explicit about what the API should return and assertions are based on local constants rather than strings living in a file full o' big ol' JSON strings.
I plan to do the others like this too (app summary is now fairly low hanging fruit) but smaller commits == betterer

How to review
-------------

Let your CI system run the tests and assure yourself behaviour hasn't changed.
Run pazmin with the stub-api and check the spaces/application page still looks alright.

Who can review
---------------

Anyone on the PaaS team. Especially people who hate scrolling through JSON in Typescript strings.
