### PR TITLE
[#169625355] Endpoint for downloading a CSV of org spend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3694,6 +3694,12 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
     "clone-deep": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -4480,6 +4486,15 @@
         "http-errors": "~1.7.2"
       }
     },
+    "csv-parse": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.6.5.tgz",
+      "integrity": "sha512-tUohmlM5X1Wtn7aRA4FsJMmnvGo+GUknK/Dp+//ms7pvpXADda5HIi5vFYOvAs/WSn5JUM1bt2AT3TxtDFV3Cw==",
+      "dev": true,
+      "requires": {
+        "pad": "^3.2.0"
+      }
+    },
     "cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
@@ -4919,6 +4934,15 @@
       "dev": true,
       "requires": {
         "strip-bom": "^3.0.0"
+      }
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -12744,6 +12768,15 @@
         }
       }
     },
+    "pad": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pad/-/pad-3.2.0.tgz",
+      "integrity": "sha512-2u0TrjcGbOjBTJpyewEl4hBO3OeX5wWue7eIFPzQTg6wFSvoaHcBTTUY5m+n0hd04gmTCPuY0kCpVIVuw5etwg==",
+      "dev": true,
+      "requires": {
+        "wcwidth": "^1.0.1"
+      }
+    },
     "pako": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -18334,6 +18367,15 @@
         "chokidar": "^2.0.2",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "cheerio": "^1.0.0-rc.3",
     "compression-webpack-plugin": "3.0.0",
     "css-loader": "3.2.0",
+    "csv-parse": "^4.6.5",
     "expect": "^24.9.0",
     "extract-loader": "3.1.0",
     "file-loader": "4.2.0",

--- a/src/components/app/app.test-helpers.ts
+++ b/src/components/app/app.test-helpers.ts
@@ -40,7 +40,7 @@ export function createTestContext(ctx?: {}): IContext {
     ),
     viewContext: {
       csrf: '',
-      location: 'eu-west-2',
+      location: config.location,
     },
     session: new FakeSession(),
     ...ctx,

--- a/src/components/app/app.test.config.ts
+++ b/src/components/app/app.test.config.ts
@@ -38,4 +38,5 @@ export const config: IAppConfig = {
   domainName: 'https://admin.example.com/',
   awsRegion: 'eu-west-1',
   awsCloudwatchEndpoint: 'https://aws.example.com/',
+  adminFee: 0.1,
 };

--- a/src/components/app/app.test.config.ts
+++ b/src/components/app/app.test.config.ts
@@ -29,7 +29,7 @@ export const config: IAppConfig = {
   oauthClientID: 'key',
   oauthClientSecret: 'secret',
   cloudFoundryAPI: 'https://example.com/api',
-  location: 'eu-west-1',
+  location: 'Ireland',
   uaaAPI: 'https://example.com/uaa',
   authorizationAPI: 'https://example.com/login',
   notifyAPIKey: 'test-123456-qwerty',

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -38,6 +38,7 @@ export interface IAppConfig {
   readonly domainName: string;
   readonly awsRegion: string;
   readonly awsCloudwatchEndpoint?: string;
+  readonly adminFee: number;
 }
 
 export type OIDCProviderName = 'microsoft' | 'google';

--- a/src/components/app/router-middleware.test.ts
+++ b/src/components/app/router-middleware.test.ts
@@ -43,9 +43,14 @@ describe('app test suite - router-middleware', () => {
         path: '/download',
       },
       {
-        name: 'mimetype',
+        name: 'png-mimetype',
         action: async (_c, _p, _b) => ({mimeType: 'image/png'}),
         path: '/image',
+      },
+      {
+        name: 'csv-mimetype',
+        action: async (_c, _p, _b) => ({mimeType: 'text/csv'}),
+        path: '/csv',
       },
     ]);
 
