### PR TITLE
[#169180189] Add backing service metrics for RDS services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,443 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-sdk/abort-controller": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-0.1.0-preview.7.tgz",
+      "integrity": "sha512-UpAa0PQ4u1UdDYPU9ajO/vzfmSn3rTMjXQjlsd0Ue4oK/A2lffNN28+egMVuS+Ivs96pv1HAfA4t4tPw+U6wjA==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/client-cloudwatch-node": {
+      "version": "0.1.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-node/-/client-cloudwatch-node-0.1.0-preview.2.tgz",
+      "integrity": "sha512-DGr3hGdJbwwSDV7xx2c3GscsI+VQE/fyOTdgxdsrKbjKPzSL2eG9yQHy5xyiVRppJJVcLNZ2QFvTyaIhJUZ/lw==",
+      "requires": {
+        "@aws-sdk/config-resolver": "^0.1.0-preview.5",
+        "@aws-sdk/core-handler": "^0.1.0-preview.5",
+        "@aws-sdk/credential-provider-node": "^0.1.0-preview.6",
+        "@aws-sdk/hash-node": "^0.1.0-preview.5",
+        "@aws-sdk/middleware-content-length": "^0.1.0-preview.5",
+        "@aws-sdk/middleware-header-default": "^0.1.0-preview.5",
+        "@aws-sdk/middleware-serializer": "^0.1.0-preview.5",
+        "@aws-sdk/middleware-stack": "^0.1.0-preview.6",
+        "@aws-sdk/node-http-handler": "^0.1.0-preview.6",
+        "@aws-sdk/protocol-query": "^0.1.0-preview.6",
+        "@aws-sdk/query-builder": "^0.1.0-preview.5",
+        "@aws-sdk/query-error-unmarshaller": "^0.1.0-preview.6",
+        "@aws-sdk/region-provider": "^0.1.0-preview.5",
+        "@aws-sdk/retry-middleware": "^0.1.0-preview.5",
+        "@aws-sdk/signature-v4": "^0.1.0-preview.6",
+        "@aws-sdk/signing-middleware": "^0.1.0-preview.6",
+        "@aws-sdk/stream-collector-node": "^0.1.0-preview.5",
+        "@aws-sdk/types": "^0.1.0-preview.5",
+        "@aws-sdk/url-parser-node": "^0.1.0-preview.5",
+        "@aws-sdk/util-base64-node": "^0.1.0-preview.3",
+        "@aws-sdk/util-body-length-node": "^0.1.0-preview.4",
+        "@aws-sdk/util-user-agent-node": "^0.1.0-preview.6",
+        "@aws-sdk/util-utf8-node": "^0.1.0-preview.3",
+        "@aws-sdk/xml-body-parser": "^0.1.0-preview.6",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-0.1.0-preview.7.tgz",
+      "integrity": "sha512-clP/NFkGyIJzCPPZ9y9vc4rQD2O8euuEVtYDlHNPfe+791uo43I1/qhw20v31mPY1OH0dScf5Jn/n4Ed9YO1VA==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/core-handler": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core-handler/-/core-handler-0.1.0-preview.7.tgz",
+      "integrity": "sha512-F+BAYmcPGbbK2w6Y9i4RgK9f8ojUuQKoZuFCxiYoujLGoak/p81gACTz3dQyV9/NiY46EvmdpyaGQeLtpfuriQ==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-0.1.0-preview.8.tgz",
+      "integrity": "sha512-wW2XRalzx8jAIsVSdOM4cDP3hgbvPy6UJhQwpn9N3kfb22G5FPEry6hlJKHAVzQ15tkTNd0C6SyRlXgC5zEzmA==",
+      "requires": {
+        "@aws-sdk/property-provider": "^0.1.0-preview.7",
+        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-0.1.0-preview.7.tgz",
+      "integrity": "sha512-FgrXEUf9/6VL+YWwGGpzVC7+hHcb43+kUtez/HoVq7duCi8OpnCAdLuGFoJdWhi2K76Qf1i3z2+fUYcSQnjcoQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-0.1.0-preview.7.tgz",
+      "integrity": "sha512-iIVGZonHwy08RJgW9AZURKAbRTcBtwZw9wWSkO1YgtFVKYHH81E+C/k3o9ljCD9TK+XfvB2dv5alPkS71EufIQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "^0.1.0-preview.7",
+        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "0.1.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-0.1.0-preview.9.tgz",
+      "integrity": "sha512-l7AioIfRpNjgEe+8ikWUEFV8Z5eDMQTDl6BEG3y2O9K+rksSmYvIAkraOJjJmHPi/nTKgCXrWzoBpasYahuSvA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "^0.1.0-preview.8",
+        "@aws-sdk/credential-provider-imds": "^0.1.0-preview.7",
+        "@aws-sdk/credential-provider-ini": "^0.1.0-preview.7",
+        "@aws-sdk/credential-provider-process": "^0.1.0-preview.5",
+        "@aws-sdk/property-provider": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "0.1.0-preview.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-0.1.0-preview.5.tgz",
+      "integrity": "sha512-OIBmuaul/aF3w3oCc1zIw+jE5tlhacrhCD/LXf0DornF8Bfp4oaYA5qJ4Lttu/Q25s2qW5+YEuFlDsnqpIQUyw==",
+      "requires": {
+        "@aws-sdk/credential-provider-ini": "^0.1.0-preview.7",
+        "@aws-sdk/property-provider": "^0.1.0-preview.7",
+        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-0.1.0-preview.8.tgz",
+      "integrity": "sha512-tYBKE5ggAfw7oCLj3/jVJomruUMXhFOL+yH7xnKbgEjCi2m/jsSClCwjUbco2d5eFeC75t74RsFuyCREm9o+nw==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-0.1.0-preview.3.tgz",
+      "integrity": "sha512-8SM7kBGkwH6JCKA6K1w4Jrj+EABFOPQkbPvwaf6BILYiUMUbgJvjOPjNQE2MrvRxJz50WAcZDHnlwhstuwIRnw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/is-iterable": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-iterable/-/is-iterable-0.1.0-preview.3.tgz",
+      "integrity": "sha512-dmqXKd7BlAGAaOz1dvmBw5MeOy/94LOxIRv4i8I76JPyTJsxFKjzJIHeRMnQ/5WJ3/POhmb6ZjBW/GwS/upaFw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-0.1.0-preview.7.tgz",
+      "integrity": "sha512-6ZI+dY8VgWmKL48tBtFGFgllwdhKgqNztscLtYPmHl38zrz4sITJnyGwbYDGLW+xLIGDOQhyFd/6kWTqT9QyKQ==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-0.1.0-preview.7.tgz",
+      "integrity": "sha512-hf7+YMiPnyzRKzmcZZ5v2NKkC6CKgo8nnckJ1A1OlvWYGq3hLMF1gKDMzdkEFjWJmDWv6AVNyHjw5qe4AV8LVA==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-serializer": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serializer/-/middleware-serializer-0.1.0-preview.7.tgz",
+      "integrity": "sha512-mc5xBnrdDM9k3a78cbTSw+VWTadpDQQBObSuAy4fCxrkPZa+APqRY+y9MMDQ0uWI80e6Ab1pt9wTx1/OM1uMWQ==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-0.1.0-preview.8.tgz",
+      "integrity": "sha512-dlcq80vQe5buIVlAyPjJE0uL21IPfr04j5catPIfQ9rBm4809pib7vJoUkjNrfCk+RTeeVgynVdSdUaxlF5oWw==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-0.1.0-preview.8.tgz",
+      "integrity": "sha512-D3hISgch64L2rG8RQDi361ywoSgsyH/5Yj4ZF05ZCo8UZ8TjU1CtiLPKy1is0XLqojhLlDAQ65lNna44xoArcw==",
+      "requires": {
+        "@aws-sdk/abort-controller": "^0.1.0-preview.7",
+        "@aws-sdk/querystring-builder": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.7.tgz",
+      "integrity": "sha512-8yKkR78XC3fvdd+ePohfLuZHKBL7e3k+t82JL775phiXO94WHiz/hlvm6tGhNz5zKzz72yLrJPCyoQAZLrxrTg==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/protocol-query": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-query/-/protocol-query-0.1.0-preview.8.tgz",
+      "integrity": "sha512-O/y5XB1n9BoKYhxjN29cRvCAOXbrh3AhcdrsefcusWt5zv718TtLnTAPIpgfiCdAiCtB1Wywrmty6HgheuwY/A==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
+        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "@types/node": "^10.0.0",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.2.tgz",
+          "integrity": "sha512-sAh60KDol+MpwOr1RTK0+HgBEYejKsxdpmrOS1Wts5bI03dLzq8F7T0sRXDKeaEK8iWDlGfdzxrzg6vx/c5pNA=="
+        }
+      }
+    },
+    "@aws-sdk/protocol-timestamp": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-timestamp/-/protocol-timestamp-0.1.0-preview.7.tgz",
+      "integrity": "sha512-ObO202v456/S6Ckhlu844KBXN9toFTPt8zzrJpESzntVXIaidDECetd120/xToycYmICinvAYH9o1E2l6VlCRQ==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/query-builder": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/query-builder/-/query-builder-0.1.0-preview.7.tgz",
+      "integrity": "sha512-dKPHM2I+k3vQTJxL3b7vmi5qOXrNnbJzHAY+d0SHLinFM1CgSdQaAWIjO5lICkktiX65M6x7xCjVZbXwo8pfaw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
+        "@aws-sdk/is-iterable": "^0.1.0-preview.3",
+        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/query-error-unmarshaller": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/query-error-unmarshaller/-/query-error-unmarshaller-0.1.0-preview.8.tgz",
+      "integrity": "sha512-41lNT9delFhOss5H3eoi/2wYLYFuVqLXutRb5ZM5VvdhE4ZG+L8oE8HM0LSwQBttQFHaZcjdx3x3n9EVatSuCw==",
+      "requires": {
+        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-0.1.0-preview.7.tgz",
+      "integrity": "sha512-U2d9CYTwnF4/Qc8XXFmCdRzcApTmwEXLyHUcjK2/GaOHKkHDAeIC94+cuP+H3nDjCjb3TdKV2xrl/wzuP0YBrg==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "@aws-sdk/util-uri-escape": "^0.1.0-preview.3",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-0.1.0-preview.7.tgz",
+      "integrity": "sha512-r72E/wZYrhTXTK950Ld/L2Loso/HDqExQkIuCn1Pu8Rx0+uC3Y8fQTx+JZd5M5kOniCpGKdHWGc7y/bH/tjH4A==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/region-provider": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-provider/-/region-provider-0.1.0-preview.7.tgz",
+      "integrity": "sha512-n+LeuQYPYbCyfCboz9mmYqcPPKdmdd60KPbPeRqSdJYr9QZz9hWU962oCOl5EtLYIsUzy7Fm33APv6toEcAPVw==",
+      "requires": {
+        "@aws-sdk/property-provider": "^0.1.0-preview.7",
+        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/response-metadata-extractor": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/response-metadata-extractor/-/response-metadata-extractor-0.1.0-preview.8.tgz",
+      "integrity": "sha512-c5aJGYDiEwWqYpsROCqrmR60d0yeVdvRtzMptcpCI95BvIizS3hTc+PfuOq3Gcz7L+EQysbzQyqZutCJ/zLbew==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/retry-middleware": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/retry-middleware/-/retry-middleware-0.1.0-preview.7.tgz",
+      "integrity": "sha512-ULiq+dffOPurjyHm95PYWi1Cy27LQg9jPwLz5tiL7oIla/j9b5bcclZE3n0RtqbHDUvWJL5kxmYw0Kjrggr5iw==",
+      "requires": {
+        "@aws-sdk/service-error-classification": "^0.1.0-preview.3",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-0.1.0-preview.3.tgz",
+      "integrity": "sha512-3TXwADJL+HGOWyqdwx+pOdwr8L8LGbdxwHR0D05PP3skY+TP34F3ye2DJlyCll4S9vYzf9GlSbwJWviN9Sujrw=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-0.1.0-preview.3.tgz",
+      "integrity": "sha512-1wuV2YpZm+sW4AZa7CBD3A3b7+vSHX0DWBgGaENYdqC+MUEl6lD57ZOUGLryPq5xv/tQfy8BC7QT+qDNHElcuw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "0.1.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-0.1.0-preview.9.tgz",
+      "integrity": "sha512-772F+4Z3VHMQUIpdXmcg4Ar6ATiDQ+tLXdUQX/jDvkXbQWXURjZLLL6X1ghFSlXKmOR0fRxmYZL0fG/M9PwssQ==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
+        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "@aws-sdk/util-hex-encoding": "^0.1.0-preview.3",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/signing-middleware": {
+      "version": "0.1.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signing-middleware/-/signing-middleware-0.1.0-preview.9.tgz",
+      "integrity": "sha512-XXrs0h5YTLgkviotIQSwYjAf0aTPKCFYPA0vYubTP1EY7fUGI3hLlFttaUh5/77h8b3RNYx/QFcRXodY5GAxWg==",
+      "requires": {
+        "@aws-sdk/signature-v4": "^0.1.0-preview.9",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/stream-collector-node": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/stream-collector-node/-/stream-collector-node-0.1.0-preview.8.tgz",
+      "integrity": "sha512-p8cpGYqUy0pgOsephImE4yar3CJqhuVgPqhegRQXXYor3ZPkGloPymNys/1FmVb4RbzLrQ8WmpM+Fd0dUIu3PA==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-0.1.0-preview.7.tgz",
+      "integrity": "sha512-gpyU8N9XEs8diE4uW9B6/hjKDrB/c4a1GF4ICwkaGYpXrbJy9QLrEU8Hk4rC6P1l++YYyJKMl7RjMmTyBtNOzw=="
+    },
+    "@aws-sdk/url-parser-node": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-node/-/url-parser-node-0.1.0-preview.8.tgz",
+      "integrity": "sha512-h8YwL+mLTBPNzryREkLChhtRSdz70tOR9y/UB6PATGKoJbMUFoTsDY1jbJ4WWBfdKjphZy9xVWTyxoCkP07tQQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "0.1.0-preview.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-0.1.0-preview.4.tgz",
+      "integrity": "sha512-L9O3lMWB7y2xVIgg/nSJ7xZLVFmxMCk1maaup3CoL5USLqB7n7ngpf/WAH2LyhaGo8Og8TrAKt4BizpxbZU7wg==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "0.1.0-preview.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-0.1.0-preview.5.tgz",
+      "integrity": "sha512-ZmqB7E/RizTe8ajxLyXdshoyzQg47CAkbnCK7yRE4A9N7XMEUgzyFVXuKT08DmbAwYSYWI5jaUwm3jpMKqG+bw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-0.1.0-preview.3.tgz",
+      "integrity": "sha512-n78cUmI1SbluJgTgyqp24GgNQ3A5NUGB4rwRAoID7k7JpsiNJUWTXkijl3hxfNov2sEjMWvdQIGvAF6F/Q2mfw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-error-constructor": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-error-constructor/-/util-error-constructor-0.1.0-preview.7.tgz",
+      "integrity": "sha512-sb8gruiOadl0YXG2yn0EMBkB/Oy/7y4mt8Wfl7G3crvWXcHtD7flbW7wjbFiMcQU91vi5sTaZ56hwvDA9lu0ug==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-0.1.0-preview.3.tgz",
+      "integrity": "sha512-X/Qq5e2H4/EQ0WEwWUiSxGbFARk7IKZpa+E4pzQm49sxS2omVsvuphcr4yYJq4SZKEtuB2w2nHMr7NmGlWt4Xg==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-0.1.0-preview.3.tgz",
+      "integrity": "sha512-axArIOq8+2PKjY9Fz+LKfCY127rjWQD50F1DAhCC0BV3mrG0OlhcQ8uKaNfMXVrveTqT+QYvrpTsrziHYjjTQw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "0.1.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-0.1.0-preview.9.tgz",
+      "integrity": "sha512-V/1n0KAFvAIsguDXMJ9zvbJmv3j5dyOhjHKf6nhWYBR7hLYGdKA5HlZmQsoRCJf3B3whl6z1HSkmtTPOtY9Hlg==",
+      "requires": {
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "0.1.0-preview.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-0.1.0-preview.4.tgz",
+      "integrity": "sha512-FxIWpC4LdKiJgJgiaLWMdZY/DbreSIRgVGO9cOlV5fI59KdN+2Aqb6sLnlp7yVbo2hiL0Hlcv7fcf4MEtELn0g==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/xml-body-parser": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-body-parser/-/xml-body-parser-0.1.0-preview.8.tgz",
+      "integrity": "sha512-qK9+ZT5c1pj30e8td4E04ly3JczgnKAwNdJp76eTJzHXzZewQhL7VlFg2TU5UVNc/3MWSgwQHcWEtcRaOtOEiw==",
+      "requires": {
+        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "zombie": "^6.1.4"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch-node": "0.1.0-preview.2",
     "axios": "0.19.0",
     "compression": "1.7.4",
     "cookie-session": "2.0.0-beta.3",

--- a/src/components/app/router-middleware.test.ts
+++ b/src/components/app/router-middleware.test.ts
@@ -42,6 +42,11 @@ describe('app test suite - router-middleware', () => {
         action: async (_c, _p, _b) => ({download: {data: `text`, name: 'download.txt'}}),
         path: '/download',
       },
+      {
+        name: 'mimetype',
+        action: async (_c, _p, _b) => ({mimeType: 'image/png'}),
+        path: '/image',
+      },
     ]);
 
     function linkTo(name: string, params: IParameters = {}) {
@@ -72,6 +77,7 @@ describe('app test suite - router-middleware', () => {
     const notFoundResponse = await agent.get('/404');
     const serverErrorResponse = await agent.get('/500');
     const downloadResponse = await agent.get('/download');
+    const imgResponse = await agent.get('/image');
 
     expect(linkTo('hello', {name: 'World'})).toEqual('/hello/World');
     expect(linkTo('home')).toEqual('/');
@@ -83,5 +89,6 @@ describe('app test suite - router-middleware', () => {
     expect(notFoundResponse.status).toEqual(404);
     expect(serverErrorResponse.status).toEqual(500);
     expect(downloadResponse.header['content-disposition']).toEqual(`attachment; filename="download.txt"`);
+    expect(imgResponse.header['content-type']).toEqual(`image/png`);
   });
 });

--- a/src/components/app/router-middleware.ts
+++ b/src/components/app/router-middleware.ts
@@ -16,6 +16,10 @@ function handleResponse(res: express.Response) {
       return res.send(r.download.data);
     }
 
+    if (r.mimeType) {
+      res.contentType(r.mimeType);
+    }
+
     res.status(r.status || 200).send(r.body);
   };
 }

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -5,6 +5,7 @@ import * as applications from '../applications';
 import * as orgUsers from '../org-users';
 import * as organizations from '../organizations';
 import * as reports from '../reports';
+import * as serviceMetrics from '../service-metrics';
 import * as services from '../services';
 import * as spaces from '../spaces';
 import * as statements from '../statements';
@@ -48,6 +49,16 @@ const router = new Router([
     action: services.viewService,
     name: 'admin.organizations.spaces.services.view',
     path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID',
+  },
+  {
+    action: serviceMetrics.viewServiceMetricImage,
+    name: 'admin.organizations.spaces.services.metrics.view.image',
+    path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/metrics/:metricDimension.png',
+  },
+  {
+    action: serviceMetrics.viewServiceMetrics,
+    name: 'admin.organizations.spaces.services.metrics.view',
+    path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/metrics',
   },
   {
     action: orgUsers.listUsers,

--- a/src/components/service-metrics/index.ts
+++ b/src/components/service-metrics/index.ts
@@ -1,0 +1,1 @@
+export * from './service-metrics';

--- a/src/components/service-metrics/service-metrics.njk
+++ b/src/components/service-metrics/service-metrics.njk
@@ -1,0 +1,93 @@
+{% extends "../services/_tabs.njk" %}
+{% from "govuk-frontend/govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% block pageTitle %}
+  {{ service.entity.name }} - Service Metrics
+{% endblock %}
+
+{% block insideTabs %}
+
+{{ govukPhaseBanner({
+  tag: {
+    text: "beta"
+  },
+  html: 'Backing service metrics is a new feature under active development. Expect frequent changes.'
+}) }}
+
+<br>
+
+{% set rdsPattern = r/^postgres|^mysql/ %}
+{% if rdsPattern.test(serviceLabel) %}
+    <div className="govuk-grid-row">
+    <div className="govuk-grid-column-one-third">
+        <h3 className="govuk-heading-m">
+        Free disk space
+        </h3>
+
+        <img src="{{
+        linkTo(
+        'admin.organizations.spaces.services.metrics.view.image',
+        {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, metricDimension: 'FreeStorageSpace' }
+        ) }}" alt="Graph showing free disk space over the last 24 hours">
+    </div>
+    <div className="govuk-grid-column-one-third">
+        <h3 className="govuk-heading-m">
+        CPU Utilisation
+        </h3>
+
+        <img src="{{
+        linkTo(
+        'admin.organizations.spaces.services.metrics.view.image',
+        {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, metricDimension: 'CPUUtilization' }
+        ) }}" alt="Graph showing CPU utilisation over the last 24 hours">
+    </div>
+    <div className="govuk-grid-column-one-third">
+        <h3 className="govuk-heading-m">
+        Database Connections
+        </h3>
+
+        <img src="{{
+        linkTo(
+        'admin.organizations.spaces.services.metrics.view.image',
+        {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, metricDimension: 'DatabaseConnections' }
+        ) }}" alt="Graph showing database connections over the last 24 hours">
+    </div>
+    <div className="govuk-grid-column-one-third">
+        <h3 className="govuk-heading-m">
+        Freeable Memory
+        </h3>
+
+        <img src="{{
+        linkTo(
+        'admin.organizations.spaces.services.metrics.view.image',
+        {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, metricDimension: 'FreeableMemory' }
+        ) }}" alt="Graph showing freeable memory over the last 24 hours">
+    </div>
+    <div className="govuk-grid-column-one-third">
+        <h3 className="govuk-heading-m">
+        Read IOPS
+        </h3>
+
+        <img src="{{
+        linkTo(
+        'admin.organizations.spaces.services.metrics.view.image',
+        {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, metricDimension: 'ReadIOPS' }
+        ) }}" alt="Graph showing read IOPS over the last 24 hours">
+    </div>
+    <div className="govuk-grid-column-one-third">
+        <h3 className="govuk-heading-m">
+        Write IOPS
+        </h3>
+
+        <img src="{{
+        linkTo(
+        'admin.organizations.spaces.services.metrics.view.image',
+        {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, metricDimension: 'WriteIOPS' }
+        ) }}" alt="Graph showing write IOPS over the last 24 hours">
+    </div>
+    </div>
+{% else %}
+  <p>Metrics are not available for this service yet.</p>
+{% endif %}
+
+{% endblock %}

