### PR TITLE
[#169035672] Support multiple exchange rates per month

### DIFF
--- a/src/components/statements/statements.njk
+++ b/src/components/statements/statements.njk
@@ -100,9 +100,18 @@
           <td td class="paas-month-price"><small>&pound;{{ (totals.incVAT * adminFee) | currency(2) }}</small></td>
         </tr>
         <tr class="paas-month-total-information">
-          {% if usdCurrencyRate %}
+          {% if usdCurrencyRates.length == 1 %}
             <td class="govuk-table__cell">
-              Exchange rate: &pound;1 to &dollar;{{1.0 / usdCurrencyRate.rate | currency(2)}}
+              Exchange rate: &pound;1 to &dollar;{{1.0 / usdCurrencyRates[0].rate | currency(2)}}
+            </td>
+          {% elif usdCurrencyRates.length > 1 %}
+            <td class="govuk-table__cell">
+              Exchange rate:
+              {% set comma = joiner() %}
+              {% for usdCurrencyRate in usdCurrencyRates %}
+                {{ comma() }}
+                &pound;1 to &dollar;{{1.0 / usdCurrencyRate.rate | currency(2)}} from {{usdCurrencyRate.validFrom | nicedate }}
+              {% endfor %}
             </td>
           {% endif %}
           <td class="paas-month-price">ex VAT</td>

--- a/src/components/statements/statements.test.ts
+++ b/src/components/statements/statements.test.ts
@@ -222,7 +222,7 @@ describe('statements test suite', () => {
     expect(response.body).not.toContain('Exchange rate');
   });
 
-  it('outputs USD rate if set', async () => {
+  it('outputs a single USD rate if there is only one', async () => {
     nockBilling
       .get(
         '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
@@ -250,6 +250,42 @@ describe('statements test suite', () => {
     });
 
     expect(response.body).toContain('&pound;1 to &dollar;1.25');
+    expect(response.body).not.toContain('&pound;1 to &dollar;1.25 after');
+  });
+
+  it('outputs multiple USD rates if there are multiple this month', async () => {
+    nockBilling
+      .get(
+        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+      )
+      .reply(200, billingData.billableEvents)
+
+      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .reply(200, [
+        {code: 'USD', rate: 0.8, valid_from: '2017-01-01'},
+        {code: 'USD', rate: 0.5, valid_from: '2017-01-15'},
+      ])
+    ;
+
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .times(2)
+      .reply(200, data.userRolesForOrg)
+
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
+      .reply(200, JSON.stringify(defaultOrg()))
+    ;
+
+    const response = await statement.viewStatement(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      rangeStart: '2018-01-01',
+      space: 'bc8d3381-390d-4bd7-8c71-25309900a2e3',
+      service: 'f4d4b95a-f55e-4593-8d54-3364c25798c4',
+    });
+
+    expect(response.body).toContain('Exchange rate:');
+    expect(response.body).toContain('&pound;1 to &dollar;1.25 from January 1st 2017');
+    expect(response.body).toContain('&pound;1 to &dollar;2 from January 15th 2017');
   });
 
   it('should throw an error due to selecting middle of the month', async () => {

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -135,7 +135,7 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
   }));
 
   const currencyRates = await billingClient.getCurrencyRates(filter);
-  const usdCurrencyRate = currencyRates.filter(currencyRate => currencyRate.code === 'USD')[0];
+  const usdCurrencyRates = currencyRates.filter(currencyRate => currencyRate.code === 'USD');
 
   /* istanbul ignore next */
   const itemsObject: IResourceGroup = cleanEvents.reduce((resources: IResourceGroup, event: IBillableEvent) => {
@@ -227,7 +227,7 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
       items: filteredItems,
       spaces: listSpaces,
       plans: listPlans,
-      usdCurrencyRate,
+      usdCurrencyRates,
       isCurrentMonth:
         Object.keys(listOfPastYearMonths)[0] === params.rangeStart,
       listOfPastYearMonths,


### PR DESCRIPTION
What
----

https://github.com/alphagov/paas-billing/pull/89 allows us to use multiple exchange rates per month. This PR ensures that we list all the exchange rates that are used, and when they were valid from.

How to review
-------------

Code review.

Who can review
---------------

Not @46bit.