@@ -78,6 +83,7 @@ describe('app test suite - router-middleware', () => {
     const serverErrorResponse = await agent.get('/500');
     const downloadResponse = await agent.get('/download');
     const imgResponse = await agent.get('/image');
+    const csvResponse = await agent.get('/csv');
 
     expect(linkTo('hello', {name: 'World'})).toEqual('/hello/World');
     expect(linkTo('home')).toEqual('/');
@@ -90,5 +96,6 @@ describe('app test suite - router-middleware', () => {
     expect(serverErrorResponse.status).toEqual(500);
     expect(downloadResponse.header['content-disposition']).toEqual(`attachment; filename="download.txt"`);
     expect(imgResponse.header['content-type']).toEqual(`image/png`);
+    expect(csvResponse.header['content-type']).toEqual(`text/csv; charset=utf-8`);
   });
 });

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -162,6 +162,11 @@ const router = new Router([
     path: '/reports/cost-by-service/:rangeStart',
   },
   {
+    action: reports.viewPmoOrgSpendReportCSV,
+    name: 'admin.reports.pmo-org-spend-csv',
+    path: '/reports/pmo-org-spend/:rangeStart',
+  },
+  {
     action: reports.viewVisualisation,
     name: 'admin.reports.visualisation',
     path: '/reports/visualisation/:rangeStart',

--- a/src/components/reports/index.ts
+++ b/src/components/reports/index.ts
@@ -1,4 +1,5 @@
 export * from './cost';
 export * from './cost-by-service';
+export * from './pmo-org-spend';
 export * from './organizations';
 export * from './visualisation';

--- a/src/components/reports/pmo-org-spend.csv.njk
+++ b/src/components/reports/pmo-org-spend.csv.njk
@@ -1,0 +1,4 @@
+Billing month,Org,Region,Unique ID,Spend without VAT
+{%- for billablesForOrg in billablesByOrganisation %}
+{{ month }},{{ billablesForOrg.org.name }},{{ location }},{{ billablesForOrg.org.guid }},£{{ (billablesForOrg.exVAT + (billablesForOrg.exVAT * adminFee)) | currency(2) }}
+{%- endfor %}

--- a/src/components/reports/pmo-org-spend.test.ts
+++ b/src/components/reports/pmo-org-spend.test.ts
@@ -1,0 +1,342 @@
+// tslint:disable-next-line:no-submodule-imports
+import parse from 'csv-parse/lib/sync';
+import moment from 'moment';
+import nock from 'nock';
+import {createTestContext} from '../app/app.test-helpers';
+
+import {v3Org as defaultOrg} from '../../lib/cf/test-data/org';
+import {wrapV3Resources} from '../../lib/cf/test-data/wrap-resources';
+
+import { config } from '../app/app.test.config';
+import { IContext } from '../app/context';
+import * as reports from '../reports';
+
+describe('csv organisation monthly spend report for the pmo team', () => {
+  const ctx: IContext = createTestContext();
+  let nockCF: nock.Scope;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    nockCF = nock(ctx.app.cloudFoundryAPI);
+    nockCF
+      .get(`/v2/quota_definitions?q=name:default`)
+      .reply(200, `{"resources": [
+        {"metadata": {"guid": "default-quota"}, "entity": {"name": "default"}}
+      ]}`);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should return a one-line CSV when there are no organisations', async () => {
+    const rangeStart = moment().startOf('month').format('YYYY-MM-DD');
+
+    nockCF.get('/v3/organizations')
+      .times(5)
+      .reply(200, JSON.stringify(wrapV3Resources()));
+    nock(config.billingAPI)
+      .get('/billable_events')
+      .query(true)
+      .reply(200, '[]');
+
+    const response = await reports.viewPmoOrgSpendReportCSV(ctx, {rangeStart});
+    expect(response.download).not.toBeUndefined();
+    expect(response.download!.data)
+      .toEqual(`Billing month,Org,Region,Unique ID,Spend without VAT\n`);
+  });
+
+  it('should name the CSV appropriately', async () => {
+    nockCF.get('/v3/organizations')
+      .times(5)
+      .reply(200, JSON.stringify(wrapV3Resources(defaultOrg())));
+    nock(config.billingAPI)
+      .get('/billable_events')
+      .query(true)
+      .reply(200, '[]');
+
+    const response = await reports.viewPmoOrgSpendReportCSV(ctx, {rangeStart: '2018-01-01'});
+    expect(response.download).not.toBeUndefined();
+    expect(response.download!.name)
+      .toEqual('paas-pmo-org-spend-ireland-2018-01.csv');
+  });
+
+  it('should apply the 10% admin fee', async () => {
+    const rangeStart = moment().startOf('month');
+
+    const defaultPriceDetails = {
+      name: 'instance',
+      start: '2018-04-20T14:36:09+00:00',
+      stop: '2018-04-20T14:45:46+00:00',
+      plan_name: 'default-plan-name',
+      ex_vat: 0,
+      inc_vat: 0,
+      vat_rate: 10,
+    };
+    const defaultPrice = {
+      ex_vat: 0,
+      inc_vat: 0,
+      details: [defaultPriceDetails],
+    };
+    const defaultBillableEvent = {
+      event_guid: 'default-event-guid',
+      event_start: '2018-04-20T14:36:09+00:00',
+      event_stop: '2018-04-20T14:45:46+00:00',
+      resource_guid: 'default-resource-guid',
+      resource_name: 'default-resource-name',
+      resource_type: 'app',
+      org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+      space_guid: 'default-space-guid',
+      plan_guid: 'default-plan-guid',
+      quota_definition_guid: 'default-quota-definition-guid',
+      number_of_nodes: 1,
+      memory_in_mb: 64,
+      storage_in_mb: 0,
+      price: defaultPrice,
+    };
+    nock(config.billingAPI)
+      .get('/billable_events')
+      .query(true)
+      .times(2)
+      .reply(200, JSON.stringify([
+        {...defaultBillableEvent, org_guid: 'org-one', price: {...defaultPrice, ex_vat: '1'}},
+      ]));
+    nockCF
+      .get('/v3/organizations')
+      .reply(200, wrapV3Resources(
+        {...defaultOrg(), guid: 'org-one', name: 'Org One'},
+      ));
+
+    const response = await reports.viewPmoOrgSpendReportCSV(ctx, {rangeStart: rangeStart.format('YYYY-MM-DD')});
+    expect(response.download).not.toBeUndefined();
+    const records = parse(response.download!.data, {columns: true});
+    expect(records.length).toEqual(1);
+    expect(records).toContainEqual({
+      'Billing month': rangeStart.format('MMMM YYYY'),
+      'Org': 'Org One',
+      'Region': 'Ireland',
+      'Unique ID': 'org-one',
+      'Spend without VAT': '£1.10',
+    });
+  });
+
+  it('should group billable events by org', async () => {
+    const rangeStart = moment().startOf('month');
+
+    const defaultPriceDetails = {
+      name: 'instance',
+      start: '2018-04-20T14:36:09+00:00',
+      stop: '2018-04-20T14:45:46+00:00',
+      plan_name: 'default-plan-name',
+      ex_vat: 0,
+      inc_vat: 0,
+      vat_rate: 10,
+    };
+    const defaultPrice = {
+      ex_vat: 0,
+      inc_vat: 0,
+      details: [defaultPriceDetails],
+    };
+    const defaultBillableEvent = {
+      event_guid: 'default-event-guid',
+      event_start: '2018-04-20T14:36:09+00:00',
+      event_stop: '2018-04-20T14:45:46+00:00',
+      resource_guid: 'default-resource-guid',
+      resource_name: 'default-resource-name',
+      resource_type: 'app',
+      org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+      space_guid: 'default-space-guid',
+      plan_guid: 'default-plan-guid',
+      quota_definition_guid: 'default-quota-definition-guid',
+      number_of_nodes: 1,
+      memory_in_mb: 64,
+      storage_in_mb: 0,
+      price: defaultPrice,
+    };
+    nock(config.billingAPI)
+      .get('/billable_events')
+      .query(true)
+      .times(2)
+      .reply(200, JSON.stringify([
+        {...defaultBillableEvent, org_guid: 'org-one', price: {...defaultPrice, ex_vat: '1'}},
+        {...defaultBillableEvent, org_guid: 'org-two', price: {...defaultPrice, ex_vat: '10'}},
+        {...defaultBillableEvent, org_guid: 'org-one', price: {...defaultPrice, ex_vat: '100'}},
+        {...defaultBillableEvent, org_guid: 'org-one', price: {...defaultPrice, ex_vat: '1000'}},
+        {...defaultBillableEvent, org_guid: 'org-two', price: {...defaultPrice, ex_vat: '10000'}},
+      ]));
+    nockCF
+      .get('/v3/organizations')
+      .reply(200, wrapV3Resources(
+        {...defaultOrg(), guid: 'org-one', name: 'Org One'},
+        {...defaultOrg(), guid: 'org-two', name: 'Org Two'},
+      ));
+
+    const response = await reports.viewPmoOrgSpendReportCSV(ctx, {rangeStart: rangeStart.format('YYYY-MM-DD')});
+    expect(response.download).not.toBeUndefined();
+    const records = parse(response.download!.data, {columns: true});
+    expect(records.length).toEqual(2);
+    expect(records).toContainEqual({
+      'Billing month': rangeStart.format('MMMM YYYY'),
+      'Org': 'Org One',
+      'Region': 'Ireland',
+      'Unique ID': 'org-one',
+      'Spend without VAT': '£1211.10',
+    });
+    expect(records).toContainEqual({
+      'Billing month': rangeStart.format('MMMM YYYY'),
+      'Org': 'Org Two',
+      'Region': 'Ireland',
+      'Unique ID': 'org-two',
+      'Spend without VAT': '£11011.00',
+    });
+  });
+
+  it('should list billable orgs which have no billable events', async () => {
+    const rangeStart = moment().startOf('month');
+
+    nockCF.get('/v3/organizations')
+      .times(5)
+      .reply(200, JSON.stringify(wrapV3Resources(
+        {...defaultOrg(), guid: 'org-with-nothing-billed', name: 'Org With Nothing Billed'},
+       )));
+    nock(config.billingAPI)
+      .get('/billable_events')
+      .query(true)
+      .reply(200, '[]');
+
+    const response = await reports.viewPmoOrgSpendReportCSV(ctx, {
+      rangeStart: rangeStart.format('YYYY-MM-DD'),
+    });
+    expect(response.download).not.toBeUndefined();
+    const records = parse(response.download!.data, {columns: true});
+    expect(records.length).toEqual(1);
+    expect(records[0]).toEqual({
+      'Billing month': rangeStart.format('MMMM YYYY'),
+      'Org': 'Org With Nothing Billed',
+      'Region': 'Ireland',
+      'Unique ID': 'org-with-nothing-billed',
+      'Spend without VAT': '£0.00',
+    });
+  });
+});
+
+describe('cost report grouping functions', () => {
+  const defaultPrice = { incVAT: 0, exVAT: 0, details: [] };
+  const defaultBillableEvent = {
+    price: defaultPrice,
+    eventGUID: '',
+    eventStart: new Date(),
+    eventStop: new Date(),
+    resourceGUID: '',
+    resourceName: '',
+    resourceType: '',
+    orgGUID: '',
+    spaceGUID: '',
+    spaceName: '',
+    planGUID: '',
+    numberOfNodes: 0,
+    memoryInMB: 0,
+    storageInMB: 0,
+  };
+
+  describe('getBillablesByOrganisation', () => {
+    it('should work with zero orgs and events', () => {
+      const results = reports.getBillablesByOrganisation([], []);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should work with zero events', () => {
+      const results = reports.getBillablesByOrganisation([defaultOrg()], []);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({
+        org:   defaultOrg(),
+        exVAT: 0,
+      });
+    });
+
+    it('should sum costs for services of the same organisation', () => {
+      const results = reports.getBillablesByOrganisation([
+        {...defaultOrg(), guid: 'org-one', name: 'Org One'},
+      ], [
+        {...defaultBillableEvent, orgGUID: 'org-one', price: {...defaultPrice, exVAT: 1}},
+        {...defaultBillableEvent, orgGUID: 'org-one', price: {...defaultPrice, exVAT: 10}},
+      ]);
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({
+        org:   {...defaultOrg(), guid: 'org-one', name: 'Org One'},
+        exVAT: 11,
+      });
+    });
+
+    it('should not sum costs for different organisations', () => {
+      const results = reports.getBillablesByOrganisation([
+        {...defaultOrg(), guid: 'org-one', name: 'Org One'},
+        {...defaultOrg(), guid: 'org-two', name: 'Org Two'},
+      ], [
+        {...defaultBillableEvent, orgGUID: 'org-one', price: {...defaultPrice, exVAT: 5}},
+        {...defaultBillableEvent, orgGUID: 'org-two', price: {...defaultPrice, exVAT: 7}},
+      ]);
+      expect(results).toHaveLength(2);
+      expect(results).toContainEqual({
+        org:   {...defaultOrg(), guid: 'org-one', name: 'Org One'},
+        exVAT: 5,
+      });
+      expect(results).toContainEqual({
+        org:   {...defaultOrg(), guid: 'org-two', name: 'Org Two'},
+        exVAT: 7,
+      });
+    });
+  });
+
+  it('filterRealOrgs should filter out tests and admin', () => {
+    const orgs = [
+      {...defaultOrg(), name: 'govuk-doggos' },
+      {...defaultOrg(), name: 'admin' },
+      {...defaultOrg(), name: 'ACC-123' },
+      {...defaultOrg(), name: 'BACC-123' },
+      {...defaultOrg(), name: 'CATS-123' },
+      {...defaultOrg(), name: 'department-for-coffee' },
+      {...defaultOrg(), name: 'SMOKE-' },
+    ];
+
+    const filteredOrgs = reports.filterRealOrgs(orgs);
+
+    expect(filteredOrgs.length).toEqual(2);
+    expect(filteredOrgs[0].name).toEqual('govuk-doggos');
+    expect(filteredOrgs[1].name).toEqual('department-for-coffee');
+  });
+
+  it('filterBillableOrgs should filter out trial orgs', () => {
+    const trialGUID = 'trial-guid';
+    const paidGUID = 'expensive-guid';
+
+    const orgs = [
+      {
+        ...defaultOrg(),
+        relationships: {quota: {data: { guid: trialGUID }}},
+        name:          '1-trial-org',
+      },
+      {
+        ...defaultOrg(),
+        relationships: {quota: {data: { guid: paidGUID }}},
+        name:          '1-paid-org',
+      },
+      {
+        ...defaultOrg(),
+        relationships: {quota: {data: { guid: trialGUID }}},
+        name:          '2-trial-org',
+      },
+      {
+        ...defaultOrg(),
+        relationships: {quota: {data: { guid: paidGUID }}},
+        name:          '2-paid-org',
+      },
+    ];
+
+    const billableOrgs = reports.filterBillableOrgs(trialGUID, orgs);
+
+    expect(billableOrgs.length).toEqual(2);
+    expect(billableOrgs).toContainEqual(orgs[1]);
+    expect(billableOrgs).toContainEqual(orgs[3]);
+  });
+});

