### PR TITLE
Remove unnsecessary check

### DIFF
--- a/src/components/org-users/org-users.test.ts
+++ b/src/components/org-users/org-users.test.ts
@@ -822,7 +822,7 @@ describe('org-users test suite', () => {
       .reply(200, JSON.stringify(defaultOrg()))
 
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
-      .times(4)
+      .times(3)
       .reply(200, cfData.userRolesForOrg)
     ;
 
@@ -838,7 +838,7 @@ describe('org-users test suite', () => {
   it('should fail to show the user edit page due to not existing user', async () => {
     nockCF
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
-      .times(4)
+      .times(3)
       .reply(200, cfData.userRolesForOrg)
 
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/spaces')
@@ -876,7 +876,7 @@ describe('org-users test suite', () => {
       .reply(200, JSON.stringify(defaultOrg()))
 
       .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
-      .times(4)
+      .times(3)
       .reply(200, cfData.userRolesForOrg)
     ;
 

--- a/src/components/org-users/org-users.ts
+++ b/src/components/org-users/org-users.ts
@@ -654,14 +654,6 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
     cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'billing_manager'),
   ]);
 
-  const users = await cf.usersForOrganization(params.organizationGUID);
-  const managers = users.filter((manager: IOrganizationUserRoles) =>
-    manager.entity.organization_roles.some(role => role === 'org_manager'),
-  );
-  const billingManagers = users.filter((manager: IOrganizationUserRoles) =>
-    manager.entity.organization_roles.some(role => role === 'billing_manager'),
-  );
-
   /* istanbul ignore next */
   if (!isAdmin && !isManager) {
     throw new NotFoundError('not found');
@@ -731,8 +723,6 @@ export async function editUser(ctx: IContext, params: IParameters): Promise<IRes
       routePartOf: ctx.routePartOf,
       linkTo: ctx.linkTo,
       context: ctx.viewContext,
-      managers,
-      billingManagers,
       organization,
       spaces,
       user,

--- a/src/components/org-users/permissions.njk
+++ b/src/components/org-users/permissions.njk
@@ -53,12 +53,6 @@
       <th class="govuk-table__header" scope="row">{{ organization.entity.name }}</th>
       <td class="govuk-table__cell ">
         <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].managers }}" name="org_roles[{{ organization.metadata.guid }}][managers][current]">
-        {% if (managers | length < 2) and (values.org_roles[organization.metadata.guid].managers) %}
-          {% set isCheckboxDisabled = true %}
-          <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].managers }}" name="org_roles[{{ organization.metadata.guid }}][managers][desired]">
-        {% else %}
-          {% set isCheckboxDisabled = false %}
-        {% endif %}
         {{ govukCheckboxes({
           id: "org_roles[" + organization.metadata.guid + "][managers]",
           name: "org_roles[" + organization.metadata.guid + "][managers][desired]",
@@ -66,20 +60,13 @@
             {
               value: "1",
               html: "<span>Org manager</span>",
-              checked: values.org_roles[organization.metadata.guid].managers === '1',
-              disabled: isCheckboxDisabled
+              checked: values.org_roles[organization.metadata.guid].managers === '1'
             }
           ]
         }) }}
       </td>
       <td class="govuk-table__cell ">
         <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][current]">
-        {% if (billingManagers | length < 2) and (values.org_roles[organization.metadata.guid].billing_managers) %}
-          {% set isCheckboxDisabled = true %}
-          <input type="hidden" value="{{ values.org_roles[organization.metadata.guid].billing_managers }}" name="org_roles[{{ organization.metadata.guid }}][billing_managers][desired]">
-        {% else %}
-          {% set isCheckboxDisabled = false %}
-        {% endif %}
         {{ govukCheckboxes({
           id: "org_roles[" + organization.metadata.guid + "][billing_managers]",
           name: "org_roles[" + organization.metadata.guid + "][billing_managers][desired]",
@@ -87,8 +74,7 @@
             {
               value: "1",
               html: "<span>Billing manager</span>",
-              checked: values.org_roles[organization.metadata.guid].billing_managers === '1',
-              disabled: isCheckboxDisabled
+              checked: values.org_roles[organization.metadata.guid].billing_managers === '1'
             }
           ]
         }) }}


### PR DESCRIPTION
What
----

We've discussed this with @tlwr, and believe that this isn't
essentially necessary.

There is a potential for someone locking themselves out of their
organisation or remove a billing manager, which would cause us some
pain, but frankly at the moment, this is replaced by another bug, where
inviting users have this box disabled.

This could be fixed in another way, but could mean going through a
rabbit hole, and perhaps not provide that much value to us.

We believe that if a user locks themselves out accidentally, we as
GOV.UK PaaS team, will be helpful enough to respond to their support
ticket and help them out.

How to review
-------------

- Sanity check
- See if you agree with Toby and I

Who can review
---------------

Not @tlwr 