### PR TITLE
Perioded metrics

### DIFF
--- a/config/nunjucks.config.js
+++ b/config/nunjucks.config.js
@@ -49,6 +49,14 @@ function configure(env) {
     return moment(date).format('HH:mm');
   });
 
+  env.addFilter('nicedatetime', (date) => {
+    return moment(date).format('h:mma, D MMMM YYYY');
+  });
+
+  env.addFilter('dateTime', (date) => {
+    return moment(date).format('YYYY-MM-DD[T]HH:mm');
+  });
+
   env.addFilter('relativetime', (date) => {
     return moment(date).fromNow();
   });

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -78,6 +78,11 @@ const router = new Router([
     path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/metrics',
   },
   {
+    action: serviceMetrics.resolveServiceMetrics,
+    name: 'admin.organizations.spaces.services.metrics.redirect',
+    path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/metrics/:offset',
+  },
+  {
     action: serviceEvents.viewServiceEvents,
     name: 'admin.organizations.spaces.services.events.view',
     path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/events',

--- a/src/components/charts/line-graph.ts
+++ b/src/components/charts/line-graph.ts
@@ -4,7 +4,6 @@ import {format as d3Format} from 'd3-format';
 import {scaleLinear, scaleTime} from 'd3-scale';
 import {select} from 'd3-selection';
 import {line} from 'd3-shape';
-import {timeFormat} from 'd3-time-format';
 import {JSDOM} from 'jsdom';
 import {flatMap} from 'lodash';
 import moment from 'moment';
@@ -43,7 +42,7 @@ const viewBox = {
 const padding = {
   top: 25,
   right: 30,
-  bottom: 80,
+  bottom: 132,
   left: 50,
 };
 
@@ -121,7 +120,13 @@ export function drawLineGraph(metricGraphData: IMetricGraphData): SVGElement {
     .attr('class', 'axis bottom')
     .attr('transform', `translate(0, ${viewBox.height - padding.bottom})`)
     .attr('aria-hidden', 'true')
-    .call(axisBottom<Date>(xScale).tickFormat(timeFormat('%H:%M')));
+    .call(axisBottom<Date>(xScale))
+    .selectAll('text')
+      .attr('y', 8)
+      .attr('x', -8)
+      .attr('dy', '.35em')
+      .attr('transform', 'rotate(-45)')
+      .style('text-anchor', 'end');
 
   svg.append('text')
     .attr('class', 'label left')

--- a/src/components/service-metrics/elasticache-service-metrics.njk
+++ b/src/components/service-metrics/elasticache-service-metrics.njk
@@ -8,113 +8,117 @@
 {% block insideTabs %}
 
 <div class="border-bottom-box">
-<p>{{ govukTag({text: "experimental"}) }}</p>
+  <p>{{ govukTag({text: "experimental"}) }}</p>
 
-<p>Backing service metrics is a new feature under active development. Expect frequent changes.</p>
-
-<p>Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>
-if you have any feedback.</p>
-</div>
-
-<p>
-The graphs below show metrics for the
-<a href="{{ linkTo(
-  'admin.organizations.spaces.services.view',
-  {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid}
-  )}}" class="govuk-link">{{ service.entity.name }}</a>
-service over the last 24 hours.
-</p>
-
-<p>Currently the available metrics for {{serviceLabel}} are:
-<ul>
-  <li><a href="#cpu-utilisation" class="govuk-link">CPU utilisation</a></li>
-  <li><a href="#memory-used" class="govuk-link">Memory used</a></li>
-  <li><a href="#swap-memory-used" class="govuk-link">Swap memory used</a></li>
-  <li><a href="#evictions">Evictions</a></li>
-  <li><a href="#connection-count">Connection count</a></li>
-  <li><a href="#cache-hits">Cache hits</a></li>
-  <li><a href="#cache-misses">Cache misses</a></li>
-  <li><a href="#item-count">Item count</a></li>
-  <li><a href="#network-bytes-in">Network bytes in</a></li>
-  <li><a href="#network-bytes-out">Network bytes out</a></li>
-</ul>
-</p>
-
-<div>
-  <h3 class="govuk-heading-m" id="cpu-utilisation">CPU Utilisation</h3>
-  <p>
-    How much computational work redis is doing. High CPU Utilisation may indicate you need to reduce your usage
-    or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans">update your service to use a bigger plan</a>.
+  <p class="govuk-body">
+    Backing service metrics is a new feature under active development.
+    Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you have any feedback.
   </p>
-  <div>{{metricGraphsById['mCPUUtilization'].graph | safe}}</div>
 </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="memory-used">Memory used</h3>
-  <p>
-  The total amount of memory redis is using to store your data and redis'
-  internal buffers. If redis reaches its memory limit and cannot evict any
-  keys it will return errors when executing commands that increase memory
-  use.
-  </p>
-  <div>{{metricGraphsById['mBytesUsedForCache'].graph | safe}}</div>
+<div class="govuk-grid-column-full">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p>Currently the available metrics for {{serviceLabel}} are:</p>
+      <ul class="govuk-list">
+        <li><a href="#cpu-utilisation" class="govuk-link">CPU utilisation</a></li>
+        <li><a href="#memory-used" class="govuk-link">Memory used</a></li>
+        <li><a href="#swap-memory-used" class="govuk-link">Swap memory used</a></li>
+        <li><a href="#evictions">Evictions</a></li>
+        <li><a href="#connection-count">Connection count</a></li>
+        <li><a href="#cache-hits">Cache hits</a></li>
+        <li><a href="#cache-misses">Cache misses</a></li>
+        <li><a href="#item-count">Item count</a></li>
+        <li><a href="#network-bytes-in">Network bytes in</a></li>
+        <li><a href="#network-bytes-out">Network bytes out</a></li>
+      </ul>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      {% include "./range-picker.njk" %}
+    </div>
+  </div>
 </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="swap-memory-used">Swap memory used</h3>
-  <p>
-  If redis is running low on memory it will start to swap memory onto the hard disk. If redis is using more than 50 <abbr title="MegaBytes">MB</abbr>
-  of swap memory you may need to reduce your usage or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans">update your service to use a bigger plan</a>.
-  </p>
-  <div>{{metricGraphsById['mSwapUsage'].graph | safe}}</div>
-</div>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="cpu-utilisation">CPU Utilisation</h3>
+      <p>
+        How much computational work redis is doing. High CPU Utilisation may indicate you need to reduce your usage
+        or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans">update your service to use a bigger plan</a>.
+      </p>
+      <div>{{metricGraphsById['mCPUUtilization'].graph | safe}}</div>
+    </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="evictions">Evictions</h3>
-  <p>
-  Redis will evict keys when it reaches its configured memory limit. It will try to remove less recently used keys first, but only among keys
-  that have an EXPIRE set. If there are no keys left to evict redis will return errors when executing commands that increase memory use.
-  </p>
-  <div>{{metricGraphsById['mEvictions'].graph | safe}}</div>
-</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="memory-used">Memory used</h3>
+      <p>
+      The total amount of memory redis is using to store your data and redis'
+      internal buffers. If redis reaches its memory limit and cannot evict any
+      keys it will return errors when executing commands that increase memory
+      use.
+      </p>
+      <div>{{metricGraphsById['mBytesUsedForCache'].graph | safe}}</div>
+    </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="connection-count">Connection count</h3>
-  <p>
-  How many open connections there are to redis. High values may indicate problems with your applications' connection management.
-  Zero values may indicate that redis is unavailable, or that your applications cannot connect to the database.
-  </p>
-  <div>{{metricGraphsById['mCurrConnections'].graph | safe}}</div>
-</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="swap-memory-used">Swap memory used</h3>
+      <p>
+      If redis is running low on memory it will start to swap memory onto the hard disk. If redis is using more than 50 <abbr title="MegaBytes">MB</abbr>
+      of swap memory you may need to reduce your usage or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans">update your service to use a bigger plan</a>.
+      </p>
+      <div>{{metricGraphsById['mSwapUsage'].graph | safe}}</div>
+    </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="cache-hits">Cache hits</h3>
-  <p>The number of successful key lookups.</p>
-  <div>{{metricGraphsById['mCacheHits'].graph | safe}}</div>
-</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="evictions">Evictions</h3>
+      <p>
+      Redis will evict keys when it reaches its configured memory limit. It will try to remove less recently used keys first, but only among keys
+      that have an EXPIRE set. If there are no keys left to evict redis will return errors when executing commands that increase memory use.
+      </p>
+      <div>{{metricGraphsById['mEvictions'].graph | safe}}</div>
+    </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="cache-misses">Cache misses</h3>
-  <p>The number of unsuccessful key lookups.</p>
-  <div>{{metricGraphsById['mCacheMisses'].graph | safe}}</div>
-</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="connection-count">Connection count</h3>
+      <p>
+      How many open connections there are to redis. High values may indicate problems with your applications' connection management.
+      Zero values may indicate that redis is unavailable, or that your applications cannot connect to the database.
+      </p>
+      <div>{{metricGraphsById['mCurrConnections'].graph | safe}}</div>
+    </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="item-count">Item count</h3>
-  <p>The number of items in redis.</p>
-  <div>{{metricGraphsById['mCurrItems'].graph | safe}}</div>
-</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="cache-hits">Cache hits</h3>
+      <p>The number of successful key lookups.</p>
+      <div>{{metricGraphsById['mCacheHits'].graph | safe}}</div>
+    </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="network-bytes-in">Network bytes in</h3>
-  <p>The number of bytes redis has read from the network.</p>
-  <div>{{metricGraphsById['mNetworkBytesIn'].graph | safe}}</div>
-</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="cache-misses">Cache misses</h3>
+      <p>The number of unsuccessful key lookups.</p>
+      <div>{{metricGraphsById['mCacheMisses'].graph | safe}}</div>
+    </div>
 
-<div>
-  <h3 class="govuk-heading-m" id="network-bytes-out">Network bytes out</h3>
-  <p>The number of bytes sent by redis.</p>
-  <div>{{metricGraphsById['mNetworkBytesOut'].graph | safe}}</div>
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="item-count">Item count</h3>
+      <p>The number of items in redis.</p>
+      <div>{{metricGraphsById['mCurrItems'].graph | safe}}</div>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="network-bytes-in">Network bytes in</h3>
+      <p>The number of bytes redis has read from the network.</p>
+      <div>{{metricGraphsById['mNetworkBytesIn'].graph | safe}}</div>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m" id="network-bytes-out">Network bytes out</h3>
+      <p>The number of bytes sent by redis.</p>
+      <div>{{metricGraphsById['mNetworkBytesOut'].graph | safe}}</div>
+    </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/src/components/service-metrics/range-picker.njk
+++ b/src/components/service-metrics/range-picker.njk
@@ -1,0 +1,71 @@
+{% from "govuk-frontend/govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk-frontend/govuk/components/input/macro.njk" import govukInput %}
+
+<div class="paas-statement-filters">
+  <p class="govuk-body">
+    Showing metrics between <strong class="non-breaking">{{ rangeStart | nicedatetime }}</strong>
+    and <strong class="non-breaking">{{ rangeStop | nicedatetime }}</strong> for <a href="{{ linkTo(
+      'admin.organizations.spaces.services.view',
+      {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid}
+      )}}" class="govuk-link non-breaking">{{ service.entity.name }}</a>.
+  </p>
+
+  <p class="govuk-body">  
+    Each point is an average over <strong class="non-breaking">{{ period.humanize() }}</strong>.
+  </p>
+
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Change time period
+      </span>
+    </summary>
+
+    <ol class="govuk-list">
+      <li>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '1h'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 1 hour">Last 1 hour</a>
+      </li>
+      <li>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '3h'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 3 hours">Last 3 hours</a>
+      </li>
+      <li>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '12h'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 12 hours">Last 12 hours</a>
+      </li>
+      <li>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '24h'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 24 hours">Last 24 hours</a>
+      </li>
+      <li>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '7d'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 7 days">Last 7 days</a>
+      </li>
+      <li>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '30d'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 30 days">Last 30 days</a>
+      </li>
+    </ol>
+
+    <form method="get"
+      action="{{ linkTo('admin.organizations.spaces.services.metrics.view', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid}) }}">
+      <input type="hidden" name="_csrf" value="{{ context.csrf }}" />
+
+      <h3 class="govuk-heading-s">Or provide custom date</h3>
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="rangeStart">Start time</label>
+        <input type="datetime-local"
+          id="rangeStart"
+          name="rangeStart"
+          class="govuk-input"
+          value="{{ rangeStart | dateTime }}">
+      </div>
+
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="rangeStop">End time</label>
+        <input type="datetime-local"
+          id="rangeStop"
+          name="rangeStop"
+          class="govuk-input"
+          value="{{ rangeStop | dateTime }}">
+      </div>
+
+      {{ govukButton({text: "Update", preventDoubleClick: true}) }}
+    </form>
+  </details>
+</div>

