### PR TITLE
Add organisation owner to /reports/organisations

### DIFF
--- a/src/components/reports/organizations.njk
+++ b/src/components/reports/organizations.njk
@@ -36,6 +36,7 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Organisation</th>
+        <th class="govuk-table__header">Owner</th>
         <th class="govuk-table__header">Quota</th>
         <th class="govuk-table__header">Creation date</th>
         <th class="govuk-table__header">Status</th>
@@ -45,20 +46,23 @@
     {% for organization in trialOrgs %}
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          <a href="{{linkTo('admin.organizations.view', {organizationGUID: organization.metadata.guid})}}" class="govuk-link">
-            {{ organization.entity.name }}
+          <a href="{{linkTo('admin.organizations.view', {organizationGUID: organization.guid})}}" class="govuk-link">
+            {{ organization.name }}
           </a>
         </td>
         <td class="govuk-table__cell">
-          {{orgQuotaMapping[organization.entity.quota_definition_guid].entity.name}}
+          {{organization.metadata.annotations.owner | default('Unknown')}}
         </td>
         <td class="govuk-table__cell">
-          {{organization.metadata.created_at | nicedate}}
+          {{orgQuotaMapping[organization.relationships.quota.data.guid].entity.name}}
         </td>
         <td class="govuk-table__cell">
-					{{orgTrialExpirys[organization.metadata.guid] | pastorfuture('Expired', 'Expires') -}}
+          {{organization.created_at | nicedate}}
+        </td>
+        <td class="govuk-table__cell">
+					{{orgTrialExpirys[organization.guid] | pastorfuture('Expired', 'Expires') -}}
           {{- ' ' -}}
-          {{orgTrialExpirys[organization.metadata.guid] | relativetime}}
+          {{orgTrialExpirys[organization.guid] | relativetime}}
         </td>
       </tr>
     {% endfor %}
@@ -82,6 +86,7 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Organisation</th>
+        <th class="govuk-table__header">Owner</th>
         <th class="govuk-table__header">Quota</th>
         <th class="govuk-table__header">Creation date</th>
         <th class="govuk-table__header">Time since creation</th>
@@ -91,18 +96,21 @@
     {% for organization in billableOrgs %}
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          <a href="{{linkTo('admin.organizations.view', {organizationGUID: organization.metadata.guid})}}" class="govuk-link">
-            {{ organization.entity.name }}
+          <a href="{{linkTo('admin.organizations.view', {organizationGUID: organization.guid})}}" class="govuk-link">
+            {{ organization.name }}
           </a>
         </td>
         <td class="govuk-table__cell">
-          {{orgQuotaMapping[organization.entity.quota_definition_guid].entity.name}}
+          {{organization.metadata.annotations.owner | default('Unknown')}}
         </td>
         <td class="govuk-table__cell">
-          {{organization.metadata.created_at | nicedate}}
+          {{orgQuotaMapping[organization.relationships.quota.data.guid].entity.name}}
         </td>
         <td class="govuk-table__cell">
-          Created {{organization.metadata.created_at | relativetime}}
+          {{organization.created_at | nicedate}}
+        </td>
+        <td class="govuk-table__cell">
+          Created {{organization.created_at | relativetime}}
         </td>
       </tr>
     {% endfor %}

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -89,6 +89,22 @@ describe('lib/cf test suite', () => {
     expect(collection[1]).toEqual('b');
   });
 
