### PR TITLE
Fix handling dates in URL

### DIFF
--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -56,8 +56,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(1, 'hour').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(1, 'hour').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -77,8 +77,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(10, 'days').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(10, 'days').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -98,8 +98,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(24, 'hours').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(24, 'hours').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -119,8 +119,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(90, 'minutes').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(90, 'minutes').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -140,8 +140,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(30, 'minutes').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(30, 'minutes').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -161,8 +161,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(10, 'minutes').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(10, 'minutes').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -187,8 +187,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(1, 'hour').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(1, 'hour').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -214,8 +214,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(1, 'hour').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(1, 'hour').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -228,8 +228,8 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: userProvidedServiceGUID,
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(1, 'hour').unix(),
-      rangeStop: moment().unix(),
+      rangeStart: moment().subtract(1, 'hour').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     });
 
     expect(response.status).not.toEqual(302);
@@ -288,23 +288,33 @@ describe('service metrics test suite', () => {
     expect(response.redirect).toContain('rangeStop');
   });
 
-  it('should thow an error if rangeStop is sooner than rangeStart', async () => {
+  it('should throw an error if rangeStop is sooner than rangeStart', async () => {
     await expect(viewServiceMetrics(ctx, {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().unix(),
-      rangeStop: moment().subtract(1, 'hour').unix(),
+      rangeStart: moment().format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().subtract(1, 'hour').format('YYYY-MM-DD[T]HH:mm'),
     })).rejects.toThrow(/Invalid time range provided/);
   });
 
-  it('should thow an error if asking for more than a year of metrics', async () => {
+  it('should throw an error if asking for more than a year of metrics', async () => {
+    await expect(viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(1, 'year').subtract(5, 'minutes').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
+    })).rejects.toThrow('Cannot handle more than a year of metrics');
+  });
+
+  it('should throw an error if providing non-ISO format', async () => {
     await expect(viewServiceMetrics(ctx, {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
       rangeStart: moment().subtract(1, 'year').subtract(5, 'minutes').unix(),
       rangeStop: moment().unix(),
-    })).rejects.toThrow('Cannot handle more than a year of metrics');
+    })).rejects.toThrow('Cannot handle over a year old metrics');
   });
 });


### PR DESCRIPTION
What
----

Rafal has arbitrarily decided, that UNIX timestamp is one true format
for everyone. Perhaps Rafal is right, however that doesn't mean the rest
of the world agrees with Rafal.

The HTML datetime-local input uses the ISO format when it handles dates.
That means, whenever a user is entering specific time range and
submiting the form, the URL query parameters are in a form of
`2000-05-25T13:45`. This coincidentally doesn't translate well into a
UNIX timestamp without adding extra code complexity. Without any
specific implementation in place, Moment will decide that it cannot use
that "timestamp", but instead will decide that we mean the beggining of
time otherwise known as UNIX birthday.

When sending that information to AWS, rightfully AWS is struggling to
produce any viable data, and throws somewhat unhelpfull error message:

```
ValidationError: The parameter StartTime must not equal parameter EndTime.
The parameter MetricDataQueries.member.1.MetricStat.Period must be a
value in the set [ 1, 5, 10, 30 ].
```

Where if you focus on the first line, you will instantly understand what
we're fixing in this commit, but if you do a mistake of reading through,
you may get yourself into redherring int a problem...

This doesn't however mean it's not a problem. In our code, we've decided
that if user asks for less than 15 minutes of metrics, they probably
would like to see 3 second perioded metrics. Which is coincidentally not
supported by AWS as per above error message. Correcting that on the way.

How to review
-------------

- Sanity check
- See `tlwr`s environment
- ClickOps the way around