### PR TITLE
[#168031285] Fast calculator

### DIFF
--- a/config/jest/pegjs.js
+++ b/config/jest/pegjs.js
@@ -1,0 +1,5 @@
+module.exports = {
+  process(src) {
+    return `const peg = require("pegjs");module.exports = peg.generate(${JSON.stringify(src)});`;
+  }
+}

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -125,6 +125,14 @@ let cfg = {
             }
           }
         ]
+      },
+      {
+        test: /\.pegjs$/,
+        use: [
+          {
+            loader: 'pegjs-loader'
+          }
+        ]
       }
     ]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5237,8 +5237,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5256,13 +5255,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5275,18 +5272,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5389,8 +5383,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5400,7 +5393,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5413,20 +5405,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5443,7 +5432,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5516,8 +5504,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5527,7 +5514,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5603,8 +5589,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5634,7 +5619,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5652,7 +5636,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5691,13 +5674,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -10809,6 +10790,47 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "pegjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+      "dev": true
+    },
+    "pegjs-loader": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/pegjs-loader/-/pegjs-loader-0.5.5.tgz",
+      "integrity": "sha512-WrYAnc/2sx9K+Aw/JPdUVeXINLwA2Bi5h3BtdRxvu5tcdh4eI/YesEaUldmEuvhcZGsTnRhFrDRbakRLeGfARg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^0.2.5"
+      },
+      "dependencies": {
+        "big.js": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+          "dev": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          }
+        }
       }
     },
     "performance-now": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "node-sass": "^4.12.0",
     "nodemon-webpack-plugin": "^4.0.8",
     "nyc": "14.1.1",
+    "pegjs": "^0.10.0",
+    "pegjs-loader": "^0.5.5",
     "postcss-loader": "3.0.0",
     "postcss-url": "8.0.0",
     "regexp-replace-loader": "1.0.1",
@@ -159,6 +161,7 @@
       "^.+\\.(ts|tsx)$": "ts-jest",
       "^.+\\.(css|scss|sass)$": "identity-obj-proxy",
       "^.+\\.(html|njk)$": "<rootDir>/config/jest/njk.js",
+      "^.+\\.(pegjs)$": "<rootDir>/config/jest/pegjs.js",
       "^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/config/jest/file.js"
     },
     "globals": {

--- a/src/@types/pegjs/index.d.ts
+++ b/src/@types/pegjs/index.d.ts
@@ -1,0 +1,4 @@
+declare module '*.pegjs' {
+  export function parse(expression: string): number;
+}
+

--- a/src/components/calculator/calculator.test.ts
+++ b/src/components/calculator/calculator.test.ts
@@ -109,7 +109,7 @@ describe('calculator test suite', () => {
 
   });
 
-  it('should use calculator when provided fake services', async () => {
+  it('should calculate prices (including exchange rate) when provided fake services', async () => {
     const rangeStart = moment().startOf('month').format('YYYY-MM-DD');
     const rangeStop = moment().endOf('month').format('YYYY-MM-DD');
 
@@ -144,6 +144,12 @@ describe('calculator test suite', () => {
           ],
         },
       ]))
+      .get(`/currency_rates?range_start=${rangeStart}&range_stop=${rangeStop}`)
+      .reply(200, JSON.stringify([{
+        code: 'USD',
+        valid_from: '1970-01-01T00:00:00.000Z',
+        rate: 2.0,
+      }]))
     ;
     // tslint:enable:max-line-length
 
@@ -155,9 +161,9 @@ describe('calculator test suite', () => {
     });
 
     expect(response.body).toContain('app');
-    expect(response.body).toContain('&pound;9.99');
+    expect(response.body).toContain('&pound;19.98');
     expect(response.body).toContain('postgres');
-    expect(response.body).toContain('&pound;6.66');
+    expect(response.body).toContain('&pound;13.32');
   });
 
   it('should sort the quote by order added', async () => {
@@ -181,6 +187,12 @@ describe('calculator test suite', () => {
           plan_guid: appGuid,
         },
       ]))
+      .get(`/currency_rates?range_start=${rangeStart}&range_stop=${rangeStop}`)
+      .reply(200, JSON.stringify([{
+        code: 'USD',
+        valid_from: '1970-01-01T00:00:00.000Z',
+        rate: 2.0,
+      }]))
     ;
     // tslint:enable:max-line-length
 