--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -1,0 +1,58 @@
+import nock from 'nock';
+
+import {viewServiceMetrics} from '.';
+
+import * as data from '../../lib/cf/cf.test.data';
+import {org as defaultOrg} from '../../lib/cf/test-data/org';
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
+
+const ctx: IContext = createTestContext();
+
+describe('service metrics test suite', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+    // tslint:disable:max-line-length
+    nock('https://example.com/api')
+      .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9/user_roles').times(5).reply(200, data.userRolesForOrg)
+      .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92').times(1).reply(200, data.serviceInstance)
+      .get('/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1').times(1).reply(200, data.servicePlan)
+      .get('/v2/services/a14baddf-1ccc-5299-0152-ab9s49de4422').times(1).reply(200, data.service)
+      .get('/v2/spaces/38511660-89d9-4a6e-a889-c32c7e94f139').times(1).reply(200, data.space)
+      .get('/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9').times(1).reply(200, defaultOrg())
+      .get('/v2/user_provided_service_instances?q=space_guid:38511660-89d9-4a6e-a889-c32c7e94f139').times(1).reply(200, data.userServices)
+      .get('/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee').times(1).reply(200, data.userServiceInstance);
+    // tslint:enable:max-line-length
+  });
+
+  it('should show the service metrics page', async () => {
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+    });
+
+    expect(response.body).toContain('name-1508 - Service Metrics');
+  });
+
+  it('should return cloudwatch metrics for a postgres backing service', async () => {
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+    });
+
+    expect(response.body).toContain('Free disk space');
+  });
+
+  it('should not return metrics for a user provided service', async () => {
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+    });
+
+    expect(response.body).not.toContain('Free disk space');
+    expect(response.body).toContain('Metrics are not available for this service yet.');
+  });
+});

