### PR TITLE
Fix all orgs are billable on orgs page

### DIFF
--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -4,6 +4,7 @@ import nock from 'nock';
 import request, {SuperTest, Test} from 'supertest';
 
 import {org as defaultOrg} from '../../lib/cf/test-data/org';
+import { billableOrgQuota, billableOrgQuotaGUID } from '../../lib/cf/test-data/org-quota';
 import {wrapResources} from '../../lib/cf/test-data/wrap-resources';
 import Router, { IParameters } from '../../lib/router';
 import * as uaaData from '../../lib/uaa/uaa.test.data';
@@ -190,6 +191,9 @@ describe('app test suite', () => {
         nockCF
           .get('/v2/organizations')
           .reply(200, JSON.stringify(wrapResources(defaultOrg())))
+
+          .get(`/v2/quota_definitions/${billableOrgQuotaGUID}`)
+          .reply(200, JSON.stringify(billableOrgQuota()))
         ;
 
         nockUAA
@@ -300,6 +304,9 @@ describe('app test suite', () => {
       nockCF
         .get('/v2/organizations')
         .reply(200, JSON.stringify(wrapResources(defaultOrg())))
+
+        .get(`/v2/quota_definitions/${billableOrgQuotaGUID}`)
+        .reply(200, JSON.stringify(billableOrgQuota()))
       ;
 
       nockUAA

--- a/src/components/organizations/organizations.njk
+++ b/src/components/organizations/organizations.njk
@@ -41,7 +41,7 @@
             </a>
           </td>
           <td class="govuk-table__cell">
-            {% if org.entity.quota.entity.name == 'default' %}
+            {% if orgQuotasByGUID[org.entity.quota_definition_guid].entity.name == 'default' %}
               Trial
             {% else %}
               Billable

--- a/src/components/organizations/organizations.test.ts
+++ b/src/components/organizations/organizations.test.ts
@@ -3,6 +3,12 @@ import nock from 'nock';
 
 import {listOrganizations} from '.';
 import {org as defaultOrg} from '../../lib/cf/test-data/org';
+import {
+  billableOrgQuota,
+  billableOrgQuotaGUID,
+  trialOrgQuota,
+  trialOrgQuotaGUID,
+} from '../../lib/cf/test-data/org-quota';
 import {wrapResources} from '../../lib/cf/test-data/wrap-resources';
 import * as uaaData from '../../lib/uaa/uaa.test.data';
 import {createTestContext} from '../app/app.test-helpers';
@@ -13,6 +19,14 @@ const organizations = JSON.stringify(wrapResources(
   lodash.merge(defaultOrg(), {entity: {name: 'd-org-name-2'}}),
   lodash.merge(defaultOrg(), {entity: {name: 'b-org-name-3'}}),
   lodash.merge(defaultOrg(), {entity: {name: 'a-org-name-4'}}),
+
+  lodash.merge(
+    defaultOrg(), {
+      entity: {
+        name: 'a-trial-org-name',
+        quota_definition_guid: trialOrgQuotaGUID,
+      },
+    }),
 ));
 
 const ctx: IContext = createTestContext();
@@ -30,6 +44,12 @@ describe('organizations test suite', () => {
     nockCF
       .get('/v2/organizations')
       .reply(200, organizations)
+
+      .get(`/v2/quota_definitions/${billableOrgQuotaGUID}`)
+      .reply(200, JSON.stringify(billableOrgQuota()))
+
+      .get(`/v2/quota_definitions/${trialOrgQuotaGUID}`)
+      .reply(200, JSON.stringify(trialOrgQuota()))
     ;
 
     nockUAA
@@ -58,16 +78,24 @@ describe('organizations test suite', () => {
     const response = await listOrganizations(ctx, {});
 
     const matches = extractOrganizations(response.body as string);
-    expect(matches.length).toBe(4);
+    expect(matches.length).toBe(5);
     expect(matches[0]).toBe('a-org-name-4');
-    expect(matches[1]).toBe('b-org-name-3');
-    expect(matches[2]).toBe('c-org-name-1');
-    expect(matches[3]).toBe('d-org-name-2');
+    expect(matches[1]).toBe('a-trial-org-name');
+    expect(matches[2]).toBe('b-org-name-3');
+    expect(matches[3]).toBe('c-org-name-1');
+    expect(matches[4]).toBe('d-org-name-2');
+  });
+
+  it('should report the org quotas for both trial and billable orgs', async () => {
+    const response = await listOrganizations(ctx, {});
+
+    expect(response.body).toMatch(/a-org-name-4.*(?!Trial)Billable/sm);
+    expect(response.body).toMatch(/a-trial-org-name.*(?!Billable)Trial/sm);
   });
 });
 
 function extractOrganizations(responseBody: string): ReadonlyArray<string> {
-  const re = /(.-org-name-\d)/g;
+  const re = /(.-(trial-)?org-name(-\d)?)/g;
   const matches = [];
   while (true) {
     const match = re.exec(responseBody);

--- a/src/lib/cf/test-data/org-quota.ts
+++ b/src/lib/cf/test-data/org-quota.ts
@@ -1,0 +1,53 @@
+import { IOrganizationQuota } from '../types';
+
+export const billableOrgQuotaName = 'billable';
+export const billableOrgQuotaGUID = 'dcb680a9-b190-4838-a3d2-b84aa17517a6';
+
+export const billableOrgQuota = (): IOrganizationQuota => JSON.parse(`{
+  "metadata": {
+    "guid": "${billableOrgQuotaGUID}",
+    "url": "/v2/quota_definitions/${billableOrgQuotaGUID}",
+    "created_at": "2016-06-08T16:41:39Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "${billableOrgQuotaName}",
+    "non_basic_services_allowed": true,
+    "total_services": 60,
+    "total_routes": 1000,
+    "total_private_domains": -1,
+    "memory_limit": 20480,
+    "trial_db_allowed": true,
+    "instance_memory_limit": -1,
+    "app_instance_limit": -1,
+    "app_task_limit": -1,
+    "total_service_keys": -1,
+    "total_reserved_route_ports": 5
+  }
+}`);
+
+export const trialOrgQuotaName = 'default';
+export const trialOrgQuotaGUID = '99999999-a8c0-4c43-9c72-649df53da8cb';
+
+export const trialOrgQuota = (): IOrganizationQuota => JSON.parse(`{
+  "metadata": {
+    "guid": "${trialOrgQuotaGUID}",
+    "url": "/v2/quota_definitions/${trialOrgQuotaGUID}",
+    "created_at": "2016-06-08T16:41:39Z",
+    "updated_at": "2016-06-08T16:41:26Z"
+  },
+  "entity": {
+    "name": "${trialOrgQuotaName}",
+    "non_basic_services_allowed": false,
+    "total_services": 60,
+    "total_routes": 1000,
+    "total_private_domains": -1,
+    "memory_limit": 20480,
+    "trial_db_allowed": false,
+    "instance_memory_limit": -1,
+    "app_instance_limit": -1,
+    "app_task_limit": -1,
+    "total_service_keys": -1,
+    "total_reserved_route_ports": 5
+  }
+}`);


### PR DESCRIPTION
Closes #450

What
----

Orgs don't have a quota directly on their object, you have to get it
directly.

This wasn't obvious because nunjucks isn't compile time type checked

We should look up the quotas after we get the orgs, and have some tests
so this doesn't happen again

How to review
-------------

Tests

Code review

Who can review
---------------

Not @tlwr