--- a/src/components/reports/pmo-org-spend.ts
+++ b/src/components/reports/pmo-org-spend.ts
@@ -1,0 +1,107 @@
+import {groupBy, sortBy, sumBy} from 'lodash';
+import moment from 'moment';
+
+import { BillingClient } from '../../lib/billing';
+import CloudFoundryClient from '../../lib/cf';
+import { IV3OrganizationResource } from '../../lib/cf/types';
+import { IParameters, IResponse } from '../../lib/router';
+import { IContext } from '../app/context';
+
+import pmoOrgSpendTemplate from './pmo-org-spend.csv.njk';
+
+export function filterRealOrgs(
+  orgs: ReadonlyArray<IV3OrganizationResource>,
+): ReadonlyArray<IV3OrganizationResource> {
+  return orgs
+  .filter(org => {
+    if (org.name.match(/^(CATS|ACC|BACC|SMOKE|PERF)-/)) {
+      return false;
+    }
+
+    if (org.name === 'admin') {
+      return false;
+    }
+
+    return true;
+  })
+  ;
+}
+
+export function filterBillableOrgs(
+  trialQuotaGUID: string,
+  orgs: ReadonlyArray<IV3OrganizationResource>,
+): ReadonlyArray<IV3OrganizationResource> {
+  const billableOrgs = orgs.filter(
+    o => o.relationships.quota.data.guid !== trialQuotaGUID,
+  );
+
+  // return the newest orgs first (reverse)
+  return sortBy(billableOrgs, o => new Date(o.created_at))
+    .reverse()
+  ;
+}
+
+export interface IBillableByOrganisation {
+  org: IV3OrganizationResource;
+  exVAT: number;
+}
+
+export function getBillablesByOrganisation(
+    orgs: ReadonlyArray<IV3OrganizationResource>,
+    billableEvents: ReadonlyArray<IBillableEvent>,
+  ): ReadonlyArray<IBillableByOrganisation> {
+  const billableEventsByOrganisation = groupBy(billableEvents, e => e.orgGUID);
+  return orgs.map((org) => ({
+    org,
+    exVAT: sumBy(billableEventsByOrganisation[org.guid], x => x.price.exVAT) || 0,
+  }));
+}
+
+export async function viewPmoOrgSpendReportCSV(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const rangeStart = moment(params.rangeStart, 'YYYY-MM-DD').toDate();
+  const rangeStop  = moment(rangeStart).add(1, 'month').toDate();
+
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const billingClient = new BillingClient({
+    apiEndpoint: ctx.app.billingAPI,
+    accessToken: ctx.token.accessToken,
+    logger: ctx.app.logger,
+  });
+
+  const trialQuotaCandidates = await cf.quotaDefinitions({name: 'default'});
+  /* istanbul ignore next */
+  if (trialQuotaCandidates.length !== 1) {
+    throw new Error('Could not find default quota');
+  }
+  const trialQuotaGUID = trialQuotaCandidates[0].metadata.guid;
+
+  const realOrgs = filterRealOrgs(await cf.v3Organizations());
+  const billableOrgs = filterBillableOrgs(trialQuotaGUID, realOrgs);
+
+  const billableOrgsByGUID = groupBy(billableOrgs, x => x.guid);
+  const billableOrgGUIDs = Object.keys(billableOrgsByGUID);
+  const billableEvents = await billingClient.getBillableEvents({
+    rangeStart, rangeStop, orgGUIDs: billableOrgGUIDs,
+  });
+  const billablesByOrganisation = getBillablesByOrganisation(billableOrgs, billableEvents);
+
+  const nameMonth = moment(rangeStart).format('YYYY-MM');
+  const nameLocation = ctx.app.location.toLowerCase();
+  return {
+    mimeType: 'text/csv',
+    download: {
+      name: `paas-pmo-org-spend-${nameLocation}-${nameMonth}.csv`,
+      data: pmoOrgSpendTemplate.render({
+        location: ctx.app.location,
+        month: moment(rangeStart).format('MMMM YYYY'),
+        billablesByOrganisation,
+        adminFee: ctx.app.adminFee,
+      }),
+    },
+  };
+}

