### PR TITLE
Small task: Increase max width of govuk-width-container

### DIFF
--- a/src/components/org-users/org-users.njk
+++ b/src/components/org-users/org-users.njk
@@ -19,18 +19,7 @@
       Organisation level users can manage and/or view information regarding user accounts, billing,
       resource quota for the organisation and spaces. To edit a member's role go to their profile page.
     </p>
-  </div>
 
-  <div class="govuk-grid-column-one-third text-right">
-    {% if isAdmin or isManager %}
-      {{ govukButton({
-        text: "Invite a new member",
-        href: linkTo('admin.organizations.users.invite', {organizationGUID: organization.metadata.guid})
-      }) }}
-    {% endif %}
-  </div>
-
-  <div class="govuk-grid-column-full">
     <details class="govuk-details" role="group">
       <summary class="govuk-details__summary" role="button" aria-controls="details-content-0" aria-expanded="false">
         <span class="govuk-details__summary-text">
@@ -68,6 +57,15 @@
         </p>
       </div>
     </details>
+  </div>
+
+  <div class="govuk-grid-column-one-third text-right">
+    {% if isAdmin or isManager %}
+      {{ govukButton({
+        text: "Invite a new member",
+        href: linkTo('admin.organizations.users.invite', {organizationGUID: organization.metadata.guid})
+      }) }}
+    {% endif %}
   </div>
 </div>
 

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -18,6 +18,10 @@ $govuk-global-styles: true;
   font-family: "GDS Transport", Arial, sans-serif;
 }
 
+.govuk-width-container {
+  max-width: 1200px;
+}
+
 .text-right {
   text-align: right;
 }


### PR DESCRIPTION
What
----

Sticking to 960px width makes it harder for us to design an admin
interface.

If you look in analytics 90% of our users use a screen size with width >= 1280px.

We can increase the max width of the govuk-width-container which better
uses horizontal space

How to review
-------------

Code review

Deploy to your dev env and click around (alternatively look at prod and edit the class in your browser).

Check my assertion about [analytics](https://analytics.google.com/analytics/web/#/report/visitors-browser/a72121642w132192710p136112751/explorer-segmentExplorer.segmentId=analytics.screenResolution&explorer-table.plotKeys=%5B%5D&explorer-table.rowStart=0&explorer-table.rowCount=10&explorer-table-tableMode.selected=pie/)

Who can review
---------------

Not @tlwr