### PR TITLE
Fix metrics periods

### DIFF
--- a/src/components/service-metrics/service-metrics.ts
+++ b/src/components/service-metrics/service-metrics.ts
@@ -175,8 +175,7 @@ function parseRange(start: string, stop: string): IRange {
     throw new UserFriendlyError('Invalid time range provided');
   }
 
-  const secondsDifference = rangeStop.diff(rangeStart) / 1000;
-  const period = moment.duration(getPeriod(secondsDifference), 'seconds');
+  const period = moment.duration(getPeriod(rangeStart, rangeStop), 'seconds');
 
   return { period, rangeStart: roundDown(rangeStart, period), rangeStop: roundDown(rangeStop, period) };
 }

--- a/src/components/service-metrics/utils.test.ts
+++ b/src/components/service-metrics/utils.test.ts
@@ -1,51 +1,84 @@
+import moment from 'moment';
 import {getPeriod} from './utils';
 
 describe('getPeriod', () => {
+  describe('looking at times < 3 hours ago', () => {
+    const rangeStart = moment().subtract(2, 'hours');
+    it('should return one second period when asked for <= 300 seconds', () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(0, 'seconds'))).toBe(1);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(299, 'seconds'))).toBe(1);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(300, 'seconds'))).toBe(1);
+    });
 
-  it('should return one second period when asked for <= 300 seconds', () => {
-    expect(getPeriod(0)).toBe(1);
-    expect(getPeriod(299)).toBe(1);
-    expect(getPeriod(300)).toBe(1);
+    it('should return five second period when asked for > 300 <= 1500 seconds', () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(301, 'seconds'))).toBe(5);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(1499, 'seconds'))).toBe(5);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(1500, 'seconds'))).toBe(5);
+    });
+
+    it('should return ten second period when asked for > 1500 <= 3000 seconds', () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(1501, 'seconds'))).toBe(10);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(2999, 'seconds'))).toBe(10);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(3000, 'seconds'))).toBe(10);
+    });
+
+    it('should return 120 second period when asked for > 18000 < 36000 seconds', () => {
+      // Note - this is a bit of a weird test, because rangeStart is only two hours ago
+      // and we're asking for 5 - 10 hours of data. This situation shouldn't really
+      // occur, but it seems reasonable to return a number anyway.
+      expect(getPeriod(rangeStart, rangeStart.clone().add(18001, 'seconds'))).toBe(120);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(35999, 'seconds'))).toBe(120);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(36000, 'seconds'))).toBe(120);
+    });
   });
 
-  it('should return five second period when asked for > 300 <= 1500 seconds', () => {
-    expect(getPeriod(301)).toBe(5);
-    expect(getPeriod(1499)).toBe(5);
-    expect(getPeriod(1500)).toBe(5);
+  describe('looking at times > 3 hours ago < 15 days ago', () => {
+    // Start time between 3 hours and 15 days ago - Use a multiple of 60 seconds (1 minute).
+    const rangeStart = moment().subtract(10, 'days');
+
+    it('should return sixty second period when asked for > 3000 <= 9000 seconds', () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(3001, 'seconds'))).toBe(60);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(8999, 'seconds'))).toBe(60);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(9000, 'seconds'))).toBe(60);
+    });
+
+    it('should return sixty second period when asked for > 9000 <= 18000 seconds', () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(9001, 'seconds'))).toBe(60);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(17999, 'seconds'))).toBe(60);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(18000, 'seconds'))).toBe(60);
+    });
+
+    it('should return 120 second period when asked for > 18000 < 36000 seconds', () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(18001, 'seconds'))).toBe(120);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(35999, 'seconds'))).toBe(120);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(36000, 'seconds'))).toBe(120);
+    });
+
+    it('should return 180 second period when asked for > 36000 < 54000 seconds', () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(36001, 'seconds'))).toBe(180);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(53999, 'seconds'))).toBe(180);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(54000, 'seconds'))).toBe(180);
+    });
+
+  });
+  describe('looking at times > 15 days ago < 63 days ago', () => {
+    // Start time between 15 and 63 days ago - Use a multiple of 300 seconds (5 minutes).
+    const rangeStart = moment().subtract(30, 'days');
+
+    it('should return 290 minute period when asked for ~60 day duration', () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(60 * 24 * 3600, 'seconds'))).toBe(290 * 60);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(60 * 24 * 3600 + 100, 'seconds'))).toBe(290 * 60);
+      expect(getPeriod(rangeStart, rangeStart.clone().add(60 * 24 * 3600 - 100, 'seconds'))).toBe(290 * 60);
+    });
   });
 