--- a/src/components/statements/statements.test.ts
+++ b/src/components/statements/statements.test.ts
@@ -381,7 +381,8 @@ describe('statements test suite', () => {
   });
 
   it('should compose csv content correctly', async () => {
-    const content = composeCSV([resourceTemplate]);
+    const adminFee = 0.1;
+    const content = composeCSV([resourceTemplate], adminFee);
 
     expect(content).toContain('Name,Space,Plan,Ex VAT,Inc VAT');
     expect(content).toContain('api,prod,app,1.00,1.20');

--- a/src/components/statements/statements.ts
+++ b/src/components/statements/statements.ts
@@ -15,8 +15,6 @@ import { UserFriendlyError } from '../errors';
 
 import usageTemplate from './statements.njk';
 
-export const adminFee = .1;
-
 interface IResourceUsage {
   readonly resourceGUID: string;
   readonly resourceName: string;
@@ -200,7 +198,7 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
   if (params.download) {
     return {
       download: {
-        data: composeCSV(filteredItems),
+        data: composeCSV(filteredItems, ctx.app.adminFee),
         name: `statement-${rangeStart.format(YYYMMDD)}.csv`,
       },
     };
@@ -237,7 +235,7 @@ export async function viewStatement(ctx: IContext, params: IParameters): Promise
       orderBy,
       orderDirection,
       currentMonth,
-      adminFee,
+      adminFee: ctx.app.adminFee,
       breadcrumbs,
     }),
   };
@@ -307,7 +305,7 @@ export function sortBySpace(a: IResourceUsage, b: IResourceUsage) {
   return 0;
 }
 
-export function composeCSV(items: ReadonlyArray<IResourceUsage>): string {
+export function composeCSV(items: ReadonlyArray<IResourceUsage>, adminFee: number): string {
   const lines = ['Name,Space,Plan,Ex VAT,Inc VAT'];
 
   for (const item of items) {

--- a/src/lib/router/route.ts
+++ b/src/lib/router/route.ts
@@ -15,7 +15,7 @@ export interface IResponse {
   readonly download?: IDownload;
   readonly redirect?: string;
   readonly status?: number;
-  readonly mimeType?: 'image/png';
+  readonly mimeType?: 'image/png' | 'text/csv';
 }
 
 export type ActionFunction = (ctx: any, params: IParameters, body?: any) => Promise<IResponse>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,6 +99,7 @@ async function main() {
     oidcProviders: providers,
     domainName: expectEnvVariable('DOMAIN_NAME'),
     awsCloudwatchEndpoint: process.env.AWS_CLOUDWATCH_ENDPOINT,
+    adminFee: .1,
   };
 
   const server = new Server(app(config), {


### PR DESCRIPTION
What
----

This PR adds a new endpoint at `/reports/pmo-org-spend/YYYY-MM` (e.g., `/reports/pmo-org-spend/2019-07`) for downloading a CSV of org spend. This is for PMO to know much to invoice tenants.

How to review
-------------

Code review. See commit message for caveats.

## Surprises

This is already manually deployed in both prods so that I could check it works.

Who can review
---------------

Not @46bit.