### PR TITLE
Fix bug, cf v3 resource paginator gets all pages

### DIFF
--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -94,15 +94,18 @@ describe('lib/cf test suite', () => {
       .get('/v3/test')
       .reply(200, `{"pagination": {"next":{"href": "/v3/test?page=2"}},"resources":["a"]}`)
       .get('/v3/test?page=2')
-      .reply(200, `{"pagination": {"next":null},"resources":["b"]}`)
+      .reply(200, `{"pagination": {"next":{"href": "/v3/test?page=3"}},"resources":["b"]}`)
+      .get('/v3/test?page=3')
+      .reply(200, `{"pagination": {"next":null},"resources":["c"]}`)
     ;
 
     const client = new CloudFoundryClient(config);
     const response = await client.request('get', '/v3/test');
     const collection = await client.allV3Resources(response);
 
-    expect([...collection].length).toEqual(2);
+    expect([...collection].length).toEqual(3);
     expect(collection[1]).toEqual('b');
+    expect(collection[2]).toEqual('c');
   });
 
   it('should throw an error when receiving 404', async () => {

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -97,14 +97,14 @@ export default class CloudFoundryClient {
   }
 
   public async allV3Resources<T>(response: AxiosResponse<cf.IV3Response<T>>): Promise<ReadonlyArray<T>> {
-    const data = response.data.resources;
+    const data: ReadonlyArray<T> = response.data.resources;
 
     if (!response.data.pagination.next) {
       return data;
     }
 
     const newResponse = await this.request('get', response.data.pagination.next.href);
-    const newData = await this.allResources(newResponse);
+    const newData: ReadonlyArray<T> = await this.allV3Resources(newResponse);
 
     return [...data, ...newData];
   }


### PR DESCRIPTION
What
----

Add a test to check that all pages are retrieved

Ensure all pages are retrieved by recursing to the correct function (i.e. call itself, not the v2 paginator).

Done as pair with @Nooshu 