+  it('should iterate over all v3 pages to gather resources', async () => {
+    nockCF
+      .get('/v3/test')
+      .reply(200, `{"pagination": {"next":{"href": "/v3/test?page=2"}},"resources":["a"]}`)
+      .get('/v3/test?page=2')
+      .reply(200, `{"pagination": {"next":null},"resources":["b"]}`)
+    ;
+
+    const client = new CloudFoundryClient(config);
+    const response = await client.request('get', '/v3/test');
+    const collection = await client.allV3Resources(response);
+
+    expect([...collection].length).toEqual(2);
+    expect(collection[1]).toEqual('b');
+  });
+
   it('should throw an error when receiving 404', async () => {
     nockCF
       .get('/v2/failure/404')

--- a/src/lib/cf/test-data/org.ts
+++ b/src/lib/cf/test-data/org.ts
@@ -1,4 +1,4 @@
-import { IOrganization } from '../types';
+import { IOrganization, IV3OrganizationResource } from '../types';
 
 export const orgName      = 'the-system_domain-org-name';
 export const orgGUID      = 'a7aff246-5f5b-4cf8-87d8-f316053e4a20';
@@ -26,5 +26,37 @@ export const org = (): IOrganization => JSON.parse(`{
     "auditors_url": "/v2/organizations/${orgGUID}/auditors",
     "app_events_url": "/v2/organizations/${orgGUID}/app_events",
     "space_quota_definitions_url": "/v2/organizations/${orgGUID}/space_quota_definitions"
+  }
+}`);
+
+export const v3Org = (): IV3OrganizationResource => JSON.parse(`{
+  "guid": "${orgGUID}",
+  "created_at": "2016-06-08T16:41:33Z",
+  "updated_at": "2016-06-08T16:41:26Z",
+  "name": "${orgName}",
+  "suspended": false,
+  "relationships": {
+     "quota": {
+        "data": {
+           "guid": "${orgQuotaGUID}"
+        }
+     }
+  },
+  "links": {
+     "self": {
+        "href": "/v3/organizations/${orgGUID}"
+     },
+     "domains": {
+        "href": "/v3/organizations/${orgGUID}/domains"
+     },
+     "default_domain": {
+        "href": "/v3/organizations/${orgGUID}/domains/default"
+     }
+  },
+  "metadata": {
+     "labels": {},
+     "annotations": {
+        "owner": "some-owner"
+     }
   }
 }`);

--- a/src/lib/cf/test-data/wrap-resources.ts
+++ b/src/lib/cf/test-data/wrap-resources.ts
@@ -1,3 +1,5 @@
+import { IV3Response } from '../types';
+
 export function wrapResources(...resources: ReadonlyArray<any>) {
   return {
     total_pages: 1,
@@ -7,5 +9,17 @@ export function wrapResources(...resources: ReadonlyArray<any>) {
 
     prev_url: null,
     next_url: null,
+  };
+}
+
+export function wrapV3Resources(...resources: ReadonlyArray<any>): IV3Response<any> {
+  return {
+    pagination: {
+      total_pages: 1,
+      total_results: resources.length,
+      first: { href: '/not-implemented' },
+      last: { href: '/not-implemented' },
+    },
+    resources,
   };
 }

--- a/src/lib/cf/types.ts
+++ b/src/lib/cf/types.ts
@@ -115,6 +115,50 @@ export interface IOrganization {
   readonly metadata: IMetadata;
 }
 
+interface IV3Link {
+  href: string;
+}
+
+interface IV3Pagination {
+  total_results: number;
+  total_pages: number;
+  first: IV3Link;
+  last: IV3Link;
+  next?: IV3Link;
+  previous?: IV3Link;
+}
+
+export interface IV3OrganizationResource {
+  guid: string;
+  created_at: string;
+  updated_at: string;
+  name: string;
+  suspended: boolean;
+  relationships: {
+    quota: {
+      data: {
+        guid: string;
+      },
+    },
+  };
+  links: {
+    self: IV3Link;
+    domains: IV3Link;
+    default_domain: IV3Link;
+  };
+  metadata: {
+    labels: {};
+    annotations: {
+      owner?: string;
+    };
+  };
+}
+
+export interface IV3Response<T> {
+  readonly pagination: IV3Pagination;
+  readonly resources: ReadonlyArray<T>;
+}
+
 export interface IOrganizationQuota {
   readonly entity: {
     readonly app_instance_limit: number;


### PR DESCRIPTION
What
----

I'm using annotations from the cf v3 api to record who the owner for
each organisation is. Because lables don't let you put spaces in the
values I went with annotations, but these aren't in the CLI yet so you
have to use `cf curl` to get / set them:

```
cf curl /v3/organizations/some-guid -d '{"metadata":{"annotations":{"owner":"GDS"}}}' -X PATCH

cf curl /v3/organizations/some-guid
```

So that the engagement team / people who are doing engagement can see
which organisation belongs to which organisation owner I've added a
column to the organisations report that shows the annotation.

This meant I had to switch to using the V3 API for organisations on this
page. Since this is the first V3 API we've interacted with that meant I
had to write the boilerplate to handle pagination, and the associated
tests.

I've only switched the /reports/organisations view to use V3 API, so all
the end-user facing views are still using V2 - this minimises the blast
radius if I've screwed anything up.

How to review
-------------

* Code review
* Check out this screenshot:

![image](https://user-images.githubusercontent.com/1696784/67101176-0e241400-f1b9-11e9-81c7-f945664b2985.png)

* `cf push` to a dev env and check out `/reports/organisations`
* `cf curl "/v3/organizations/$(cf org govuk-paas --guid)" -d '{"metadata":{"annotations":{"owner":"GDS"}}}' -X PATCH` to set an annotation for the govuk-paas organisation

Who can review
---------------

Not @richardtowers