--- a/src/components/service-metrics/rds-service-metrics.njk
+++ b/src/components/service-metrics/rds-service-metrics.njk
@@ -8,107 +8,113 @@
 {% block insideTabs %}
 
 <div class="border-bottom-box">
-<p>{{ govukTag({text: "experimental"}) }}</p>
+  <p>{{ govukTag({text: "experimental"}) }}</p>
 
-<p>Backing service metrics is a new feature under active development. Expect frequent changes.</p>
-
-<p>Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>
-if you have any feedback.</p>
+  <p class="govuk-body">
+    Backing service metrics is a new feature under active development.
+    Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you have any feedback.
+  </p>
 </div>
 
-<p>
-The graphs below show metrics for the
-<a href="{{ linkTo(
-  'admin.organizations.spaces.services.view',
-  {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid}
-  )}}" class="govuk-link">{{ service.entity.name }}</a>
-service over the last 24 hours.
-</p>
-<p>Currently the available metrics for {{serviceLabel}} are:
-<ul>
-  <li><a href="#free-disk-space" class="govuk-link">Free disk space</a></li>
-  <li><a href="#cpu-utilisation" class="govuk-link">CPU Utilisation</a></li>
-  <li><a href="#database-connections" class="govuk-link">Database Connections</a></li>
-  <li><a href="#freeable-memory" class="govuk-link">Freeable Memory</a></li>
-  <li><a href="#read-iops" class="govuk-link">Read IOPS</a></li>
-  <li><a href="#write-iops" class="govuk-link">Write IOPS</a></li>
-</ul>
-</p>
-<div>
-    <h3 class="govuk-heading-m" id="free-disk-space">
-    Free disk space
-    </h3>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p>Currently the available metrics for {{serviceLabel}} are:</p>
+      <ul class="govuk-list">
+        <li><a href="#free-disk-space" class="govuk-link">Free disk space</a></li>
+        <li><a href="#cpu-utilisation" class="govuk-link">CPU Utilisation</a></li>
+        <li><a href="#database-connections" class="govuk-link">Database Connections</a></li>
+        <li><a href="#freeable-memory" class="govuk-link">Freeable Memory</a></li>
+        <li><a href="#read-iops" class="govuk-link">Read IOPS</a></li>
+        <li><a href="#write-iops" class="govuk-link">Write IOPS</a></li>
+      </ul>
+    </div>
 
