### PR TITLE
Fix email lowercase

### DIFF
--- a/src/components/org-users/org-users.ts
+++ b/src/components/org-users/org-users.ts
@@ -388,13 +388,15 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
       logger: ctx.app.logger,
     });
 
-    const uaaUser = await uaa.findUser(values.email);
+    const emailAddress = values.email.toLowerCase();
+
+    const uaaUser = await uaa.findUser(emailAddress);
     let userGUID = uaaUser && uaaUser.id;
     let invitation: IUaaInvitation | undefined;
 
     if (!userGUID) {
       invitation = await uaa.inviteUser(
-        values.email,
+        emailAddress,
         'user_invitation',
         'https://www.cloud.service.gov.uk/next-steps?success',
       );
@@ -406,7 +408,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
 
       userGUID = invitation.userId;
 
-      await accounts.createUser(userGUID, values.email, values.email);
+      await accounts.createUser(userGUID, emailAddress, emailAddress);
     }
 
     const users = await cf.usersForOrganization(params.organizationGUID);
@@ -442,7 +444,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
           },
         });
 
-        await notify.sendWelcomeEmail(values.email, {
+        await notify.sendWelcomeEmail(emailAddress, {
           organisation: organization.entity.name,
           url: invitation.inviteLink,
           location: ctx.app.location,


### PR DESCRIPTION
What
----

Change invite process to lowercase email addresses.

This is branched of #396 for better tests. 

How to review
-------------

Code review the last commit

Read my comment below

Who can review
---------------

Not @tlwr 

---

I'm not actually sure we can do this easily, we have some other users in our user databases which have uppercased email addresses, which means we cannot blindly lowercase all email addresses, otherwise we will email users with already existing accounts if someone types in the wrong casing.

What I think we should do is forget completely about UAA for email addresses, and do everything based on the accounts database.

So the invitation code would change from:

```
const uaaUser = await uaa.findUser(emailAddress);
```

```
const accountsUser = await accounts.getUserByEmail(emailAddress.toLowerCase())
```

We only use `uaa.findUser` in two places and they are in this codepath.
