### PR TITLE
Events pagination QoL and platform admin QoL

### DIFF
--- a/src/components/application-events/application-events.njk
+++ b/src/components/application-events/application-events.njk
@@ -5,35 +5,40 @@
 {% endblock %}
 
 {% block insideTabs %}
+
+  {% set pagination_controls %}
+    {% if pagination.total_pages > 1 %}
+        <p class="govuk-body">
+        {% if page <= 1 %}
+          <a class="govuk-link" disabled>Previous page</a>
+        {% else %}
+          <a class="govuk-link" href="{{
+            linkTo(
+              'admin.organizations.spaces.applications.events.view',
+              {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, applicationGUID: application.metadata.guid, page: page-1}
+            ) }}">Previous page</a>
+        {% endif %}
+
+        {% if pagination.next %}
+          <a class="govuk-link" href="{{
+            linkTo(
+              'admin.organizations.spaces.applications.events.view',
+              {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, applicationGUID: application.metadata.guid, page: page+1}
+            ) }}">Next page</a>
+        {% else %}
+          <a class="govuk-link" disabled>Next page</a>
+        {% endif %}
+      </p>
+    {% endif %}
+  {% endset %}
+
   {% include "../events/totals.njk" %}
 
   {% include "../events/details.njk" %}
 
-  <p class="govuk-body">
-    {% if pagination.total_pages > 1 %}
-      {% if page <= 1 %}
-        <a class="govuk-link" disabled>Previous page</a>
-      {% else %}
-        <a class="govuk-link" href="{{
-          linkTo(
-            'admin.organizations.spaces.applications.events.view',
-            {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, applicationGUID: application.metadata.guid, page: page-1}
-          ) }}">Previous page</a>
-      {% endif %}
-
-      {% if pagination.next %}
-        <a class="govuk-link" href="{{
-          linkTo(
-            'admin.organizations.spaces.applications.events.view',
-            {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, applicationGUID: application.metadata.guid, page: page+1}
-          ) }}">Next page</a>
-      {% else %}
-        <a class="govuk-link" disabled>Next page</a>
-      {% endif %}
-    {% endif %}
-  </p>
-
   {% if events.length > 0 %}
+    {{ pagination_controls | safe }}
+
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -80,6 +85,8 @@
       {% endfor %}
       </tbody>
     </table>
+
+    {{ pagination_controls | safe }}
   {% endif %}
 
 {% endblock %}

--- a/src/components/platform-admin/homepage-costs.njk
+++ b/src/components/platform-admin/homepage-costs.njk
@@ -43,7 +43,8 @@
                  id="view-costs-year"
                  name="year"
                  type="number"
-                 pattern="20[123][0-9]">
+                 value="{{ thisYear }}"
+                 pattern="20[123][0-9]"/>
         </div>
       </div>
     </div>

--- a/src/components/platform-admin/homepage.ts
+++ b/src/components/platform-admin/homepage.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import {
   IParameters,
   IResponse,
@@ -18,10 +20,13 @@ export async function viewHomepage(
     throw new NotAuthorisedError('Not a platform admin');
   }
 
+  const thisYear = moment().format('YYYY');
+
   return {
     body: homepageTemplate.render({
       linkTo: ctx.linkTo,
       context: ctx.viewContext,
+      thisYear,
     }),
   };
 }

--- a/src/components/service-events/service-events.njk
+++ b/src/components/service-events/service-events.njk
@@ -5,35 +5,40 @@
 {% endblock %}
 
 {% block insideTabs %}
+
+  {% set pagination_controls %}
+    {% if pagination.total_pages > 1 %}
+      <p class="govuk-body">
+        {% if page <= 1 %}
+          <a class="govuk-link" disabled>Previous page</a>
+        {% else %}
+          <a class="govuk-link" href="{{
+            linkTo(
+              'admin.organizations.spaces.services.events.view',
+              {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, page: page-1}
+            ) }}">Previous page</a>
+        {% endif %}
+
+        {% if pagination.next %}
+          <a class="govuk-link" href="{{
+            linkTo(
+              'admin.organizations.spaces.services.events.view',
+              {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, page: page+1}
+            ) }}">Next page</a>
+        {% else %}
+          <a class="govuk-link" disabled>Next page</a>
+        {% endif %}
+      </p>
+    {% endif %}
+  {% endset %}
+
   {% include "../events/totals.njk" %}
 
   {% include "../events/details.njk" %}
 