-    <p>How much hard disk space your database has remaining. If your database runs out of disk space it will stop working.</p>
-
-    <div>{{metricGraphsById['mFreeStorageSpace'].graph | safe}}</div>
+    <div class="govuk-grid-column-one-third">
+      {% include "./range-picker.njk" %}
+    </div>
+  </div>
 </div>
-<div>
-    <h3 class="govuk-heading-m" id="cpu-utilisation">
-    CPU Utilisation
-    </h3>
 
-    <p>
-    How much computational work your database is doing. High
-    CPU Utilisation may indicate you need to optimise your database queries
-    or <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
-    </p>
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m" id="free-disk-space">
+        Free disk space
+        </h3>
 
-    <div>{{metricGraphsById['mCPUUtilization'].graph | safe}}</div>
-</div>
-<div>
-    <h3 class="govuk-heading-m" id="database-connections">
-    Database Connections
-    </h3>
+        <p>How much hard disk space your database has remaining. If your database runs out of disk space it will stop working.</p>
 
-    <p>
-    How many open connections there are to your database. High values may indicate problems with your applications' connection management, or that you need to
-    <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
-    Zero values may indicate the database is unavailable, or that your applications cannot connect to the database.
-    </p>
+        <div>{{metricGraphsById['mFreeStorageSpace'].graph | safe}}</div>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m" id="cpu-utilisation">
+        CPU Utilisation
+        </h3>
 
