### PR TITLE
[#168783741] Expand reports for our economist

### DIFF
--- a/src/components/org-users/org-users.ts
+++ b/src/components/org-users/org-users.ts
@@ -100,7 +100,7 @@ async function setAllUserRolesForOrg(
   params: IParameters,
   roles: { readonly [i: string]: IPermissions },
 ): Promise<any> {
-  const spaces = await cf.spaces(params.organizationGUID);
+  const spaces = await cf.orgSpaces(params.organizationGUID);
 
   const orgRoleEndpoints: ReadonlyArray<OrganizationUserRoleEndpoints> = [
     'billing_managers',
@@ -258,7 +258,7 @@ export async function listUsers(ctx: IContext, params: IParameters): Promise<IRe
     cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'billing_manager'),
     cf.organization(params.organizationGUID),
     cf.usersForOrganization(params.organizationGUID),
-    cf.spaces(params.organizationGUID),
+    cf.orgSpaces(params.organizationGUID),
   ]);
 
   const spaceUserLists = await Promise.all(spacesVisibleToUser.map(async space => {
@@ -336,7 +336,7 @@ export async function inviteUserForm(ctx: IContext, params: IParameters): Promis
 
   const [organization, spaces] = await Promise.all([
     cf.organization(params.organizationGUID),
-    cf.spaces(params.organizationGUID),
+    cf.orgSpaces(params.organizationGUID),
   ]);
 
   /* istanbul ignore next */
@@ -406,7 +406,7 @@ export async function inviteUser(ctx: IContext, params: IParameters, body: objec
 
   const [organization, spaces] = await Promise.all([
     cf.organization(params.organizationGUID),
-    cf.spaces(params.organizationGUID),
+    cf.orgSpaces(params.organizationGUID),
   ]);
   const errors = [];
   const values: IUserPostBody = merge({
@@ -669,7 +669,7 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
 
   const [organization, spaces, orgUsers] = await Promise.all([
     cf.organization(params.organizationGUID),
-    cf.spaces(params.organizationGUID),
+    cf.orgSpaces(params.organizationGUID),
     cf.usersForOrganization(params.organizationGUID),
   ]);
 
@@ -766,7 +766,7 @@ export async function updateUser(ctx: IContext, params: IParameters, body: objec
 
   const [organization, spaces, orgUsers] = await Promise.all([
     cf.organization(params.organizationGUID),
-    cf.spaces(params.organizationGUID),
+    cf.orgSpaces(params.organizationGUID),
     cf.usersForOrganization(params.organizationGUID),
   ]);
   const errors = [];

--- a/src/components/reports/cost-by-service.njk
+++ b/src/components/reports/cost-by-service.njk
@@ -85,4 +85,52 @@
     <tfoot>
   </table>
 
+  <h1 class="govuk-heading-l">
+    Billables by organisation and space and service for {{ date }}
+  </h1>
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">
+          Organization
+        </th>
+        <th class="govuk-table__header" scope="col">
+          Space
+        </th>
+        <th class="govuk-table__header" scope="col">
+          Service
+        </th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+          Including VAT
+        </th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+          Excluding VAT
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {% for record in billablesByOrganisationAndSpaceAndService %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell" scope="row">
+            {{ record.orgName }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ record.spaceName }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ record.serviceGroup }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            £{{ record.incVAT | currency(2) }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">
+            £{{ record.exVAT | currency(2) }}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    <tfoot>
+  </table>
+
 {% endblock %}

--- a/src/components/reports/cost-by-service.ts
+++ b/src/components/reports/cost-by-service.ts
@@ -41,8 +41,7 @@ export async function viewCostByServiceReport(
   });
 
   const orgs = (await cf.organizations())
-    .filter(org => !org.entity.name.match(/^(CAT|SMOKE|PERF|ACC)/));
-
+    .filter(org => !org.entity.name.match(/^(CAT|SMOKE|PERF|ACC|BACC)/));
   const orgsByGUID = groupBy(orgs, x => x.metadata.guid);
   const orgGUIDs = Object.keys(orgsByGUID);
 

--- a/src/components/reports/cost-by-service.ts
+++ b/src/components/reports/cost-by-service.ts
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 import { BillingClient } from '../../lib/billing';
 import CloudFoundryClient from '../../lib/cf';
-import { IOrganization } from '../../lib/cf/types';
+import { IOrganization, ISpace } from '../../lib/cf/types';
 import { IParameters, IResponse } from '../../lib/router';
 
 import { IContext } from '../app/context';
@@ -19,6 +19,11 @@ export interface IBillableByService {
 export interface IBillableByOrganisationAndService extends IBillableByService {
   orgGUID: string;
   orgName: string;
+}
+
+export interface IBillableByOrganisationAndSpaceAndService extends IBillableByOrganisationAndService {
+  spaceGUID: string;
+  spaceName: string;
 }
 
 export async function viewCostByServiceReport(
@@ -49,8 +54,13 @@ export async function viewCostByServiceReport(
     rangeStart, rangeStop, orgGUIDs,
   });
 
+  const spaces = await cf.spaces();
+  const spacesByGUID = groupBy(spaces, x => x.metadata.guid);
+
   const billablesByService = getBillableEventsByService(billableEvents);
   const billablesByOrganisationAndService = getBillableEventsByOrganisationAndService(billableEvents, orgsByGUID);
+  const billablesByOrganisationAndSpaceAndService = getBillableEventsByOrganisationAndSpaceAndService(
+    billableEvents, orgsByGUID, spacesByGUID);
 
   return {
     body: costReportTemplate.render({
@@ -61,6 +71,7 @@ export async function viewCostByServiceReport(
       date: moment(rangeStart).format('MMMM YYYY'),
       billablesByService,
       billablesByOrganisationAndService,
+      billablesByOrganisationAndSpaceAndService,
     }),
   };
 }
@@ -94,6 +105,30 @@ export function getBillableEventsByOrganisationAndService(
     .sort((a, b) => compareOrgName(a, b) || comparePriceIncVAT(a, b));
 }
 
+export function getBillableEventsByOrganisationAndSpaceAndService(
+    billableEvents: ReadonlyArray<IBillableEvent>,
+    orgsByGUID: Dictionary<ReadonlyArray<IOrganization>>,
+    spacesByGUID: Dictionary<ReadonlyArray<ISpace>>,
+  ): ReadonlyArray<IBillableByOrganisationAndSpaceAndService> {
+  const billableEventsByOrgGUID = Object.entries(groupBy(billableEvents, x => x.orgGUID));
+  return flatMap(
+    billableEventsByOrgGUID,
+    ([orgGUID, billableEventsForOrg]) => {
+      const org = (orgsByGUID[orgGUID] || [])[0];
+      const orgName = org ? org.entity.name : 'unknown';
+      const orgBillableEventsBySpaceGUID = Object.entries(groupBy(billableEventsForOrg, x => x.spaceGUID));
+      return flatMap(
+        orgBillableEventsBySpaceGUID,
+        ([spaceGUID, billableEventsForSpace]) => {
+          const space = (spacesByGUID[spaceGUID] || [])[0];
+          const spaceName = space ? space.entity.name : 'unknown';
+          return getBillableEventsByService(billableEventsForSpace)
+            .map(x => ({...x, orgGUID, orgName, spaceGUID, spaceName}));
+        });
+    })
+    .sort((a, b) => compareOrgName(a, b) || compareSpaceName(a, b) || comparePriceIncVAT(a, b));
+}
+
 function getServiceGroup(billableEvent: IBillableEvent) {
   const details = billableEvent.price.details;
   if (details.length < 1) {
@@ -113,6 +148,10 @@ function getServiceGroup(billableEvent: IBillableEvent) {
 
 function compareOrgName(a: {readonly orgName: string}, b: {readonly orgName: string}) {
   return a.orgName.localeCompare(b.orgName);
+}
+
+function compareSpaceName(a: {readonly spaceName: string}, b: {readonly spaceName: string}) {
+  return a.spaceName.localeCompare(b.spaceName);
 }
 
 function comparePriceIncVAT(a: {readonly incVAT: number}, b: {readonly incVAT: number}) {

--- a/src/components/spaces/spaces.ts
+++ b/src/components/spaces/spaces.ts
@@ -132,7 +132,7 @@ export async function listSpaces(ctx: IContext, params: IParameters): Promise<IR
   const [isManager, isBillingManager, spaces, organization, users, cflinuxfs2StackGUID] = await Promise.all([
     cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'org_manager'),
     cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'billing_manager'),
-    cf.spaces(params.organizationGUID),
+    cf.orgSpaces(params.organizationGUID),
     cf.organization(params.organizationGUID),
     cf.usersForOrganization(params.organizationGUID).then(async (orgUsers) => {
       return hydrateAccountsUsernames(orgUsers, accountsClient);

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -200,14 +200,27 @@ describe('lib/cf test suite', () => {
     expect(quota.entity.name).toEqual('name-1996');
   });
 
-  it('should obtain list of spaces', async () => {
+  it('should obtain list of an organization\'s spaces', async () => {
     nockCF
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
       .reply(200, data.spaces)
     ;
 
     const client = new CloudFoundryClient(config);
-    const spaces = await client.spaces('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
+    const spaces = await client.orgSpaces('3deb9f04-b449-4f94-b3dd-c73cefe5b275');
+
+    expect(spaces.length > 0).toBeTruthy();
+    expect(spaces[0].entity.name).toEqual('name-1774');
+  });
+
+  it('should obtain list of spaces', async () => {
+    nockCF
+      .get('/v2/spaces')
+      .reply(200, data.spaces)
+    ;
+
+    const client = new CloudFoundryClient(config);
+    const spaces = await client.spaces();
 
     expect(spaces.length > 0).toBeTruthy();
     expect(spaces[0].entity.name).toEqual('name-1774');

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -140,7 +140,12 @@ export default class CloudFoundryClient {
     return response.data;
   }
 
-  public async spaces(organizationGUID: string): Promise<ReadonlyArray<cf.ISpace>> {
+  public async spaces(): Promise<ReadonlyArray<cf.ISpace>> {
+    const response = await this.request('get', `/v2/spaces`);
+    return this.allResources(response);
+  }
+
+  public async orgSpaces(organizationGUID: string): Promise<ReadonlyArray<cf.ISpace>> {
     const response = await this.request('get', `/v2/organizations/${organizationGUID}/spaces`);
     return this.allResources(response);
   }


### PR DESCRIPTION
What
----

This PR adds a new table to the `cost-by-service` reports page, breaking costs down by organisation, space and backing service.

How to review
-------------

* Code review;
* View the report. Not that it's linked to anywhere. This needs some rethinking–we should be able to get CSVs out easily.

Who can review
---------------

Not @46bit 