@@ -298,6 +310,12 @@ describe('calculator test suite', () => {
           number_of_nodes: 1,
         },
       ]))
+      .get(`/currency_rates?range_start=${rangeStart}&range_stop=${rangeStop}`)
+      .reply(200, JSON.stringify([{
+        code: 'USD',
+        valid_from: '1970-01-01T00:00:00.000Z',
+        rate: 2.0,
+      }]))
     ;
     // tslint:enable:max-line-length
 

--- a/src/components/calculator/calculator.test.ts
+++ b/src/components/calculator/calculator.test.ts
@@ -12,42 +12,17 @@ const defaultPricingPlan = {
   name: 'default-plan-name',
   plan_guid: 'default-plan-guid',
   valid_from: '2017-01-01T00:00:00+00:00',
-  components: [],
+  components: [
+    {
+      name: 'instance',
+      formula: 'ceil($time_in_seconds/3600) * 0.01',
+      vat_code: 'Standard',
+      currency_code: 'USD',
+    },
+  ],
   memory_in_mb: 0,
   storage_in_mb: 0,
   number_of_nodes: 0,
-};
-
-const defaultForecastEvent = {
-  event_guid: 'default-event-guid',
-  event_start: '2001-01-01T00:00:00+00:00',
-  event_stop: '2001-01-01T01:00:00+00:00',
-  resource_guid: 'default-resource-guid',
-  resource_name: 'default-resource-name',
-  resource_type: 'default-resource-type',
-  org_guid: 'default-org-guid',
-  space_guid: 'default-space-guid',
-  plan_guid: 'default-plan-guid',
-  number_of_nodes: 1,
-  memory_in_mb: 1024,
-  storage_in_mb: 0,
-  price: {
-    inc_vat: '0.012',
-    ex_vat: '0.01',
-    details: [
-      {
-        name: 'default-price-detail-name',
-        plan_name: 'default-price-detail-plan-name',
-        start: '2001-01-01T00:00:00+00:00',
-        stop: '2001-01-01T01:00:00+00:00',
-        vat_rate: '0.2',
-        vat_code: 'default-vat-code',
-        currency_code: 'default-currency-code',
-        inc_vat: '0.00',
-        ex_vat: '0.00',
-      },
-    ],
-  },
 };
 
 describe('calculator test suite', () => {
@@ -103,8 +78,6 @@ describe('calculator test suite', () => {
           plan_guid: 'f4d4b95a-f55e-4593-8d54-3364c25798c9',
         },
       ]))
-      .get(`/forecast_events?range_start=${rangeStart}&range_stop=${rangeStop}&org_guid=00000001-0000-0000-0000-000000000000&events=%5B%5D`)
-      .reply(200, [])
     ;
     // tslint:enable:max-line-length
 