-    <div>{{metricGraphsById['mDatabaseConnections'].graph | safe}}</div>
-</div>
-<div>
-    <h3 class="govuk-heading-m" id="freeable-memory">
-    Freeable Memory
-    </h3>
+        <p>
+        How much computational work your database is doing. High
+        CPU Utilisation may indicate you need to optimise your database queries
+        or <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
+        </p>
 
-    <p>
-    How much <abbr title="Random Access Memory">RAM</abbr> the <abbr title="Virtual Machine">VM</abbr> your database is running on has remaining. Values near zero may indicate you need to optimise your database queries or
-    <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
-    </p>
+        <div>{{metricGraphsById['mCPUUtilization'].graph | safe}}</div>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m" id="database-connections">
+        Database Connections
+        </h3>
 
-    <div>{{metricGraphsById['mFreeableMemory'].graph | safe}}</div>
-</div>
-<div>
-    <h3 class="govuk-heading-m" id="read-iops">
-    Read <abbr title="Input / Output Operations per Second">IOPS</abbr>
-    </h3>
+        <p>
+        How many open connections there are to your database. High values may indicate problems with your applications' connection management, or that you need to
+        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
+        Zero values may indicate the database is unavailable, or that your applications cannot connect to the database.
+        </p>
 
-    <p>
-    How many read operations your database is performing per second. Databases are limited to a number of <abbr title="Input / Output Operations per Second">IOPS</abbr>
-    (read + write) based on how big their hard disk is. You get 3 <abbr title="Input / Output Operations per Second">IOPS</abbr> per <abbr title="GibiByte">GiB</abbr>, so a 100 GiB
-    database would be limited to 300 IOPS. If it looks like your database is hitting its IOPS limit you may need to
-    <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
-    </p>
+        <div>{{metricGraphsById['mDatabaseConnections'].graph | safe}}</div>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m" id="freeable-memory">
+        Freeable Memory
+        </h3>
 
