### PR TITLE
Fix no-margin on screens from 1020-1200px wide

### DIFF
--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -1,4 +1,5 @@
 $govuk-global-styles: true;
+$govuk-page-width: 1200px;
 
 @import '~govuk-frontend/govuk/all';
 
@@ -18,10 +19,6 @@ $govuk-global-styles: true;
 
 .govuk-template__body {
   font-family: "GDS Transport", Arial, sans-serif;
-}
-
-.govuk-width-container {
-  max-width: 1200px;
 }
 
 .text-right {


### PR DESCRIPTION
What
----

We increased the max-width on the container in 372202, but we did it in
a naïve way, rather than setting the variable that govuk-frontend uses
for the screen width.

If we use the variable instead then the code in
[_width-container.scss](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/objects/_width-container.scss)
will handle this for us and keep the margins correct.

How to review
-------------

* Code review
* Check these screenshots:

|        | 1020px                                                                                                                                         | 1200px                                                                                                                                      |
|--------|------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
| Before | ![Screenshot_2019-11-21 Organisations(3)](https://user-images.githubusercontent.com/1696784/69352673-3cdc5100-0c75-11ea-957a-10c389ec472f.png) | ![Screenshot_2019-11-21 Organisations(2)](https://user-images.githubusercontent.com/1696784/69352679-3f3eab00-0c75-11ea-9610-4fcb2af0168e.png) |
| After | ![Screenshot_2019-11-21 Organisations](https://user-images.githubusercontent.com/1696784/69352690-42d23200-0c75-11ea-8471-a66bcbba67b8.png) | ![Screenshot_2019-11-21 Organisations(1)](https://user-images.githubusercontent.com/1696784/69352684-41086e80-0c75-11ea-97a5-a74afe12f7f5.png) |

* Run it locally if you think I might have photoshopped the screenshots

Who can review
---------------

Not @richardtowers