### PR TITLE
Add a platform admin page

### DIFF
--- a/src/components/app/app.test-helpers.ts
+++ b/src/components/app/app.test-helpers.ts
@@ -27,7 +27,7 @@ export function createTestContext(ctx?: {}): IContext {
   return _.cloneDeep({
     app: config,
     routePartOf: () => false,
-    linkTo: () => '__LINKED_TO__',
+    linkTo: (route) => `__LINKED_TO__${route}`,
     absoluteLinkTo: () => '__ABSOLUTE_LINKED_TO__',
     log: pino({level: 'silent'}),
     token: new Token(
@@ -41,6 +41,7 @@ export function createTestContext(ctx?: {}): IContext {
     viewContext: {
       csrf: '',
       location: config.location,
+      isPlatformAdmin: false,
     },
     session: new FakeSession(),
     ...ctx,

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -132,6 +132,15 @@ describe('app test suite', () => {
     expect(response.status).toEqual(500);
   });
 
+  it('should return a 403 when accessing /forbidden', async () => {
+    // In practice this endpoint is only used for testing the 403 middleware
+
+    const app = init(config);
+    const response = await request(app).get('/forbidden');
+
+    expect(response.status).toEqual(403);
+  });
+
   describe('when authenticated as a normal user', () => {
     let response: request.Response;
     let agent: SuperTest<Test>;

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -15,6 +15,8 @@ import {wrapResources} from '../../lib/cf/test-data/wrap-resources';
 import Router, { IParameters } from '../../lib/router';
 import * as uaaData from '../../lib/uaa/uaa.test.data';
 
+import {CLOUD_CONTROLLER_ADMIN} from '../auth';
+
 import init from './app';
 import csp from './app.csp';
 import { config } from './app.test.config';
@@ -347,7 +349,7 @@ describe('app test suite', () => {
     const time = Math.floor(Date.now() / 1000);
     const token = jwt.sign({
       user_id: 'uaa-user-123',
-      scope: ['cloud_controller.admin'],
+      scope: [CLOUD_CONTROLLER_ADMIN],
       exp: (time + (24 * 60 * 60)),
       origin: 'uaa',
     }, tokenKey);
@@ -360,7 +362,7 @@ describe('app test suite', () => {
           token_type: 'bearer',
           refresh_token: '__refresh_token__',
           expires_in: (24 * 60 * 60),
-          scope: 'openid oauth.approvals cloud_controller.admin',
+          scope: `openid oauth.approvals ${CLOUD_CONTROLLER_ADMIN}`,
           jti: '__jti__',
         })
       ;

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -8,7 +8,7 @@ import helmet from 'helmet';
 import { IncomingMessage, ServerResponse } from 'http';
 import { BaseLogger } from 'pino';
 
-import { IResponse } from '../../lib/router';
+import { IResponse, NotAuthorisedError } from '../../lib/router';
 import auth from '../auth';
 import { internalServerErrorMiddleware } from '../errors';
 import { termsCheckerMiddleware } from '../terms';
@@ -89,6 +89,10 @@ export default function(config: IAppConfig) {
   app.use(csrf());
 
   app.get('/healthcheck', (_req: express.Request, res: express.Response) => res.send({message: 'OK'}));
+
+  app.get('/forbidden', () => {
+    throw new NotAuthorisedError('Forbidden');
+  });
 
   app.get('/calculator', (req: express.Request, res: express.Response, next: express.NextFunction) => {
     const route = router.findByName('admin.home');

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -10,7 +10,7 @@ import { BaseLogger } from 'pino';
 
 import { IResponse } from '../../lib/router';
 import auth from '../auth';
-import { internalServerErrorMiddleware, pageNotFoundMiddleware } from '../errors';
+import { internalServerErrorMiddleware } from '../errors';
 import { termsCheckerMiddleware } from '../terms';
 
 import { getCalculator } from '../calculator';
@@ -119,7 +119,6 @@ export default function(config: IAppConfig) {
 
   app.use(routerMiddleware(router, config));
 
-  app.use(pageNotFoundMiddleware);
   app.use(internalServerErrorMiddleware);
 
   return app;

--- a/src/components/app/context.ts
+++ b/src/components/app/context.ts
@@ -13,6 +13,7 @@ export interface IViewContext {
   readonly csrf: string;
   readonly location: string;
   readonly origin?: string;
+  readonly isPlatformAdmin: boolean;
 }
 
 export interface IContext {
@@ -28,6 +29,7 @@ export interface IContext {
 
 export function initContext(req: any, router: Router, route: Route, config: IAppConfig): IContext {
   const origin = req.token && req.token.origin;
+  const isPlatformAdmin = req.token && req.token.hasAdminScopes && req.token.hasAdminScopes();
 
   return {
     app: config,
@@ -43,7 +45,7 @@ export function initContext(req: any, router: Router, route: Route, config: IApp
     viewContext: {
       location: config.location,
       csrf: req.csrfToken(),
-      origin,
+      origin, isPlatformAdmin,
     },
     session: req.session,
   };

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -5,6 +5,7 @@ import * as applicationEvents from '../application-events';
 import * as applications from '../applications';
 import * as orgUsers from '../org-users';
 import * as organizations from '../organizations';
+import * as platformAdmin from '../platform-admin';
 import * as reports from '../reports';
 import * as serviceEvents from '../service-events';
 import * as serviceMetrics from '../service-metrics';
@@ -207,6 +208,17 @@ const router = new Router([
     action: users.getUser,
     name: 'users.get',
     path: '/users/:emailOrUserGUID',
+  },
+  {
+    action: platformAdmin.viewHomepage,
+    name: 'platform-admin.homepage',
+    path: '/platform-admin',
+  },
+  {
+    action: platformAdmin.redirectToPage,
+    method: 'post',
+    name: 'platform-admin.redirect',
+    path: '/platform-admin',
   },
 ]);
 

--- a/src/components/auth/has-role.ts
+++ b/src/components/auth/has-role.ts
@@ -39,6 +39,14 @@ export class Token {
 
     return false;
   }
+
+  public hasAdminScopes(): boolean {
+    return this.hasAnyScope(
+      CLOUD_CONTROLLER_ADMIN,
+      CLOUD_CONTROLLER_GLOBAL_AUDITOR,
+      CLOUD_CONTROLLER_READ_ONLY_ADMIN,
+    );
+  }
 }
 
 function verify(accessToken: string, signingKeys: ReadonlyArray<string>): IToken {

--- a/src/components/errors/error.403.njk
+++ b/src/components/errors/error.403.njk
@@ -1,0 +1,13 @@
+{% extends "../../layouts/govuk.njk" %}
+
+{% block pageTitle %}
+  Page not authorised
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+
+  <h1 class="govuk-heading-xl">Page not authorised</h1>
+  <p class="govuk-body">If you entered a web address please check it was correct.</p>
+  <p>You can browse from the <a href="/">homepage</a> to find the information you need.</p>
+{% endblock %}

--- a/src/components/errors/error.ts
+++ b/src/components/errors/error.ts
@@ -2,6 +2,7 @@ import express from 'express';
 
 import { NotAuthorisedError, NotFoundError } from '../../lib/router';
 
+import pageNotAuthorised from './error.403.njk';
 import pageNotFound from './error.404.njk';
 import internalServerError from './error.500.njk';
 
@@ -65,10 +66,11 @@ export function pageNotFoundMiddleware(req: any, res: express.Response, _next: e
 
 export function pageNotAuthorisedMiddleware(req: any, res: express.Response, _next: express.NextFunction) {
   res.status(403);
-  res.send(pageNotFound.render(userHostileError(req)));
+  res.send(pageNotAuthorised.render(userHostileError(req)));
 }
 
 export default {
   internalServerErrorMiddleware,
   pageNotFoundMiddleware,
+  pageNotAuthorisedMiddleware,
 };

--- a/src/components/platform-admin/homepage-costs.njk
+++ b/src/components/platform-admin/homepage-costs.njk
@@ -1,0 +1,80 @@
+<h2 class="govuk-heading-m">Costs</h2>
+
+<h3 class="govuk-heading-s">View costs for a month</h3>
+
+<form action="{{ linkTo('platform-admin.redirect') }}" method="POST">
+  <input type="hidden" name="_csrf" value="{{ context.csrf }}" />
+
+  <input type="hidden" name="action" value="view-costs" />
+
+  <div class="govuk-form-group">
+    <div class="govuk-date-input" id="passport-issued">
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label"
+                 for="view-costs-month">
+            Month
+          </label>
+         <select class="govuk-select"
+                 id="view-costs-month"
+                 name="month">
+            <option value="01">January</option>
+            <option value="02">February</option>
+            <option value="03">March</option>
+            <option value="04">April</option>
+            <option value="05">May</option>
+            <option value="06">June</option>
+            <option value="07">July</option>
+            <option value="08">August</option>
+            <option value="09">September</option>
+            <option value="10">October</option>
+            <option value="11">November</option>
+            <option value="12">December</option>
+          </select>
+        </div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label"
+                 for="view-costs-year">
+            Year
+          </label>
+          <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                 id="view-costs-year"
+                 name="year"
+                 type="number"
+                 pattern="20[123][0-9]">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-form-group">
+    <label class="govuk-label govuk-date-input__label">Format</label>
+    <div class="govuk-radios govuk-radios--small">
+      {% for label, val in [
+        [ "Overall costs",                    "cost" ],
+        [ "Costs by service",                 "costbyservice" ],
+        [ "Spend for PMO team in CSV format", "pmo-org-spend-csv" ],
+        [ "Sankey diagram",                   "visualisation" ]
+      ] %}
+        <div class="govuk-radios__item">
+
+          <input class="govuk-radios__input"
+                 id="view-costs-format-{{val}}"
+                 name="format" type="radio"
+                 {% if loop.first %}checked{% endif %}
+                 value="{{ val }}">
+
+          <label class="govuk-label govuk-radios__label"
+                 for="view-costs-format-{{val}}">
+            {{ label }}
+          </label>
+
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  <button class="govuk-button">View costs</button>
+</form>

--- a/src/components/platform-admin/homepage-orgs.njk
+++ b/src/components/platform-admin/homepage-orgs.njk
@@ -1,0 +1,10 @@
+<h2 class="govuk-heading-m">
+  Organisation management
+</h2>
+
+<p class="govuk-body">
+  <a class="govuk-link"
+     href="{{ linkTo('admin.reports.organizations') }}">
+    View trial and billable organisations
+  </a>
+</p>

--- a/src/components/platform-admin/homepage-users.njk
+++ b/src/components/platform-admin/homepage-users.njk
@@ -1,0 +1,24 @@
+<h2 class="govuk-heading-m">User management</h2>
+
+<h3 class="govuk-heading-s">Find a user</h3>
+
+<form action="{{ linkTo('platform-admin.redirect') }}" method="POST">
+  <input type="hidden" name="_csrf" value="{{ context.csrf }}" />
+
+  <input type="hidden" name="action" value="find-user" />
+
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="find-user-email-or-user-guid">
+      Email address or GUID
+    </label>
+
+    <input class="govuk-input"
+           id="find-user-email-or-user-guid"
+           name="email-or-user-guid"
+           type="text"/>
+  </div>
+
+  <button class="govuk-button">
+    Find user
+  </button>
+</form>

--- a/src/components/platform-admin/homepage.njk
+++ b/src/components/platform-admin/homepage.njk
@@ -1,0 +1,26 @@
+{% extends "../../layouts/govuk.njk" %}
+
+{% block pageTitle %}
+  Statement
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+
+  <h1 class="govuk-heading-l">
+    Platform Admin
+  </h1>
+
+  <div class="govuk-grid-row govuk-grid-row-vertically-separated">
+    <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
+      {% include "./homepage-costs.njk" %}
+    </div>
+    <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
+      {% include "./homepage-users.njk" %}
+    </div>
+    <div class="govuk-grid-column-full govuk-grid-column-one-third-from-desktop">
+      {% include "./homepage-orgs.njk" %}
+    </div>
+  </div>
+
+{% endblock %}

--- a/src/components/platform-admin/homepage.test.ts
+++ b/src/components/platform-admin/homepage.test.ts
@@ -1,0 +1,88 @@
+import jwt from 'jsonwebtoken';
+
+import {IResponse} from '../../lib/router';
+
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
+import {CLOUD_CONTROLLER_ADMIN} from '../auth/has-role';
+
+import {
+  Token,
+} from '../auth';
+
+import { viewHomepage } from './homepage';
+
+const tokenKey = 'secret';
+
+describe('homepage', () => {
+  describe('when not a platform admin', () => {
+
+    const time = Math.floor(Date.now() / 1000);
+    const rawToken = {
+      user_id: 'uaa-id-253',
+      scope: [],
+      exp: (time + (24 * 60 * 60)),
+      origin: 'uaa',
+    };
+    const accessToken = jwt.sign(rawToken, tokenKey);
+
+    const token = new Token(accessToken, [tokenKey]);
+    const ctx: IContext = createTestContext({ token });
+
+    it('should return an error', async () => {
+      await expect(
+        viewHomepage(ctx, {}),
+      ).rejects.toThrow(/Not a platform admin/);
+    });
+  });
+
+  describe('when a platform admin', () => {
+
+    const time = Math.floor(Date.now() / 1000);
+    const rawToken = {
+      user_id: 'uaa-id-253',
+      scope: [CLOUD_CONTROLLER_ADMIN],
+      exp: (time + (24 * 60 * 60)),
+      origin: 'uaa',
+    };
+    const accessToken = jwt.sign(rawToken, tokenKey);
+
+    const token = new Token(accessToken, [tokenKey]);
+    const ctx: IContext = createTestContext({ token });
+
+    let response: IResponse;
+
+    beforeEach(async () => {
+      response = await viewHomepage(ctx, {});
+    });
+
+    it('should show the homepage with useful headings', async () => {
+      expect(response.body).toMatch(/Platform Admin/);
+      expect(response.body).toMatch(/Costs/);
+      expect(response.body).toMatch(/Organisation management/);
+      expect(response.body).toMatch(/User management/);
+    });
+
+    it('should show a link to the org report', async () => {
+      expect(response.body).toMatch(/Organisation management/);
+      expect(response.body).toMatch(/View trial and billable organisations/);
+    });
+
+    it('should show a form to lookup a user', async () => {
+      expect(response.body).toMatch(/User management/);
+      expect(response.body).toMatch(/Find a user/);
+      expect(response.body).toMatch(/<button[^<]*Find user\s+<\/button>/m);
+    });
+
+    it('should show a form to show costs', async () => {
+      expect(response.body).toMatch(/Costs/);
+      expect(response.body).toMatch(/View costs for a month/);
+      expect(response.body).toMatch(/January/);
+      expect(response.body).toMatch(/December/);
+      expect(response.body).toMatch(/Overall costs/);
+      expect(response.body).toMatch(/Costs by service/);
+      expect(response.body).toMatch(/Spend for PMO team/);
+      expect(response.body).toMatch(/Sankey/);
+    });
+  });
+});

--- a/src/components/platform-admin/homepage.ts
+++ b/src/components/platform-admin/homepage.ts
@@ -1,0 +1,27 @@
+import {
+  IParameters,
+  IResponse,
+  NotAuthorisedError,
+} from '../../lib/router';
+
+import { IContext } from '../app/context';
+
+import homepageTemplate from './homepage.njk';
+
+export async function viewHomepage(
+  ctx: IContext,
+  _params: IParameters,
+): Promise<IResponse> {
+  const token = ctx.token;
+
+  if (!token.hasAdminScopes()) {
+    throw new NotAuthorisedError('Not a platform admin');
+  }
+
+  return {
+    body: homepageTemplate.render({
+      linkTo: ctx.linkTo,
+      context: ctx.viewContext,
+    }),
+  };
+}

--- a/src/components/platform-admin/index.ts
+++ b/src/components/platform-admin/index.ts
@@ -1,0 +1,2 @@
+export * from './homepage';
+export * from './redirect';

--- a/src/components/platform-admin/redirect.test.ts
+++ b/src/components/platform-admin/redirect.test.ts
@@ -1,0 +1,139 @@
+import jwt from 'jsonwebtoken';
+
+import {createTestContext} from '../app/app.test-helpers';
+import {IContext} from '../app/context';
+import {CLOUD_CONTROLLER_ADMIN} from '../auth/has-role';
+
+import {
+  Token,
+} from '../auth';
+
+import { redirectToPage } from './redirect';
+
+const tokenKey = 'secret';
+
+describe('redrect', () => {
+  describe('when not a platform admin', () => {
+
+    const time = Math.floor(Date.now() / 1000);
+    const rawToken = {
+      user_id: 'uaa-id-253',
+      scope: [],
+      exp: (time + (24 * 60 * 60)),
+      origin: 'uaa',
+    };
+    const accessToken = jwt.sign(rawToken, tokenKey);
+
+    const token = new Token(accessToken, [tokenKey]);
+    const ctx: IContext = createTestContext({ token });
+
+    it('should return an error', async () => {
+      await expect(
+        redirectToPage(ctx, {}, {}),
+      ).rejects.toThrow(/not a platform admin/);
+    });
+  });
+
+  describe('when a platform admin', () => {
+
+    const time = Math.floor(Date.now() / 1000);
+    const rawToken = {
+      user_id: 'uaa-id-253',
+      scope: [CLOUD_CONTROLLER_ADMIN],
+      exp: (time + (24 * 60 * 60)),
+      origin: 'uaa',
+    };
+    const accessToken = jwt.sign(rawToken, tokenKey);
+
+    const token = new Token(accessToken, [tokenKey]);
+    const ctx: IContext = createTestContext({ token });
+
+    describe('when the action is not present', () => {
+      it('should throw an error', async () => {
+        await expect(
+          redirectToPage(ctx, {}, {}),
+        ).rejects.toThrow(/Action not present/);
+      });
+    });
+
+    describe('when the action is unknown', () => {
+      it('should throw an error', async () => {
+        await expect(
+          redirectToPage(ctx, {}, { action: 'this-action-is-not-supported' }),
+        ).rejects.toThrow(/Unknown action: this-action-is-not-supported/);
+      });
+    });
+
+    describe('when the action is find-user', () => {
+      [undefined, ''].map(emailOrUserGUID => {
+        it(`should throw an error if email-or-user-guid is ${emailOrUserGUID}`, async () => {
+          await expect(
+            redirectToPage(ctx, {}, {
+              'action': 'find-user',
+              'email-or-user-guid': emailOrUserGUID,
+            }),
+          ).rejects.toThrow(/Field email-or-user-guid is undefined or blank/);
+        });
+      });
+
+      it(`should redirect to the users page`, async () => {
+        const response = await redirectToPage(ctx, {}, {
+          'action': 'find-user',
+          'email-or-user-guid': 'user@domain.com',
+        });
+
+        expect(response.redirect).toEqual(`__LINKED_TO__users.get`);
+      });
+    });
+
+    describe('when the action is view-costs', () => {
+      [undefined, ''].map((month) => {
+        it(`should throw an error if month is ${month}`, async () => {
+          await expect(
+            redirectToPage(ctx, {}, {
+              action: 'view-costs', month, year:   '2019', format: 'cost',
+            }),
+          ).rejects.toThrow(/Field month is undefined or blank/);
+        });
+      });
+
+      [undefined, ''].map((year) => {
+        it(`should throw an error if year is ${year}`, async () => {
+          await expect(
+            redirectToPage(ctx, {}, {
+              action: 'view-costs', month: '01', year, format: 'cost',
+            }),
+          ).rejects.toThrow(/Field year is undefined or blank/);
+        });
+      });
+
+      [undefined, ''].map((format) => {
+        it(`should throw an error if format is ${format}`, async () => {
+          await expect(
+            redirectToPage(ctx, {}, {
+              action: 'view-costs', month: '01', year: '2019', format,
+            }),
+          ).rejects.toThrow(/Field format is undefined or blank/);
+        });
+      });
+
+      it('should throw an error if range start is incorrect', async () => {
+        await expect(
+          redirectToPage(ctx, {}, {
+            action: 'view-costs', month: 'blah', year: 'blah', format: 'cost',
+          }),
+        ).rejects.toThrow(/Constructed date is invalid, should be YYYY-MM-DD: blah-blah-01/);
+      });
+
+      ['cost', 'cost-by-service', 'pmo-org-spend-csv', 'visualisation'].forEach((format) => {
+        it(`should redirect to the ${format} report`, async () => {
+          const response = await redirectToPage(ctx, {}, {
+            action: 'view-costs', month:  '06', year: '2019', format,
+          });
+
+          expect(response.redirect).toEqual(`__LINKED_TO__admin.reports.${format}`);
+        });
+      });
+    });
+  });
+});

--- a/src/components/platform-admin/redirect.ts
+++ b/src/components/platform-admin/redirect.ts
@@ -1,0 +1,83 @@
+import {
+  IParameters,
+  IResponse,
+  NotAuthorisedError,
+} from '../../lib/router';
+
+import { IContext } from '../app/context';
+
+export async function redirectToPage(
+  ctx: IContext,
+  params: IParameters,
+  body: any,
+): Promise<IResponse> {
+  const token = ctx.token;
+
+  if (!token.hasAdminScopes()) {
+    throw new NotAuthorisedError('not a platform admin');
+  }
+
+  const action = body.action;
+
+  if (typeof action === 'undefined') {
+    throw new Error('Action not present');
+  }
+
+  if (action === 'find-user') {
+    return findUser(ctx, params, body);
+  }
+
+  if (action === 'view-costs') {
+    return viewCosts(ctx, params, body);
+  }
+
+  throw new Error(`Unknown action: ${action}`);
+}
+
+async function findUser(
+  ctx: IContext,
+  _params: IParameters,
+  body: any,
+): Promise<IResponse> {
+  const emailOrUserGUID = body['email-or-user-guid'];
+
+  if (typeof emailOrUserGUID === 'undefined' || emailOrUserGUID === '') {
+    throw new Error('Field email-or-user-guid is undefined or blank');
+  }
+
+  return {
+    redirect: ctx.linkTo('users.get', { emailOrUserGUID }),
+  };
+}
+
+async function viewCosts(
+  ctx: IContext,
+  _params: IParameters,
+  body: any,
+): Promise<IResponse> {
+  const month  = body.month;
+  const year   = body.year;
+  const format = body.format;
+
+  if (typeof month === 'undefined' || month === '') {
+    throw new Error('Field month is undefined or blank');
+  }
+
+  if (typeof year === 'undefined' || year === '') {
+    throw new Error('Field year is undefined or blank');
+  }
+
+  if (typeof format === 'undefined' || format === '') {
+    throw new Error('Field format is undefined or blank');
+  }
+
+  const rangeStart = `${year}-${month}-01`;
+
+  if (!rangeStart.match(/[20][123][0-9]-[01][0-9]-01/)) {
+    throw new Error(`Constructed date is invalid, should be YYYY-MM-DD: ${rangeStart}`);
+  }
+
+  return {
+    redirect: ctx.linkTo(`admin.reports.${format}`, {rangeStart}),
+  };
+}

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -76,7 +76,7 @@
           </li>
           {% if context.isPlatformAdmin %}
           <li class="govuk-header__navigation-item">
-            <a class="govuk-header__link" href="#">
+            <a class="govuk-header__link" href="/platform-admin">
               Platform admin
             </a>
           </li>

--- a/src/layouts/govuk.njk
+++ b/src/layouts/govuk.njk
@@ -74,6 +74,13 @@
               Documentation
             </a>
           </li>
+          {% if context.isPlatformAdmin %}
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Platform admin
+            </a>
+          </li>
+          {% endif %}
           <li class="govuk-header__navigation-item">
             <a class="govuk-header__link" href="/auth/logout">
               Sign out

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -64,3 +64,9 @@ abbr {
   word-break: break-word;
   white-space: pre-wrap;
 }
+
+.govuk-grid-row.govuk-grid-row-vertically-separated {
+  > *+* {
+    border-left: 1px solid $govuk-border-colour;
+  }
+}

--- a/src/lib/router/errors.ts
+++ b/src/lib/router/errors.ts
@@ -1,6 +1,15 @@
+// tslint:disable:max-classes-per-file
+
 export class NotFoundError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'NotFoundError';
+  }
+}
+
+export class NotAuthorisedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotAuthorisedError';
   }
 }


### PR DESCRIPTION
What
----

A picture is worth a thousand lines of code:

![image](https://user-images.githubusercontent.com/1482692/69447599-c14ed280-0d4e-11ea-9303-9ffe0111d40e.png)

_An image of the platform admin page_

Platform admin is an abstraction borrowed from Notify, that I have repurposed to represent global auditors, admins, and read-only admins.

This PR adds a platform admin page to help us find all the secret features that platform admins have, this will be especially useful given that we have global auditors for engagement and PMO teams.

During this I also added a 'not authorised' middleware so we can stop returning 404s everywhere

How to review
-------------

- [x] Code review

- [x] Look at the tests / linter

- [x] Deploy to your dev environment

- [x] Attempt to use the feature, as a non-platform admin

Who can review
---------------

Not @tlwr