-    <div>{{metricGraphsById['mReadIOPS'].graph | safe}}</div>
-</div>
-<div>
-    <h3 class="govuk-heading-m" id="write-iops">
-    Write <abbr title="Input / Output Operations per Second">IOPS</abbr>
-    </h3>
+        <p>
+        How much <abbr title="Random Access Memory">RAM</abbr> the <abbr title="Virtual Machine">VM</abbr> your database is running on has remaining. Values near zero may indicate you need to optimise your database queries or
+        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
+        </p>
 
-    <p>
-    How many write operations your database is performing per second. Databases are limited to a number of <abbr title="Input / Output Operations per Second">IOPS</abbr>
-    (read + write) based on how big their hard disk is. You get 3 <abbr title="Input / Output Operations per Second">IOPS</abbr> per <abbr title="GibiByte">GiB</abbr>, so a 100 GiB
-    database would be limited to 300 IOPS. If it looks like your database is hitting its IOPS limit you may need to
-    <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
-    </p>
+        <div>{{metricGraphsById['mFreeableMemory'].graph | safe}}</div>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m" id="read-iops">
+        Read <abbr title="Input / Output Operations per Second">IOPS</abbr>
+        </h3>
+
+        <p>
+        How many read operations your database is performing per second. Databases are limited to a number of <abbr title="Input / Output Operations per Second">IOPS</abbr>
+        (read + write) based on how big their hard disk is. You get 3 <abbr title="Input / Output Operations per Second">IOPS</abbr> per <abbr title="GibiByte">GiB</abbr>, so a 100 GiB
+        database would be limited to 300 IOPS. If it looks like your database is hitting its IOPS limit you may need to
+        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
+        </p>
+
+        <div>{{metricGraphsById['mReadIOPS'].graph | safe}}</div>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m" id="write-iops">
+        Write <abbr title="Input / Output Operations per Second">IOPS</abbr>
+        </h3>
+
+        <p>
+        How many write operations your database is performing per second. Databases are limited to a number of <abbr title="Input / Output Operations per Second">IOPS</abbr>
+        (read + write) based on how big their hard disk is. You get 3 <abbr title="Input / Output Operations per Second">IOPS</abbr> per <abbr title="GibiByte">GiB</abbr>, so a 100 GiB
+        database would be limited to 300 IOPS. If it looks like your database is hitting its IOPS limit you may need to
+        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
+        </p>
 
 
-    <div>{{metricGraphsById['mWriteIOPS'].graph | safe}}</div>
+        <div>{{metricGraphsById['mWriteIOPS'].graph | safe}}</div>
+    </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -117,4 +117,38 @@ describe('service metrics test suite', () => {
     expect(response.body).not.toContain('Cache hits');
     expect(response.body).toContain('Metrics are not available for this service yet.');
   });
+  it('should redirect if resolver has been accessed', async () => {
+    const response = await resolveServiceMetrics({
+      ...ctx,
+      linkTo: (_name, params) => querystring.stringify(params),
+    }, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      offset: '3h',
+    });
+
+    expect(response.body).not.toBeDefined();
+    expect(response.status).toEqual(302);
+    expect(response.redirect).toContain('rangeStart');
+    expect(response.redirect).toContain('rangeStop');
+  });
+
+  it('should redirect if resolver has been accessed with an invalid offset', async () => {
+    const response = await resolveServiceMetrics({
+      ...ctx,
+      linkTo: (_name, params) => querystring.stringify(params),
+    }, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      offset: '9999999h',
+    });
+
+    expect(response.body).not.toBeDefined();
+    expect(response.status).toEqual(302);
+    expect(response.redirect).toContain('rangeStart');
+    expect(response.redirect).toContain('rangeStop');
+  });
+
 });

--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -1,6 +1,9 @@
 import nock from 'nock';
 
-import {viewServiceMetrics} from '.';
+import {resolveServiceMetrics, viewServiceMetrics} from '.';
+
+import moment from 'moment';
+import querystring from 'querystring';
 
 import { getStubCloudwatchMetricsData } from '../../lib/aws/aws-cloudwatch.test.data';
 import * as data from '../../lib/cf/cf.test.data';
@@ -53,8 +56,116 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(1, 'hour').unix(),
+      rangeStop: moment().unix(),
     });
 
