### PR TITLE
Remove govuk-body from `<body>`

### DIFF
--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -5,7 +5,6 @@
 {% extends "govuk-frontend/govuk/template.njk" %}
 
 {% set htmlLang = "en" %}
-{% set bodyClasses = "govuk-body" %}
 
 {% block pageTitle %}PaaS Administration Tool{% endblock %}
 

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -14,6 +14,10 @@ $govuk-global-styles: true;
 
 @import '../components/statements/statements';
 
+.govuk-template__body {
+  font-family: "GDS Transport", Arial, sans-serif;
+}
+
 .text-right {
   text-align: right;
 }


### PR DESCRIPTION
What
----

The .govuk-body class is only intended for body text (like paragraphs
and so on), not the `<body>` element. Putting it on the `<body>` adds a
bunch of unintended styles. See #426.

Because we've had the class on the body all along we've got used to the
default font-family being GDS Transport, and removing it now causes a
bunch of things to fall through to the browser's default (serif,
usually). Rather than going through and adding classes to all of these
elements it's easier just to set the font-family on the body.

`.govuk-body` did a bunch of other things which will subtly change the
layouts when we remove it. Better to show than tell:

| Before | After |
|--------|------|
| ![Screenshot_2019-09-27 Organisations](https://user-images.githubusercontent.com/1696784/65786218-1a82f700-e14e-11e9-86b5-268794d62b49.png) | ![Screenshot_2019-09-27 Organisations(1)](https://user-images.githubusercontent.com/1696784/65786197-0d660800-e14e-11e9-9915-9fad23abf27c.png) |
| ![Screenshot_2019-09-27 the-system_domain-org-name – Spaces(1)](https://user-images.githubusercontent.com/1696784/65786277-38505c00-e14e-11e9-83f0-45ae9ad44c07.png) | ![Screenshot_2019-09-27 the-system_domain-org-name – Spaces](https://user-images.githubusercontent.com/1696784/65786259-3090b780-e14e-11e9-8414-c369ec3e3751.png) |
| ![Screenshot_2019-09-27 name-2064 - Overview(1)](https://user-images.githubusercontent.com/1696784/65786308-47370e80-e14e-11e9-90ac-f0c156bf0b9f.png) | ![Screenshot_2019-09-27 name-2064 - Overview](https://user-images.githubusercontent.com/1696784/65786296-41412d80-e14e-11e9-90a3-0850657ff84f.png) |
| ![Screenshot_2019-09-27 name-79 - Application Overview(1)](https://user-images.githubusercontent.com/1696784/65786329-57e78480-e14e-11e9-8311-6beedc3f7f33.png) | ![Screenshot_2019-09-27 name-79 - Application Overview](https://user-images.githubusercontent.com/1696784/65786316-51f1a380-e14e-11e9-8e6a-d69e5552c246.png) |
| ![Screenshot_2019-09-27 Invite a new team member(1)](https://user-images.githubusercontent.com/1696784/65786349-65047380-e14e-11e9-9777-82e6ad163134.png) | ![Screenshot_2019-09-27 Invite a new team member](https://user-images.githubusercontent.com/1696784/65786339-5f0e9280-e14e-11e9-85c4-4d80894cf1de.png) |

Basically some tiny changes to margins, and some font-size changes for some of the headings.

How to review
-------------

* Code review / look at the screenshots
* If you're feeling thorough, push it to your dev env

Who can review
---------------

Not @richardTowers

Fixes #426