--- a/src/components/service-metrics/service-metrics.ts
+++ b/src/components/service-metrics/service-metrics.ts
@@ -1,0 +1,101 @@
+import * as cw from '@aws-sdk/client-cloudwatch-node';
+
+import CloudFoundryClient from '../../lib/cf';
+import { IParameters, IResponse } from '../../lib/router';
+import { IContext } from '../app';
+import { CLOUD_CONTROLLER_ADMIN, CLOUD_CONTROLLER_GLOBAL_AUDITOR, CLOUD_CONTROLLER_READ_ONLY_ADMIN } from '../auth';
+import { fromOrg, IBreadcrumb } from '../breadcrumbs';
+import serviceMetricsTemplate from './service-metrics.njk';
+
+// Ignoring test coverage of viewServiceMetricImage because this is temporary code,
+// to be replaced with properly rendered SVG graphs at a later date.
+/* istanbul ignore next */
+export async function viewServiceMetricImage(ctx: IContext, params: IParameters): Promise<IResponse> {
+    const cloudWatch = new cw.CloudWatchClient({ region: 'eu-west-1' });
+    const cmd = new cw.GetMetricWidgetImageCommand({
+      MetricWidget: JSON.stringify({
+        metrics: [
+          [ 'AWS/RDS', params.metricDimension, 'DBInstanceIdentifier', `rdsbroker-${params.serviceGUID}` ],
+        ],
+        yAxis: {left: { min: 0} },
+        start: '-PT24H',
+        title: ' ',
+        legend: {position: 'hidden'},
+      }),
+    });
+
+    try {
+      const data = await cloudWatch.send(cmd);
+      if (!data.MetricWidgetImage) {
+        throw new Error('Expected MetricWidgetImage to be set');
+      }
+      return {
+          body: Buffer.from(data.MetricWidgetImage),
+          mimeType: 'image/png',
+      };
+    } catch (err) {
+      ctx.app.logger.error('failed to get metric widget image', err);
+      return {
+          body: Buffer.from(''),
+          mimeType: 'image/png',
+      };
+    }
+}
+
+export async function viewServiceMetrics(ctx: IContext, params: IParameters): Promise<IResponse> {
+    const cf = new CloudFoundryClient({
+        accessToken: ctx.token.accessToken,
+        apiEndpoint: ctx.app.cloudFoundryAPI,
+        logger: ctx.app.logger,
+      });
+
+    const isAdmin = ctx.token.hasAnyScope(
+        CLOUD_CONTROLLER_ADMIN,
+        CLOUD_CONTROLLER_READ_ONLY_ADMIN,
+        CLOUD_CONTROLLER_GLOBAL_AUDITOR,
+    );
+
+    const [isManager, isBillingManager, userProvidedServices, space, organization] = await Promise.all([
+        cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'org_manager'),
+        cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'billing_manager'),
+        cf.userServices(params.spaceGUID),
+        cf.space(params.spaceGUID),
+        cf.organization(params.organizationGUID),
+    ]);
+
+    const isUserProvidedService = userProvidedServices.some(s => s.metadata.guid === params.serviceGUID);
+
+    const service = isUserProvidedService ?
+      await cf.userServiceInstance(params.serviceGUID) :
+      await cf.serviceInstance(params.serviceGUID);
+
+    const serviceLabel = isUserProvidedService ? 'User Provided Service'
+        : (await cf.service(service.entity.service_guid)).entity.label;
+
+    const breadcrumbs: ReadonlyArray<IBreadcrumb> = fromOrg(ctx, organization, [
+        {
+            text: space.entity.name,
+            href: ctx.linkTo('admin.organizations.spaces.services.list', {
+            organizationGUID: organization.metadata.guid,
+            spaceGUID: space.metadata.guid,
+            }),
+        },
+        { text: service.entity.name },
+    ]);
+
+    return {
+        body: serviceMetricsTemplate.render({
+            routePartOf: ctx.routePartOf,
+            linkTo: ctx.linkTo,
+            context: ctx.viewContext,
+            organization,
+            service,
+            serviceLabel,
+            space,
+            isAdmin,
+            isBillingManager,
+            isManager,
+            breadcrumbs,
+        }),
+    };
+}

