### PR TITLE
Fix jumping interface

### DIFF
--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -7,6 +7,7 @@ a.paas-govuk-tag {
 
   &:hover {
     border-bottom: 3px solid #fff;
+    margin-bottom: -3px;
   }
 
   &.paas-govuk-tag-london {


### PR DESCRIPTION
What
----

Once hovering over the badge, the entire header appears to be jumping.
This can be easily solved, by reducing the margin on hover.

How to review
-------------

- Sanity check