-  it('should return ten second period when asked for > 1500 <= 3000 seconds', () => {
-    expect(getPeriod(1501)).toBe(10);
-    expect(getPeriod(2999)).toBe(10);
-    expect(getPeriod(3000)).toBe(10);
-  });
+  describe('looking at times > 63 days ago', () => {
+    // Start time greater than 63 days ago - Use a multiple of 3600 seconds (1 hour).
+    const rangeStart = moment().subtract(100, 'days');
+    const oneYearInSeconds = 365 * 24 * 60 * 60;
 
-  it('should return thirty second period when asked for > 3000 <= 9000 seconds', () => {
-    expect(getPeriod(3001)).toBe(30);
-    expect(getPeriod(8999)).toBe(30);
-    expect(getPeriod(9000)).toBe(30);
-  });
-
-  it('should return thirty second period when asked for > 9000 <= 18000 seconds', () => {
-    expect(getPeriod(9001)).toBe(60);
-    expect(getPeriod(17999)).toBe(60);
-    expect(getPeriod(18000)).toBe(60);
-  });
-
-  it('should return sixty second period when asked for > 18000 < 36000 seconds', () => {
-    expect(getPeriod(18001)).toBe(60);
-    expect(getPeriod(35999)).toBe(60);
-    expect(getPeriod(36000)).toBe(120);
-  });
-
-  it('should return 120 second period when asked for > 36000 < 54000 seconds', () => {
-    expect(getPeriod(36001)).toBe(120);
-    expect(getPeriod(53999)).toBe(120);
-    expect(getPeriod(54000)).toBe(180);
-  });
-
-  const oneYearInSeconds = 365 * 24 * 60 * 60;
-  it(`should return ~= 1 day period when asked for one year`, () => {
-    expect(getPeriod(oneYearInSeconds)).toBe(105120); // 29.2 hours, so ~= 1 day
+    it(`should return 30 hour period when asked for one year`, () => {
+      expect(getPeriod(rangeStart, rangeStart.clone().add(oneYearInSeconds, 'seconds'))).toBe(30 * 3600);
+    });
   });
 });

--- a/src/components/service-metrics/utils.ts
+++ b/src/components/service-metrics/utils.ts
@@ -1,11 +1,44 @@
 import { bisectLeft } from 'd3-array';
+import moment, { Moment } from 'moment';
 
-export function getPeriod(secondsDifference: number): number {
+export function getPeriod(rangeStart: Moment, rangeStop: Moment): number {
+  const secondsDifference = rangeStop.diff(rangeStart) / 1000;
   const desiredNumberOfPoints = 300;
   const idealPeriod = secondsDifference / desiredNumberOfPoints;
-  const allowedPeriods = [1, 5, 10, 30, 60];
 
-  return idealPeriod > 60 ?
-    Math.floor(idealPeriod / 60) * 60 :
-    allowedPeriods[bisectLeft(allowedPeriods, idealPeriod)];
+  // https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricStat.html
+
+  // The granularity, in seconds, of the returned data points. For metrics with
+  // regular resolution, a period can be as short as one minute (60 seconds) and
+  // must be a multiple of 60. For high-resolution metrics that are collected at
+  // intervals of less than one minute, the period can be 1, 5, 10, 30, 60, or
+  // any multiple of 60. High-resolution metrics are those metrics stored by a
+  // PutMetricData call that includes a StorageResolution of 1 second.
+  //
+  //  If the StartTime parameter specifies a time stamp that is greater than 3
+  //  hours ago, you must specify the period as follows or no data points in that
+  //  time range is returned:
+  //
+  //      Start time between 3 hours and 15 days ago - Use a multiple of 60 seconds (1 minute).
+  //      Start time between 15 and 63 days ago - Use a multiple of 300 seconds (5 minutes).
+  //      Start time greater than 63 days ago - Use a multiple of 3600 seconds (1 hour).
+
+  const threeHoursAgo = moment().subtract(3, 'hours');
+  const fifteenDaysAgo = moment().subtract(15, 'days');
+  const sixtyThreeDaysAgo = moment().subtract(63, 'days');
+
+  if (threeHoursAgo.isBefore(rangeStart)) {
+    const allowedPeriods = [1, 5, 10, 30, 60];
+    if (idealPeriod <= 60) {
+      return allowedPeriods[bisectLeft(allowedPeriods, idealPeriod)];
+    }
+    return Math.ceil(idealPeriod / 60) * 60;
+  }
+  if (fifteenDaysAgo.isBefore(rangeStart)) {
+    return Math.ceil(idealPeriod / 60) * 60;
+  }
+  if (sixtyThreeDaysAgo.isBefore(rangeStart)) {
+    return Math.ceil(idealPeriod / 300) * 300;
+  }
+  return Math.ceil(idealPeriod / 3600) * 3600;
 }


### PR DESCRIPTION
What
----

In 14ad2ad5 we attempted to pick better time periods for GetMetricData.

Unfortunately we missed some complexity in the AWS API, so it behaves
weirdly if StartTime is earlier than 15 days ago.

This commit handles the various rules imposed on us by AWS.

How to review
-------------

* Code review is probably enough

Who can review
---------------

Not @richardtowers