### PR TITLE
Only attempt to visualise orgs with bills

### DIFF
--- a/src/components/reports/visualisation.test.ts
+++ b/src/components/reports/visualisation.test.ts
@@ -89,7 +89,7 @@ describe('building D3 sankey input', () => {
     expect(result.links).toHaveLength(0);
   });
 
-  it('should produce nodes and links from billables', () => {
+  it('should produce nodes and links from billables, ignoring orgs without billables', () => {
     const result = reports.buildD3SankeyInput([
       {...defaultBillable, orgName: 'org-1', serviceGroup: 'service-1', exVAT: 1},
       {...defaultBillable, orgName: 'org-2', serviceGroup: 'service-1', exVAT: 2},
@@ -97,6 +97,7 @@ describe('building D3 sankey input', () => {
     ], [
       {org: 'org-1', owner: 'owner-1'},
       {org: 'org-2', owner: 'owner-1'},
+      {org: 'org-without-billables', owner: 'owner-2'},
     ]);
     expect(result.nodes).toEqual([
       {name: 'service-1'},

--- a/src/components/reports/visualisation.ts
+++ b/src/components/reports/visualisation.ts
@@ -77,7 +77,8 @@ export function buildD3SankeyInput(
   organisationsByOwner: ReadonlyArray<IOrgAndOwner>): ID3SankeyInput {
   const services = uniq(billables.map(x => x.serviceGroup));
   const orgNames = uniq(billables.map(x => x.orgName));
-  const owners = uniq(organisationsByOwner.map(x => x.owner));
+  const organisationsByOwnerWithBills = organisationsByOwner.filter(x => orgNames.includes(x.org));
+  const owners = uniq(organisationsByOwnerWithBills.map(x => x.owner));
   const nodes = [...services, ...orgNames, ...owners];
 
   if (nodes.length - owners.length === 0) {
@@ -93,7 +94,7 @@ export function buildD3SankeyInput(
     value: x.exVAT,
   }));
 
-  const ownerLinks = organisationsByOwner.map(orgOwner => ({
+  const ownerLinks = organisationsByOwnerWithBills.map(orgOwner => ({
     source: nodeIndexByName[orgOwner.org],
     target: nodeIndexByName[orgOwner.owner],
     value: sum(billables.filter(billable => billable.orgName === orgOwner.org).map(billable => billable.exVAT)),


### PR DESCRIPTION
What
----

Previously we were trying to render all of the orgs on the platform
(even those without bills for the current month), and their owners. This
left some links without sources (since there were no bills for the org)
which broke the diagram.

How to review
-------------

* Code review should be enough

Who can review
---------------

Not @richardtowers