### PR TITLE
Correctly show what orgs a user manages

### DIFF
--- a/src/components/users/user.njk
+++ b/src/components/users/user.njk
@@ -59,7 +59,7 @@
   <h3 class="govuk-heading-m">Managed Orgs</h3>
   <p class="govuk-body">This user manages {{ managedOrgs.length }} {{ managedOrgs.length | plural('org', 'orgs') }}.</p>
   <ul class="govuk-list govuk-list--bullet">
-    {% for org in orgs %}
+    {% for org in managedOrgs %}
       <li>
         <a href="{{ linkTo('admin.organizations.view', {organizationGUID: org.metadata.guid}) }}"
            class="govuk-link">


### PR DESCRIPTION
What
----

On the users page there was a bug where we looped through member orgs
twice, rather than the orgs which the user manages.

How to review
-------------

Done as pair

Co-authored-by: Lee Porte
Co-authored-by: Toby Lorne