+    expect(response.status).not.toEqual(302);
+    expect(response.body).toContain('name-1508 - Service Metrics');
+  });
+
+  it('should show the service metrics page for past 10 days', async () => {
+    nock('https://aws.example.com/')
+      .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
+        {id: 'mFreeStorageSpace', label: ''},
+        {id: 'mCPUUtilization', label: ''},
+      ]));
+
+    mockService(data.serviceObj);
+
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(10, 'days').unix(),
+      rangeStop: moment().unix(),
+    });
+
+    expect(response.status).not.toEqual(302);
+    expect(response.body).toContain('name-1508 - Service Metrics');
+  });
+
+  it('should show the service metrics page for past 24 hours', async () => {
+    nock('https://aws.example.com/')
+      .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
+        {id: 'mFreeStorageSpace', label: ''},
+        {id: 'mCPUUtilization', label: ''},
+      ]));
+
+    mockService(data.serviceObj);
+
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(24, 'hours').unix(),
+      rangeStop: moment().unix(),
+    });
+
+    expect(response.status).not.toEqual(302);
+    expect(response.body).toContain('name-1508 - Service Metrics');
+  });
+
+  it('should show the service metrics page for past 1 hours 30 minutes', async () => {
+    nock('https://aws.example.com/')
+      .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
+        {id: 'mFreeStorageSpace', label: ''},
+        {id: 'mCPUUtilization', label: ''},
+      ]));
+
+    mockService(data.serviceObj);
+
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(90, 'minutes').unix(),
+      rangeStop: moment().unix(),
+    });
+
+    expect(response.status).not.toEqual(302);
+    expect(response.body).toContain('name-1508 - Service Metrics');
+  });
+
+  it('should show the service metrics page for past half hour', async () => {
+    nock('https://aws.example.com/')
+      .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
+        {id: 'mFreeStorageSpace', label: ''},
+        {id: 'mCPUUtilization', label: ''},
+      ]));
+
+    mockService(data.serviceObj);
+
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(30, 'minutes').unix(),
+      rangeStop: moment().unix(),
+    });
+
+    expect(response.status).not.toEqual(302);
+    expect(response.body).toContain('name-1508 - Service Metrics');
+  });
+
+  it('should show the service metrics page for past 10 minutes', async () => {
+    nock('https://aws.example.com/')
+      .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
+        {id: 'mFreeStorageSpace', label: ''},
+        {id: 'mCPUUtilization', label: ''},
+      ]));
+
+    mockService(data.serviceObj);
+
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(10, 'minutes').unix(),
+      rangeStop: moment().unix(),
+    });
+
+    expect(response.status).not.toEqual(302);
     expect(response.body).toContain('name-1508 - Service Metrics');
   });
 
@@ -76,8 +187,11 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(1, 'hour').unix(),
+      rangeStop: moment().unix(),
     });
 
+    expect(response.status).not.toEqual(302);
     expect(response.body).toContain('Database Connections');
   });
 
@@ -100,8 +214,11 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(1, 'hour').unix(),
+      rangeStop: moment().unix(),
     });
 
+    expect(response.status).not.toEqual(302);
     expect(response.body).toContain('Cache hits');
   });
 
@@ -111,12 +228,32 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: userProvidedServiceGUID,
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(1, 'hour').unix(),
+      rangeStop: moment().unix(),
     });
 
+    expect(response.status).not.toEqual(302);
     expect(response.body).not.toContain('Database Connections');
     expect(response.body).not.toContain('Cache hits');
     expect(response.body).toContain('Metrics are not available for this service yet.');
   });
+
+  it('should redirect if no range provided', async () => {
+    const response = await viewServiceMetrics({
+      ...ctx,
+      linkTo: (_name, params) => querystring.stringify(params),
+    }, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+    });
+
+    expect(response.body).not.toBeDefined();
+    expect(response.status).toEqual(302);
+    expect(response.redirect).toContain('rangeStart');
+    expect(response.redirect).toContain('rangeStop');
+  });
+
   it('should redirect if resolver has been accessed', async () => {
     const response = await resolveServiceMetrics({
       ...ctx,
@@ -151,4 +288,23 @@ describe('service metrics test suite', () => {
     expect(response.redirect).toContain('rangeStop');
   });
 
+  it('should thow an error if rangeStop is sooner than rangeStart', async () => {
+    await expect(viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().unix(),
+      rangeStop: moment().subtract(1, 'hour').unix(),
+    })).rejects.toThrow(/Invalid time range provided/);
+  });
+
+  it('should thow an error if asking for more than a year of metrics', async () => {
+    await expect(viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(1, 'year').subtract(5, 'minutes').unix(),
+      rangeStop: moment().unix(),
+    })).rejects.toThrow('Cannot handle more than a year of metrics');
+  });
 });

--- a/src/components/service-metrics/service-metrics.ts
+++ b/src/components/service-metrics/service-metrics.ts
@@ -12,6 +12,30 @@ import elasticacheServiceMetricsTemplate from './elasticache-service-metrics.njk
 import rdsServiceMetricsTemplate from './rds-service-metrics.njk';
 import unsupportedServiceMetricsTemplate from './unsupported-service-metrics.njk';
 
