### PR TITLE
[#169155489] Replace mailto links with support form

### DIFF
--- a/src/components/account/access-denied.njk
+++ b/src/components/account/access-denied.njk
@@ -14,8 +14,8 @@
       <p class="govuk-body">Access Denied</p>
       <p class="govuk-body">We're unable to access information about you. You may need to provide conset with your SSO provider when asked.</p>
       <p class="govuk-body">
-        If you have any queries, send an email to
-        <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">support</a>.
+        If you have any queries, contact
+        <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">support</a>.
       </p>
       <a href="{{ linkTo("admin.home") }}">Back to account</a>
     </div>

--- a/src/components/account/temporarily-unavailable.njk
+++ b/src/components/account/temporarily-unavailable.njk
@@ -14,8 +14,8 @@
       <p class="govuk-body">{{providerName | capitalize }} SSO provider is temporarily unavailable.</p>
       <p class="govuk-body">Please try again later</p>
       <p class="govuk-body">
-        If you have any queries, send an email to
-        <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">support</a>.
+        If you have any queries, contact
+        <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">support</a>.
       </p>
       <a href="{{ linkTo("admin.home") }}">Back to account</a>
     </div>

--- a/src/components/account/unsuccessful-uplift.njk
+++ b/src/components/account/unsuccessful-uplift.njk
@@ -13,8 +13,8 @@
       <h1 class="govuk-heading-xl">Sorry, there is a problem activating {{providerName | capitalize }} SSO for your account</h1>
       <p class="govuk-body">
         We were unable to activate {{providerName | capitalize }} SSO for your GOV.UK PaaS account.
-        Please send an email to
-        <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">support</a>.
+        Please contact
+        <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">support</a>.
       </p>
       <a href="{{ linkTo("admin.home") }}">Back to account</a>
     </div>

--- a/src/components/account/use-google-sso.njk
+++ b/src/components/account/use-google-sso.njk
@@ -47,8 +47,8 @@
             </a>.
           </p>
           <p>
-            If you would like to switch sign-on method, send an email to
-            <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">support</a>.
+            If you would like to switch sign-on method, contact
+            <a href="https://www.cloud.service.gov.uk/support">support</a>.
           </p>
         </section>
       </div>
@@ -64,8 +64,8 @@
             </a>.
           </p>
           <p>
-            If you would like begin using Microsoft single sign-on, send an email to
-            <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">support</a>.
+            If you would like begin using Microsoft single sign-on, contact
+            <a href="https://www.cloud.service.gov.uk/support">support</a>.
           </p>
         </section>
       </div>

--- a/src/components/account/use-microsoft-sso.njk
+++ b/src/components/account/use-microsoft-sso.njk
@@ -47,8 +47,8 @@
             </a>.
           </p>
           <p>
-            If you would like to switch sign-on method, send an email to
-            <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">support</a>.
+            If you would like to switch sign-on method, contact
+            <a href="https://www.cloud.service.gov.uk/support">support</a>.
           </p>
         </section>
       </div>
@@ -64,8 +64,8 @@
             </a>.
           </p>
           <p>
-            If you would like begin using Microsoft single sign-on, send an email to
-            <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">support</a>.
+            If you would like begin using Microsoft single sign-on, contact
+            <a href="https://www.cloud.service.gov.uk/support">support</a>.
           </p>
         </section>
       </div>

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -103,7 +103,7 @@
       text: 'beta'
     },
     html: '
-      <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">Get support</a>
+      <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">Get support</a>
       or
       <a class="govuk-link" href="https://www.cloud.service.gov.uk/pricing">view our pricing</a>
     '


### PR DESCRIPTION
What
----

mailto: links are generally a terrible user experience, so this is
better.

Note that there's still a mailto link on the users page - there's no
immediately obvious way of fixing this one.

How to review
-------------

* Code review is probably enough

Who can review
---------------

Not @richardtowers