### PR TITLE
Improve formatting of exchange rates on statement page

### DIFF
--- a/src/components/statements/statements.njk
+++ b/src/components/statements/statements.njk
@@ -108,10 +108,9 @@
             <td class="govuk-table__cell">
               Exchange rate:
               {% set comma = joiner() %}
-              {% for usdCurrencyRate in usdCurrencyRates %}
-                {{ comma() }}
-                &pound;1 to &dollar;{{1.0 / usdCurrencyRate.rate | currency(2)}} from {{usdCurrencyRate.validFrom | nicedate }}
-              {% endfor %}
+              {% for usdCurrencyRate in usdCurrencyRates -%}
+                {{ comma() }} &pound;1 to &dollar;{{ (1.0 / usdCurrencyRate.rate) | currency(2) }} from {{usdCurrencyRate.validFrom | nicedate }}
+              {%- endfor %}
             </td>
           {% endif %}
           <td class="paas-month-price">ex VAT</td>

--- a/src/components/statements/statements.test.ts
+++ b/src/components/statements/statements.test.ts
@@ -285,7 +285,7 @@ describe('statements test suite', () => {
 
     expect(response.body).toContain('Exchange rate:');
     expect(response.body).toContain('&pound;1 to &dollar;1.25 from January 1st 2017');
-    expect(response.body).toContain('&pound;1 to &dollar;2 from January 15th 2017');
+    expect(response.body).toContain('&pound;1 to &dollar;2.00 from January 15th 2017');
   });
 
   it('should throw an error due to selecting middle of the month', async () => {


### PR DESCRIPTION
What
----

Comma should be adjacent to the date without a space

Division should happen before the currency filter to actually be fixed precision

How to review
-------------

Code review

Who can review
---------------

Not @tlwr
