### PR TITLE
Show organisation owners in billing visualisations

### DIFF
--- a/src/components/reports/cost-by-service.test.ts
+++ b/src/components/reports/cost-by-service.test.ts
@@ -2,8 +2,8 @@ import moment from 'moment';
 import nock from 'nock';
 import {createTestContext} from '../app/app.test-helpers';
 
-import {org as defaultOrg} from '../../lib/cf/test-data/org';
-import {wrapResources} from '../../lib/cf/test-data/wrap-resources';
+import {v3Org as defaultOrg} from '../../lib/cf/test-data/org';
+import {wrapV3Resources} from '../../lib/cf/test-data/wrap-resources';
 
 import { config } from '../app/app.test.config';
 import { IContext } from '../app/context';
@@ -13,9 +13,9 @@ describe('html cost report by service test suite', () => {
 
   // tslint:disable:max-line-length
   nock(config.cloudFoundryAPI)
-    .get('/v2/organizations')
+    .get('/v3/organizations')
     .times(5)
-    .reply(200, JSON.stringify(wrapResources(defaultOrg())));
+    .reply(200, JSON.stringify(wrapV3Resources(defaultOrg())));
 
   const ctx: IContext = createTestContext();
 
@@ -196,7 +196,7 @@ describe('cost report grouping functions', () => {
     });
 
     it('should look up the organisation name by GUID', () => {
-      const orgsByGUID = {'some-org-guid': [{entity: {name: 'some-org-name'}} as any]};
+      const orgsByGUID = {'some-org-guid': [{name: 'some-org-name'} as any]};
       const result = reports.getBillableEventsByOrganisationAndService(
         [{...defaultBillableEvent, orgGUID: 'some-org-guid'}],
         orgsByGUID,
@@ -207,8 +207,8 @@ describe('cost report grouping functions', () => {
 
     it('should group by organisation (sorted alphabetically), then by service (sorted by cost)', () => {
       const orgsByGUID = {
-        'org-guid-one': [{entity: {name: 'org-name-one'}} as any],
-        'org-guid-two': [{entity: {name: 'org-name-two'}} as any],
+        'org-guid-one': [{name: 'org-name-one'} as any],
+        'org-guid-two': [{name: 'org-name-two'} as any],
       };
       const result = reports.getBillableEventsByOrganisationAndService(
         [
@@ -241,7 +241,7 @@ describe('cost report grouping functions', () => {
     });
 
     it('should look up the organisation and space names by GUID', () => {
-      const orgsByGUID = {'some-org-guid': [{entity: {name: 'some-org-name'}} as any]};
+      const orgsByGUID = {'some-org-guid': [{name: 'some-org-name'} as any]};
       const spacesByGUID = {'some-space-guid': [{entity: {name: 'some-space-name'}} as any]};
       const result = reports.getBillableEventsByOrganisationAndSpaceAndService(
         [
@@ -260,8 +260,8 @@ describe('cost report grouping functions', () => {
 
     it('should group by organisation (sorted alphabetically), then by space (sorted alphabetically), then by service (sorted by cost)', () => {
       const orgsByGUID = {
-        'org-guid-one': [{entity: {name: 'org-name-one'}} as any],
-        'org-guid-two': [{entity: {name: 'org-name-two'}} as any],
+        'org-guid-one': [{name: 'org-name-one'} as any],
+        'org-guid-two': [{name: 'org-name-two'} as any],
       };
       const spacesByGUID = {
         'space-guid-one': [{entity: {name: 'space-name-one'}} as any],

--- a/src/components/reports/visualisation.ts
+++ b/src/components/reports/visualisation.ts
@@ -1,4 +1,4 @@
-import {groupBy, uniq} from 'lodash';
+import {groupBy, sum, uniq} from 'lodash';
 import moment from 'moment';
 
 import { getBillableEventsByOrganisationAndService } from '.';
@@ -21,6 +21,10 @@ interface ID3SankeyInput {
   nodes: ReadonlyArray<ID3SankeyNode>;
   links: ReadonlyArray<ID3SankeyLink>;
 }
+interface IOrgAndOwner {
+  org: string;
+  owner: string;
+}
 
 export async function viewVisualisation(
   ctx: IContext,
@@ -41,10 +45,10 @@ export async function viewVisualisation(
     logger: ctx.app.logger,
   });
 
-  const orgs = (await cf.organizations())
-    .filter(org => !org.entity.name.match(/^(CAT|SMOKE|PERF|ACC)/));
+  const orgs = (await cf.v3Organizations())
+    .filter(org => !org.name.match(/^(CAT|SMOKE|PERF|B?ACC)/));
 
-  const orgsByGUID = groupBy(orgs, x => x.metadata.guid);
+  const orgsByGUID = groupBy(orgs, x => x.guid);
   const orgGUIDs = Object.keys(orgsByGUID);
 
   const billableEvents = await billingClient.getBillableEvents({
@@ -52,7 +56,9 @@ export async function viewVisualisation(
   });
 
   const billablesByOrganisationAndService = getBillableEventsByOrganisationAndService(billableEvents, orgsByGUID);
-  const data = buildD3SankeyInput(billablesByOrganisationAndService);
+  /* istanbul ignore next */
+  const organisationsByOwner = orgs.map(x => ({owner: x.metadata.annotations.owner || 'Other', org: x.name}));
+  const data = buildD3SankeyInput(billablesByOrganisationAndService, organisationsByOwner);
 
   return {
     body: visualisationTemplate.render({
@@ -66,18 +72,35 @@ export async function viewVisualisation(
   };
 }
 
-export function buildD3SankeyInput(billables: ReadonlyArray<IBillableByOrganisationAndService>): ID3SankeyInput {
+export function buildD3SankeyInput(
+  billables: ReadonlyArray<IBillableByOrganisationAndService>,
+  organisationsByOwner: ReadonlyArray<IOrgAndOwner>): ID3SankeyInput {
   const services = uniq(billables.map(x => x.serviceGroup));
   const orgNames = uniq(billables.map(x => x.orgName));
-  const nodes = services.concat(orgNames);
+  const owners = uniq(organisationsByOwner.map(x => x.owner));
+  const nodes = [...services, ...orgNames, ...owners];
+
+  if (nodes.length - owners.length === 0) {
+    return { nodes: [], links: [] };
+  }
+
   const nodeIndexByName = nodes
     .reduce((acc, x, index) => ({...acc, [x]: index}), {}) as {[_: string]: number};
+
+  const billableLinks = billables.map(x => ({
+    source: nodeIndexByName[x.serviceGroup],
+    target: nodeIndexByName[x.orgName],
+    value: x.exVAT,
+  }));
+
+  const ownerLinks = organisationsByOwner.map(orgOwner => ({
+    source: nodeIndexByName[orgOwner.org],
+    target: nodeIndexByName[orgOwner.owner],
+    value: sum(billables.filter(billable => billable.orgName === orgOwner.org).map(billable => billable.exVAT)),
+  }));
+
   return {
     nodes: nodes.map(x => ({name: x})),
-    links: billables.map(x => ({
-      source: nodeIndexByName[x.serviceGroup],
-      target: nodeIndexByName[x.orgName],
-      value: x.incVAT,
-    })),
+    links: [...billableLinks, ...ownerLinks],
   };
 }

--- a/stub-api/stub-billing.ts
+++ b/stub-api/stub-billing.ts
@@ -58,6 +58,7 @@ function mockBilling(app: express.Application, _config: IStubServerPorts): expre
       {
         ...defaultBillingEvent,
         resource_name: 'charm',
+        org_guid: 'a-different-org',
         price: {inc_vat: "532.00", ex_vat: "512.00", details: [{...defaultPriceDetails, plan_name: "witching-plan"}]}
       },
       {

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -3,8 +3,8 @@ import lodash from 'lodash';
 
 import * as testData from '../src/lib/cf/cf.test.data';
 import {app as defaultApp} from '../src/lib/cf/test-data/app';
-import {org as defaultOrg} from '../src/lib/cf/test-data/org';
-import {wrapResources} from '../src/lib/cf/test-data/wrap-resources';
+import {org as defaultOrg, v3Org as defaultV3Org} from '../src/lib/cf/test-data/org';
+import {wrapResources, wrapV3Resources} from '../src/lib/cf/test-data/wrap-resources';
 import {IStubServerPorts} from './index';
 
 function mockCF(app: express.Application, config: IStubServerPorts): express.Application {
@@ -33,9 +33,16 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
 
   app.get('/v2/organizations/:guid',        (_, res) => res.send(JSON.stringify(defaultOrg())));
   app.get('/v2/organizations/:guid/spaces', (_, res) => res.send(testData.spaces));
-  app.get('/v2/organizations',              (_, res) => res.send(JSON.stringify(
+
+  app.get('/v2/organizations', (_, res) => res.send(JSON.stringify(
     wrapResources(
       lodash.merge(defaultOrg(), {entity: {name: 'an-org'}}),
+    ),
+  )));
+  app.get('/v3/organizations', (_, res) => res.send(JSON.stringify(
+    wrapV3Resources(
+      lodash.merge(defaultV3Org(), {name: 'an-org'}),
+      lodash.merge(defaultV3Org(), {name: 'a-different-org', guid: 'a-different-org'}),
     ),
   )));
 
@@ -57,7 +64,7 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
   app.get('/v2/user_provided_service_instances'      , (_, res) => res.send(testData.userServices));
   app.get('/v2/user_provided_service_instances/:guid', (_, res) => res.send(testData.userServiceInstance));
   app.get('/v2/users/uaa-id-253/spaces'              , (_, res) => res.send(testData.spaces));
-  app.get('/v2/users/uaa-id-253/summary'              , (_, res) => res.send(testData.userSummary));
+  app.get('/v2/users/uaa-id-253/summary'             , (_, res) => res.send(testData.userSummary));
   app.get('/v2/organizations/:guid/user_roles'       , (_, res) => res.send(testData.userRolesForOrg));
   app.get('/v2/spaces/:guid/user_roles'              , (_, res) => res.send(testData.userRolesForSpace));
   app.get('/v2/stacks'                               , (_, res) => res.send(testData.stacks));


### PR DESCRIPTION
What
----

Now that we've got the organisation owners in the organisation metadata
we can add them to the sankey visualisations. This will allow us to see
at a glance how much each organisation owner is spending.

To do this we need to switch two of the reports to use the V3
organisations API so we can see the annotations. The visualisation
report shares code with cost-by-service, so they both had to change.

How to review
-------------

* Code review
* Test locally with the stubs

Who can review
---------------

Not @richardtowers