--- a/src/components/services/_tabs.njk
+++ b/src/components/services/_tabs.njk
@@ -1,0 +1,37 @@
+{% extends "../../layouts/govuk.njk" %}
+
+{% block content %}
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">Service</span>
+  {{ service.entity.name }}
+</h1>
+
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item {% if routePartOf('admin.organizations.spaces.services.view') %}govuk-tabs__list-item--selected{% endif %}">
+      <a href="{{
+        linkTo(
+          'admin.organizations.spaces.services.view',
+          {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid }
+        ) }}">Overview</a>
+    </li>
+    <li class="govuk-tabs__list-item {% if routePartOf('admin.organizations.spaces.services.metrics.view') %}govuk-tabs__list-item--selected{% endif %}">
+      <a href="{{
+        linkTo(
+          'admin.organizations.spaces.services.metrics.view',
+          {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid }
+        ) }}">Metrics</a>
+    </li>
+  </ul>
+
+  <section class="govuk-tabs__panel">
+    {% block insideTabs %}
+    {% endblock %}
+  </section>
+</div>
+
+{% endblock %}

--- a/src/components/services/overview.njk
+++ b/src/components/services/overview.njk
@@ -1,20 +1,14 @@
-{% extends "../../layouts/govuk.njk" %}
+{% extends "./_tabs.njk" %}
 {% from "govuk-frontend/govuk/components/table/macro.njk" import govukTable %}
 
 {% block pageTitle %}
   {{ service.entity.name }} - Service Overview
 {% endblock %}
 