-  <p class="govuk-body">
-    {% if pagination.total_pages > 1 %}
-      {% if page <= 1 %}
-        <a class="govuk-link" disabled>Previous page</a>
-      {% else %}
-        <a class="govuk-link" href="{{
-          linkTo(
-            'admin.organizations.spaces.services.events.view',
-            {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, page: page-1}
-          ) }}">Previous page</a>
-      {% endif %}
-
-      {% if pagination.next %}
-        <a class="govuk-link" href="{{
-          linkTo(
-            'admin.organizations.spaces.services.events.view',
-            {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, page: page+1}
-          ) }}">Next page</a>
-      {% else %}
-        <a class="govuk-link" disabled>Next page</a>
-      {% endif %}
-    {% endif %}
-  </p>
-
   {% if events.length > 0 %}
+    {{ pagination_controls | safe }}
+
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -80,6 +85,8 @@
       {% endfor %}
       </tbody>
     </table>
+
+    {{ pagination_controls | safe }}
   {% endif %}
 
 {% endblock %}

--- a/src/components/spaces/events.njk
+++ b/src/components/spaces/events.njk
@@ -5,35 +5,40 @@
 {% endblock %}
 
 {% block insideTabs %}
+
+  {% set pagination_controls %}
+    {% if pagination.total_pages > 1 %}
+      <p class="govuk-body">
+        {% if page <= 1 %}
+          <a class="govuk-link" disabled>Previous page</a>
+        {% else %}
+          <a class="govuk-link" href="{{
+            linkTo(
+              'admin.organizations.spaces.events.view',
+              {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, page: page-1}
+            ) }}">Previous page</a>
+        {% endif %}
+
+        {% if pagination.next %}
+          <a class="govuk-link" href="{{
+            linkTo(
+              'admin.organizations.spaces.events.view',
+              {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, page: page+1}
+            ) }}">Next page</a>
+        {% else %}
+          <a class="govuk-link" disabled>Next page</a>
+        {% endif %}
+      </p>
+    {% endif %}
+  {% endset %}
+
   {% include "../events/totals.njk" %}
 
   {% include "../events/details.njk" %}
 
-  <p class="govuk-body">
-    {% if pagination.total_pages > 1 %}
-      {% if page <= 1 %}
-        <a class="govuk-link" disabled>Previous page</a>
-      {% else %}
-        <a class="govuk-link" href="{{
-          linkTo(
-            'admin.organizations.spaces.events.view',
-            {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, page: page-1}
-          ) }}">Previous page</a>
-      {% endif %}
-
-      {% if pagination.next %}
-        <a class="govuk-link" href="{{
-          linkTo(
-            'admin.organizations.spaces.events.view',
-            {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, page: page+1}
-          ) }}">Next page</a>
-      {% else %}
-        <a class="govuk-link" disabled>Next page</a>
-      {% endif %}
-    {% endif %}
-  </p>
-
   {% if events.length > 0 %}
+    {{ pagination_controls | safe }}
+
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -92,6 +97,8 @@
       {% endfor %}
       </tbody>
     </table>
+
+    {{ pagination_controls | safe }}
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
What
----

Quality of life changes for event pagination and platform admin

When we're looking through events, currently the pagination is only at the top of the page. In order to move to the next page, one must scroll back up. Instead we should have identical pagination at the top and bottom, when there are multiple pages. This is done using a set block.

When we're on the platform admin page, we should default the costs year field to be this year.

How to review
-------------

Code review

Who can review
---------------

Not @tlwr