@@ -142,39 +115,33 @@ describe('calculator test suite', () => {
 
     // tslint:disable:max-line-length
     nock(config.billingAPI)
-      .filteringPath((path: string) => {
-        if (path.includes('/forecast_events')) {
-          return '/billing/forecast_events';
-        }
-
-        return path;
-      })
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
       .reply(200, JSON.stringify([
         {
           ...defaultPricingPlan,
           name: 'app',
           plan_guid: '00000000-0000-0000-0000-000000000001',
+          components: [
+            {
+              name: 'instance',
+              formula: '9.99',
+              vat_code: 'Standard',
+              currency_code: 'USD',
+            },
+          ],
         },
         {
           ...defaultPricingPlan,
           name: 'postgres',
           plan_guid: '00000000-0000-0000-0000-000000000002',
-        },
-      ]))
-      .get(`/forecast_events`)
-      .reply(200, JSON.stringify([
-        {
-          ...defaultForecastEvent,
-          resource_name: 'APP1',
-          resource_type: '_TESTING_APPLICATION_',
-          plan_guid: '00000000-0000-0000-0000-000000000001',
-        },
-        {
-          ...defaultForecastEvent,
-          resource_name: 'SERVICE1',
-          resource_type: '_TESTING_SERVICE_',
-          plan_guid: '00000000-0000-0000-0000-000000000002',
+          components: [
+            {
+              name: 'instance',
+              formula: '6.66',
+              vat_code: 'Standard',
+              currency_code: 'USD',
+            },
+          ],
         },
       ]))
     ;
@@ -187,47 +154,31 @@ describe('calculator test suite', () => {
       ],
     });
 
-    expect(response.body).toContain('_TESTING_APPLICATION_');
-    expect(response.body).toContain('_TESTING_SERVICE_');
+    expect(response.body).toContain('app');
+    expect(response.body).toContain('&pound;9.99');
+    expect(response.body).toContain('postgres');
+    expect(response.body).toContain('&pound;6.66');
   });
 
   it('should sort the quote by order added', async () => {
     const rangeStart = moment().startOf('month').format('YYYY-MM-DD');
     const rangeStop = moment().endOf('month').format('YYYY-MM-DD');
 
+    const postgresGuid = 'f4d4b95a-f55e-4593-8d54-3364c25798c4';
+    const appGuid = 'f4d4b95b-f55e-4593-8d54-3364c25798c0';
     // tslint:disable:max-line-length
     nock(config.billingAPI)
-      .filteringPath((path: string) => {
-        if (path.includes('/forecast_events')) {
-          return '/billing/forecast_events';
-        }
-
-        return path;
-      })
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
       .reply(200, JSON.stringify([
         {
           ...defaultPricingPlan,
+          name: 'postgres',
+          plan_guid: postgresGuid,
+        },
+        {
+          ...defaultPricingPlan,
           name: 'app',
-          plan_guid: 'f4d4b95a-f55e-4593-8d54-3364c25798c4',
-        },
-      ]))
-      .get(`/forecast_events`)
-      .reply(200, JSON.stringify([
-        {
-          ...defaultForecastEvent,
-          event_guid: 'aa30fa3c-725d-4272-9052-c7186d4968a3',
-          resource_type: '_TESTING_APPLICATION_3_',
-        },
-        {
-          ...defaultForecastEvent,
-          event_guid: 'aa30fa3c-725d-4272-9052-c7186d4968a1',
-          resource_type: '_TESTING_APPLICATION_1_',
-        },
-        {
-          ...defaultForecastEvent,
-          event_guid: 'aa30fa3c-725d-4272-9052-c7186d4968a2',
-          resource_type: '_TESTING_APPLICATION_2_',
+          plan_guid: appGuid,
         },
       ]))
     ;
@@ -235,17 +186,17 @@ describe('calculator test suite', () => {
 
     const response = await getCalculator(ctx, {
       items: [
-        {planGUID: 'f4d4b95a-f55e-4593-8d54-3364c25798c4', numberOfNodes: '1'},
-        {planGUID: 'f4d4b95b-f55e-4593-8d54-3364c25798c0'},
+        {planGUID: appGuid, numberOfNodes: '1'},
+        {planGUID: postgresGuid},
       ],
     });
 
-    expect(response.body).toContain('_TESTING_APPLICATION_1_');
-    expect(response.body).toContain('_TESTING_APPLICATION_3_');
+    expect(response.body).toContain('postgres');
+    expect(response.body).toContain('app');
     if (response.body && typeof response.body === 'string') {
-      const idx1 = response.body.indexOf('_TESTING_APPLICATION_1_');
-      const idx3 = response.body.indexOf('_TESTING_APPLICATION_3_');
-      expect(idx3 > idx1).toBeTruthy(); // expected item3 to appear after item1
+      const idxPostgres = response.body.indexOf('postgres');
+      const idxApp = response.body.indexOf('app');
+      expect(idxPostgres > idxApp).toBeTruthy(); // expected postgres to appear after app
     }
   });
 
@@ -255,13 +206,6 @@ describe('calculator test suite', () => {
 
     // tslint:disable:max-line-length
     nock(config.billingAPI)
-      .filteringPath((path: string) => {
-        if (path.includes('/forecast_events')) {
-          return '/billing/forecast_events';
-        }
-
-        return path;
-      })
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
       .reply(200, JSON.stringify([
         {
@@ -270,8 +214,6 @@ describe('calculator test suite', () => {
           plan_guid: 'f4d4b95a-f55e-4593-8d54-3364c25798c1',
         },
       ]))
-      .get(`/forecast_events`)
-      .reply(200, `[]`)
     ;
     // tslint:enable:max-line-length
 
@@ -285,13 +227,6 @@ describe('calculator test suite', () => {
 
     // tslint:disable:max-line-length
     nock(config.billingAPI)
-      .filteringPath((path: string) => {
-        if (path.includes('/forecast_events')) {
-          return '/billing/forecast_events';
-        }
-
-        return path;
-      })
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
       .reply(200, JSON.stringify([
         {
@@ -325,8 +260,6 @@ describe('calculator test suite', () => {
           plan_guid: 'f4d4b95a-f55e-4593-8d54-3364c25798c6',
         },
       ]))
-      .get(`/forecast_events`)
-      .reply(200, `[]`)
     ;
     // tslint:enable:max-line-length
 
@@ -340,13 +273,6 @@ describe('calculator test suite', () => {
 
     // tslint:disable:max-line-length
     nock(config.billingAPI)
-      .filteringPath((path: string) => {
-        if (path.includes('/forecast_events')) {
-          return '/billing/forecast_events';
-        }
-
-        return path;
-      })
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
       .reply(200, JSON.stringify([
         {
@@ -372,8 +298,6 @@ describe('calculator test suite', () => {
           number_of_nodes: 1,
         },
       ]))
-      .get(`/forecast_events`)
-      .reply(200, [])
     ;
     // tslint:enable:max-line-length
 
@@ -396,13 +320,6 @@ describe('calculator test suite', () => {
 
     // tslint:disable:max-line-length
     nock(config.billingAPI)
-      .filteringPath((path: string) => {
-        if (path.includes('/forecast_events')) {
-          return '/billing/forecast_events';
-        }
-
-        return path;
-      })
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
       .reply(200, JSON.stringify([
         {
@@ -410,8 +327,6 @@ describe('calculator test suite', () => {
           name: 'aws-s3-bucket default',
         },
       ]))
-      .get(`/forecast_events`)
-      .reply(200, `[]`)
     ;
     // tslint:enable:max-line-length
 

--- a/src/components/calculator/calculator.test.ts
+++ b/src/components/calculator/calculator.test.ts
@@ -302,13 +302,10 @@ describe('calculator test suite', () => {
     // tslint:enable:max-line-length
 
     const response = await getCalculator(ctx, {
-      app: {},
-      mysql: {
-        plan: '_SERVICE_PLAN_GUID_',
-      },
-      redis: {
-        plan: '_NON_EXISTING_PLAN_',
-      },
+      items: [
+        {planGUID: '_SERVICE_PLAN_GUID_'},
+        {planGUID: '_NON_EXISTING_PLAN_'},
+      ],
     });
 
     expect(response.body).toContain('Pricing calculator');

--- a/src/components/calculator/calculator.ts
+++ b/src/components/calculator/calculator.ts
@@ -79,10 +79,6 @@ function bySize(a: IPricingPlan, b: IPricingPlan): number {
   return nameA > nameB ? 1 : -1;
 }
 
-function byEventGUID(e1: IBillableEvent, e2: IBillableEvent) {
-  return e1.eventGUID > e2.eventGUID ? 1 : -1;
-}
-
 export async function getCalculator(ctx: IContext, params: IParameters): Promise<IResponse> {
   const monthOfEstimate = moment().format('MMMM YYYY');
   const rangeStart = params.rangeStart || moment().startOf('month').format('YYYY-MM-DD');
@@ -187,7 +183,7 @@ async function getQuote(state: ICalculatorState): Promise<IQuote> {
   });
 
   return {
-    events: (forecastEvents as IBillableEvent[]).sort(byEventGUID),
+    events: (forecastEvents as IBillableEvent[]),
     exVAT: forecastEvents.reduce((total: number, instance: IBillableEvent) => total + instance.price.exVAT, 0),
     incVAT: forecastEvents.reduce((total: number, instance: IBillableEvent) => total + instance.price.incVAT, 0),
   };

--- a/src/components/calculator/calculator.ts
+++ b/src/components/calculator/calculator.ts
@@ -156,7 +156,12 @@ async function getQuote(state: ICalculatorState): Promise<IQuote> {
         resourceType: plan.serviceName,
         price: {
           ...defaultEvent.price,
-          exVAT: calculateQuote(item, plan),
+          exVAT: calculateQuote(
+            defaultEvent.memoryInMB,
+            defaultEvent.storageInMB,
+            defaultEvent.numberOfNodes,
+            plan,
+          ),
         },
       };
       return appEvent;
@@ -170,7 +175,12 @@ async function getQuote(state: ICalculatorState): Promise<IQuote> {
       storageInMB: plan.storageInMB,
       price: {
         ...defaultEvent.price,
-        exVAT: calculateQuote(item, plan),
+        exVAT: calculateQuote(
+          plan.memoryInMB,
+          plan.storageInMB,
+          plan.numberOfNodes,
+          plan,
+        ),
       },
     };
     return serviceEvent;
@@ -183,13 +193,13 @@ async function getQuote(state: ICalculatorState): Promise<IQuote> {
   };
 }
 
-function calculateQuote(item: IResourceItem, plan: IPricingPlan): number  {
+function calculateQuote(memoryInMB: number, storageInMB: number, numberOfNodes: number, plan: IPricingPlan): number  {
   return sum(plan.components.map(c => {
     const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
     const formula = c.formula
-      .replace('$memory_in_mb', item.memoryInMB || '0')
-      .replace('$storage_in_mb', item.storageInMB || '0')
-      .replace('$number_of_nodes', item.numberOfNodes || '0')
+      .replace('$memory_in_mb', memoryInMB.toString())
+      .replace('$storage_in_mb', storageInMB.toString())
+      .replace('$number_of_nodes', numberOfNodes.toString())
       .replace('$time_in_seconds', thirtyDaysInSeconds.toString());
     return formulaGrammar.parse(formula);
   }));

--- a/src/components/calculator/calculator.ts
+++ b/src/components/calculator/calculator.ts
@@ -197,7 +197,13 @@ async function getQuote(billing: BillingClient, state: ICalculatorState): Promis
   };
 }
 
-function calculateQuote(memoryInMB: number, storageInMB: number, numberOfNodes: number, plan: IPricingPlan, currencyRate: IRate): number  {
+function calculateQuote(
+  memoryInMB: number,
+  storageInMB: number,
+  numberOfNodes: number,
+  plan: IPricingPlan,
+  currencyRate: IRate,
+): number  {
   return sum(plan.components.map(c => {
     const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
     const formula = c.formula

--- a/src/components/calculator/formulaGrammar.pegjs
+++ b/src/components/calculator/formulaGrammar.pegjs
@@ -1,0 +1,42 @@
+/* Parser for the billing formulas in paas-billing's pricing plans.
+ *
+ * These are quite simple, so there's no need to go all the way to
+ * real postgres to calculate them.
+ *
+ * Examples:
+ *
+ * `ceil(8280/3600) * 0.00685`
+ * `(2 * 8280 * (2048/1024.0) * (0.01 / 3600)) * 0.40`
+ */
+
+Expression
+  = head:Term tail:(_ ("+" / "-") _ Term)* {
+      return tail.reduce(function(result, element) {
+        if (element[1] === "+") { return result + element[3]; }
+        if (element[1] === "-") { return result - element[3]; }
+      }, head);
+    }
+
+Term
+  = head:Factor tail:(_ ("*" / "/") _ Factor)* {
+      return tail.reduce(function(result, element) {
+        if (element[1] === "*") { return result * element[3]; }
+        if (element[1] === "/") { return result / element[3]; }
+      }, head);
+    }
+
+Factor
+  = "(" _ expr:Expression _ ")" { return expr; }
+  / Ceiling
+  / Number
+
+Number "number"
+  = Int Fraction? { return parseFloat(text()); }
+
+Fraction = "." [0-9]+
+Int = "0" / ([1-9] [0-9]*)
+
+Ceiling "ceil"
+  = "ceil(" val:Expression ")" { return Math.ceil(val) }
+
+_ "whitespace" = [ \t\n\r]*

--- a/src/components/calculator/formulaGrammar.test.ts
+++ b/src/components/calculator/formulaGrammar.test.ts
@@ -1,0 +1,77 @@
+import {parse} from './formulaGrammar.pegjs';
+
+describe('Billing formula grammar', () => {
+  it('should return a single number', () => {
+    expect(parse('1')).toBe(1);
+    expect(parse('0')).toBe(0);
+    expect(parse('1337.1337')).toBeCloseTo(1337.1337, 4);
+  });
+
+  it('should add 1 + 1', () => {
+    expect(parse('1 + 1')).toBe(2);
+  });
+
+  it('should add floating point numbers', () => {
+    expect(parse('1.1 + 1.1')).toBeCloseTo(2.2);
+    expect(parse('12345.6789 + 98765.4321')).toBeCloseTo(111111.111);
+  });
+
+  it('should give multiplication higher precedence than addition and subtraction', () => {
+    expect(parse('2*3+4')).toBe(10);
+    expect(parse('2+3*4')).toBe(14);
+    expect(parse('2*3-4')).toBe(2);
+    expect(parse('2-3*4')).toBe(-10);
+  });
+
+  it('should give division higher precedence than multiplication, addition and subtraction', () => {
+    expect(parse('1/2*4')).toBe(2);
+    expect(parse('4*1/2')).toBe(2);
+
+    expect(parse('4-1/2')).toBe(3.5);
+    expect(parse('1/2-1')).toBe(-0.5);
+
+    expect(parse('4+1/2')).toBe(4.5);
+    expect(parse('1/2+1')).toBe(1.5);
+  });
+
+  it('should give brackets higher precedence than multiplication', () => {
+    expect(parse('2*(3+4)')).toBe(14);
+    expect(parse('(2+3)*4')).toBe(20);
+  });
+
+  it('should give brackets higher precedence than division', () => {
+    expect(parse('1/(2*4)')).toBeCloseTo(1 / 8);
+    expect(parse('(4*1)/2')).toBe(2);
+  });
+
+  it('should round numbers up with `ceil`', () => {
+    expect(parse('ceil(1.00001)')).toBe(2);
+    expect(parse('ceil(5)')).toBe(5);
+    expect(parse('ceil(5555555555.5)')).toBe(5555555556);
+    expect(parse('ceil(0.9999999)')).toBe(1);
+  });
+
+  it('should handle heavily nested functions', () => {
+    expect(parse('(((((((1 + 1) * 2) + 1) * 2) + 1) * 2) + 1) * 2')).toBe(46);
+  });
+
+  it('should parse all the billing formula in use as of 2019-08-29', () => {
+    const formulae = [
+      { formula: '0', expectedValue: 0 },
+      { formula: 'ceil(20000/3600) * 3.385', expectedValue: 20.31 },
+      { formula: '2 * ceil(20000/3600) * 0.18', expectedValue: 2.16 },
+      { formula: '2 * 20000 * (2048/1024.0) * (0.01 / 3600)', expectedValue: 0.22222 },
+      { formula: '(4096/1024) * ceil(20000/2678401) * 0.266', expectedValue: 1.064 },
+      { formula: '(2 * 20000 * (2048/1024.0) * (0.01 / 3600)) * 0.40', expectedValue: 0.08888 },
+      { formula: '((1936.57/(48*1024))/30/24) * 2048 * ceil(20000 / 3600)', expectedValue: 0.6724201389 },
+    ];
+    formulae.forEach(f => expect(parse(f.formula)).toBeCloseTo(f.expectedValue, 4));
+  });
+
+  it('should error if the formula is badly formed', () => {
+    expect(() => parse('(1 + ()1 + 1)')).toThrow();
+    expect(() => parse('(1 + 1))')).toThrow();
+    expect(() => parse('((1 + 1)')).toThrow();
+    expect(() => parse('i liek grammar')).toThrow();
+  });
+});

--- a/stub-api/stub-billing.ts
+++ b/stub-api/stub-billing.ts
@@ -102,51 +102,45 @@ function mockBilling(app: express.Application, _config: IStubServerPorts): expre
           name: "postgres tiny-9.6",
           plan_guid: "f4d4b95a-f55e-4593-8d54-3364c25798c5",
           valid_from: "2017-01-01T00:00:00+00:00",
-          components: [],
-          memory_in_mb: 0,
-          storage_in_mb: 0,
-          number_of_nodes: 0
+          components: [
+            {
+              "name": "instance",
+              "formula": "ceil($time_in_seconds/3600) * 9",
+              "currency_code": "USD",
+              "vat_code": "Standard"
+            },
+            {
+              "name": "storage",
+              "formula": "(($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 9) * $number_of_nodes",
+              "currency_code": "USD",
+              "vat_code": "Standard"
+            }
+          ],
+          memory_in_mb: 1024,
+          storage_in_mb: 1024,
+          number_of_nodes: 4
         },
         {
           name: "postgres massive-9.6",
           plan_guid: "f4d4b95a-f55e-4593-8d54-3364c25798a5",
           valid_from: "2017-01-01T00:00:00+00:00",
-          components: [],
-          memory_in_mb: 0,
-          storage_in_mb: 0,
-          number_of_nodes: 0
-        },
-        {
-          name: "mysql large-ha-5.7",
-          plan_guid: "f4d4b95a-f55e-4593-8d54-3364c25798c6",
-          valid_from: "2017-01-01T00:00:00+00:00",
-          components: [],
-          memory_in_mb: 0,
-          storage_in_mb: 0,
-          number_of_nodes: 0
-        },
-        {
-          name: "redis tiny-clustered-3.2",
-          plan_guid: "f4d4b95a-f55e-4593-8d54-3364c25798c7",
-          valid_from: "2017-01-01T00:00:00+00:00",
-          components: [],
-          memory_in_mb: 0,
-          storage_in_mb: 0,
-          number_of_nodes: 0
-        },
-        {
-          name: "elasticsearch small-ha-6.x",
-          plan_guid: "f4d4b95a-f55e-4593-8d54-3364c25798c8",
-          valid_from: "2017-01-01T00:00:00+00:00",
-          components: [],
-          memory_in_mb: 0,
-          storage_in_mb: 0,
-          number_of_nodes: 0
-        },
-        {
-          name: "prometheus",
-          valid_from: "2002-01-01",
-          components: []
+          components: [
+            {
+              "name": "instance",
+              "formula": "ceil($time_in_seconds/3600) * 999999",
+              "currency_code": "USD",
+              "vat_code": "Standard"
+            },
+            {
+              "name": "storage",
+              "formula": "(($storage_in_mb/1024) * ceil($time_in_seconds/2678401) * 99999) * $number_of_nodes",
+              "currency_code": "USD",
+              "vat_code": "Standard"
+            }
+          ],
+          memory_in_mb: 1024,
+          storage_in_mb: 1024,
+          number_of_nodes: 4
         }
     ]))
   });


### PR DESCRIPTION
What
----

Use a parser to evaluate the expressions from the pricing plans directly, instead of sending events to postgres via the billing API.

[pegjs](https://pegjs.org/) is a simple parser generator for JavaScript that produces fast parsers.

Our billable events are calculated by evaluating formulae like:

```
$number_of_nodes * $time_in_seconds * ($memory_in_mb/1024.0) * (0.01 / 3600)
```

Currently we do this by inserting a fake event into the database with the correct details, recomputing the billable components of _every event from the beginning of time_, and then querying the database to find out how much the fake event cost.

It would be much simpler and faster if we could just evaluate the formula directly. Since the formula aren't all that complicated it's quite simple to write a grammar that does the calculation itself. The one in this PR is heavily based on the [pegjs arithmetic example](https://github.com/pegjs/pegjs/blob/master/examples/arithmetics.pegjs), but adds support for the `ceil()` function (which is equivalent to JS's `Math.ceil()`).

Using the parser means we no longer have to call `/forecast_events` in billing, so that whole code path can be cleaned up once this lands.

I've wired up `pegjs` using webpack, which means when you run `npm run build` it will generate a parser in JavaScript and bundle this into main.js. To make the tests work I had to implement a pegjs loader for Jest, and to make TypeScript happy I had to declare a module for `*.pegjs`.

Some other advantages disadvantages from one of my commit messages:

Advantages:

* It's HUGELY faster than talking to billing
* We can remove all of the /forecast_events code from billing
* It reduces the load on the billing database
* We can test that the calculator is working properly within paas-admin
  (e.g. that it's getting the maths right)
* We get to do something that almost feels like computer science

Disadvantages:

* There's a new opportunity for bugs now that we're not using the exact
  same expression evaluator as postgres (which could cause the
  calculator to give incorrect results, if we screw this up)
* If we add any logic to the pricing plans that isn't implemented in our
  simple grammar (e.g. if we used `floor` as well as `ceil`) then the
  calculator will break until we fix the grammar.

**NOTE:** I've also hardcoded the length of a month to 30 days, so this will stop the estimates from changing every month - happy to discuss whether this is the right approach.

How to review
-------------

* Code review (feel free to come chat with me if you're not sure of the grammar - it's probably an unfamiliar language to most people)
* Check that the estimates this produces in  a dev env match the ones that billing produces (maybe test before and after a `cf push`? - bear in mind that this assumes months are 30 days long)

Who can review
---------------

Not @richardTowers 