-{% block content %}
-  {{ super() }}
+{% block insideTabs %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">Service</span>
-        {{ service.entity.name }}
-      </h1>
-
       {{ govukTable({
         caption: 'Service details',
         firstCellIsHeader: false,

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -600,7 +600,7 @@ export const servicePlan = `{
     "updated_at": "2016-06-08T16:41:26Z"
   },
   "entity": {
-    "name": "name-1573",
+    "name": "postgres-1573",
     "free": false,
     "description": "desc-107",
     "service_guid": "a00cacc0-0ca6-422e-91d3-6b22bcd33450",
@@ -631,7 +631,7 @@ export const service = `{
     "updated_at": "2016-06-08T16:41:26Z"
   },
   "entity": {
-    "label": "label-58",
+    "label": "postgres-58",
     "provider": null,
     "url": null,
     "description": "desc-135",

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -369,7 +369,7 @@ describe('lib/cf test suite', () => {
     const client = new CloudFoundryClient(config);
     const servicePlan = await client.servicePlan('775d0046-7505-40a4-bfad-ca472485e332');
 
-    expect(servicePlan.entity.name).toEqual('name-1573');
+    expect(servicePlan.entity.name).toEqual('postgres-1573');
   });
 
   it('should obtain particular service', async () => {
@@ -381,7 +381,7 @@ describe('lib/cf test suite', () => {
     const client = new CloudFoundryClient(config);
     const service = await client.service('53f52780-e93c-4af7-a96c-6958311c40e5');
 
-    expect(service.entity.label).toEqual('label-58');
+    expect(service.entity.label).toEqual('postgres-58');
   });
 
   it('should create a user', async () => {

--- a/src/lib/router/route.ts
+++ b/src/lib/router/route.ts
@@ -11,10 +11,11 @@ export interface IDownload {
 }
 
 export interface IResponse {
-  readonly body?: object | string;
+  readonly body?: object | string | Buffer;
   readonly download?: IDownload;
   readonly redirect?: string;
   readonly status?: number;
+  readonly mimeType?: 'image/png';
 }
 
 export type ActionFunction = (ctx: any, params: IParameters, body?: any) => Promise<IResponse>;


### PR DESCRIPTION
What
----

Initially we're using GetMetricWidgetImage as a quick way of getting metrics in
front of users. We know these are not good for accessibility, so we'll replace
them with "proper" graphs in a future story.

We're only doing RDS services (postgres/mysql) to begin with because it's easy
to work out which AWS resource corresponds to a service in cloud foundry. This
is a bit more tricky for Redis because there's not an obvious mapping between
the service instance id and the elasticache cluster id.

We've decided not to test the image generation code because it's only temporary.

How to review
-------------

Code review

Who can review
---------------

Not me or @richardTowers 