+export async function resolveServiceMetrics(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const rangeStop = moment();
+  const timeRanges: {[key: string]: moment.Moment} = {
+    '1h': rangeStop.clone().subtract(1, 'hour'),
+    '3h': rangeStop.clone().subtract(3, 'hours'),
+    '12h': rangeStop.clone().subtract(12, 'hours'),
+    '24h': rangeStop.clone().subtract(24, 'hours'),
+    '7d': rangeStop.clone().subtract(7, 'days'),
+    '30d': rangeStop.clone().subtract(30, 'days'),
+  };
+  const rangeStart = timeRanges[params.offset] || timeRanges['24h'];
+
+  return {
+    status: 302,
+    redirect: ctx.linkTo('admin.organizations.spaces.services.metrics.view', {
+      organizationGUID: params.organizationGUID,
+      spaceGUID: params.spaceGUID,
+      serviceGUID: params.serviceGUID,
+      rangeStart: rangeStart.unix(),
+      rangeStop: rangeStop.unix(),
+    }),
+  };
+}
+
 export async function viewServiceMetrics(ctx: IContext, params: IParameters): Promise<IResponse> {
     const cf = new CloudFoundryClient({
         accessToken: ctx.token.accessToken,

--- a/src/components/service-metrics/service-metrics.ts
+++ b/src/components/service-metrics/service-metrics.ts
@@ -8,9 +8,16 @@ import { IContext } from '../app';
 import { CLOUD_CONTROLLER_ADMIN, CLOUD_CONTROLLER_GLOBAL_AUDITOR, CLOUD_CONTROLLER_READ_ONLY_ADMIN } from '../auth';
 import { fromOrg, IBreadcrumb } from '../breadcrumbs';
 import { drawMultipleLineGraphs } from '../charts/line-graph';
+import { UserFriendlyError } from '../errors';
 import elasticacheServiceMetricsTemplate from './elasticache-service-metrics.njk';
 import rdsServiceMetricsTemplate from './rds-service-metrics.njk';
 import unsupportedServiceMetricsTemplate from './unsupported-service-metrics.njk';
+
+interface IRange {
+  readonly period: moment.Duration;
+  readonly rangeStart: moment.Moment;
+  readonly rangeStop: moment.Moment;
+}
 
 export async function resolveServiceMetrics(ctx: IContext, params: IParameters): Promise<IResponse> {
   const rangeStop = moment();
@@ -49,6 +56,22 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
         CLOUD_CONTROLLER_GLOBAL_AUDITOR,
     );
 
+    if (!params.rangeStart || !params.rangeStop) {
+      return {
+        status: 302,
+        redirect: ctx.linkTo(
+          'admin.organizations.spaces.services.metrics.view', {
+            organizationGUID: params.organizationGUID,
+            spaceGUID: params.spaceGUID,
+            serviceGUID: params.serviceGUID,
+            rangeStart: moment().subtract(24, 'hours').unix(),
+            rangeStop: moment().unix(),
+          }),
+      };
+    }
+
+    const {rangeStart, rangeStop, period} = parseRange(params.rangeStart, params.rangeStop);
+
     const [isManager, isBillingManager, userProvidedServices, space, organization] = await Promise.all([
         cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'org_manager'),
         cf.hasOrganizationRole(params.organizationGUID, ctx.token.userID, 'billing_manager'),
@@ -84,16 +107,12 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
       }),
     );
 
-    const period = moment.duration(5, 'minutes');
-    const endTime = roundDown(moment(), period);
-    const startTime = endTime.clone().subtract(1, 'day');
-
     const metricGraphData = await cloudWatchMetricDataClient.getMetricGraphData(
       service.metadata.guid,
       serviceLabel,
       period,
-      startTime,
-      endTime,
+      rangeStart,
+      rangeStop,
     );
 
     const defaultTemplateParams = {
@@ -108,6 +127,9 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
         isBillingManager,
         isManager,
         breadcrumbs,
+        period,
+        rangeStart,
+        rangeStop,
     };
     if (!metricGraphData) {
       return {
@@ -135,4 +157,35 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
       default:
         throw new Error(`Unrecognised service type ${metricGraphData.serviceType}`);
     }
+}
+
+function parseRange(start: string, stop: string): IRange {
+  const rangeStart = moment.unix(parseInt(start, 10));
+  const rangeStop = moment.unix(parseInt(stop, 10));
+  const secondsDifference = rangeStop.diff(rangeStart) / 1000;
+  let period;
+
+  if (rangeStop.isBefore(rangeStart)) {
+    throw new UserFriendlyError('Invalid time range provided');
+  }
+
+  if (secondsDifference <= 900) { // If less than 15 minutes
+    period = moment.duration(3, 'seconds');
+  } else if (secondsDifference <= 3600) { // If less than an hour
+    period = moment.duration(10, 'seconds');
+  } else if (secondsDifference <= 7200) { // If less than 2 hours
+    period = moment.duration(30, 'seconds');
+  } else if (secondsDifference <= 90000) { // If less than 25 hours
+    period = moment.duration(5, 'minutes');
+  } else if (secondsDifference <= 1080000) { // If less than 300 hours
+    period = moment.duration(1, 'hour');
+  } else {
+    period = moment.duration(1, 'day');
+  }
+
+  if (rangeStart.isBefore(rangeStop.clone().subtract(1, 'year'))) {
+    throw new UserFriendlyError('Invalid time range provided. Cannot handle more than a year of metrics');
+  }
+
+  return { period, rangeStart: roundDown(rangeStart, period), rangeStop: roundDown(rangeStop, period) };
 }

--- a/src/layouts/_elements.scss
+++ b/src/layouts/_elements.scss
@@ -8,3 +8,14 @@ code {
   -ms-word-break: break-all;
   word-break: break-all;
 }
+
+
+ul, ol {
+  &.single-line li {
+    display: inline;
+  }
+}
+
+.non-breaking {
+  white-space: nowrap;
+}


### PR DESCRIPTION
What
----

We'd like to allow users to pick from a range of times latest to their
relative local time. For instance:

Last 1h, Last 3h, Last 24h, Last week, Last month

In order to assure this is indeed picking a range `NOW` - `OFFSET` at
all times, and not hack around with html/forms to inject ranges into the
system, we can have an additional endpoint that will be generating the
ranges for us and redirect back to the view with the set of ranges.

This for instance could have been a problem, if user has a stale view of
the page, say not refreshed for a day, and then they'd pick an offset
such as 15m. The pre-baked range would mean they're looking at 15m slot
one day ago.

This _should_ also solve the problem, of the server being too slow, and
the user manages to choose an offset and immediately attempt to update
the form with submit button.

We'd like to allow our users to choose specific range for their
representation of metrics, to help them better visualise what's going on
on our platform.

This is a rough design and should be revisited, hopefully with a
designer.

We're also reducing the size of the charts themselves, to perhaps clean
up a little visually and leave us with some room with potential
improvements to the charts themselves, for instance a tooltip on a side.

How to review
-------------

- Code review
- Sanity check
- `npm run push` and have a play around
- **Validate if the period calculation is good enough...**

### Validate if the period calculation is good enough...

I really don't like the way I solved it... I think I'd like to do something along the lines of:

```diff
diff --git a/src/components/service-metrics/service-metrics.ts b/src/components/service-metrics/service-metrics.ts
index de13960..21849a5 100644
--- a/src/components/service-metrics/service-metrics.ts
+++ b/src/components/service-metrics/service-metrics.ts
@@ -159,23 +159,16 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
 }
 
 function parseRange(start: string, stop: string): IRange {
+  const numberOfPoints = 300;
   const rangeStart = moment.unix(parseInt(start, 10));
   const rangeStop = moment.unix(parseInt(stop, 10));
   const secondsDifference = rangeStop.diff(rangeStart) / 1000;
-  let period;
+  const period = moment.duration(Math.floor(secondsDifference / numberOfPoints), 'seconds');
 
   if (rangeStop.isBefore(rangeStart)) {
     throw new UserFriendlyError('Invalid time range provided');
   }
 
-  if (secondsDifference < 90000) { // If less than 25 hours
-    period = moment.duration(5, 'minutes');
-  } else if (secondsDifference < 1080000) { // If less than 300 hours
-    period = moment.duration(1, 'hour');
-  } else {
-    period = moment.duration(1, 'day');
-  }
-
   if (rangeStart.isBefore(rangeStop.clone().subtract(1, 'year'))) {
     throw new UserFriendlyError('Invalid time range provided. Cannot handle more than a year of metrics');
   }
```

but would love to hear @richardTowers opinions on the matter... surely some edge cases would blow up? 🤔 

## Before

![Screenshot 2019-11-22 at 11 09 23](https://user-images.githubusercontent.com/2418945/69421313-a5303e80-0d18-11ea-980a-5e976d9b3f7c.png)

## After

![Screenshot 2019-11-22 at 11 08 08](https://user-images.githubusercontent.com/2418945/69421344-b24d2d80-0d18-11ea-8d8b-8626eb7e7c1c.png)
---
![Screenshot 2019-11-22 at 11 08 13](https://user-images.githubusercontent.com/2418945/69421345-b24d2d80-0d18-11ea-95bf-daa404b291eb.png)
