### PR TITLE
Adjust one year old metrics rule

### DIFF
--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -64,6 +64,27 @@ describe('service metrics test suite', () => {
     expect(response.body).toContain('name-1508 - Service Metrics');
   });
 
+  it('should show the service metrics page when asking JUST for over one year of metrics', async () => {
+    nock('https://aws.example.com/')
+      .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
+        {id: 'mFreeStorageSpace', label: ''},
+        {id: 'mCPUUtilization', label: ''},
+      ]));
+
+    mockService(data.serviceObj);
+
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      rangeStart: moment().subtract(1, 'year').subtract(2, 'days').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
+    });
+
+    expect(response.status).not.toEqual(302);
+    expect(response.body).toContain('name-1508 - Service Metrics');
+  });
+
   it('should return cloudwatch metrics for a postgres backing service', async () => {
     nock('https://aws.example.com/')
       .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
@@ -198,7 +219,7 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(1, 'year').subtract(5, 'minutes').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStart: moment().subtract(1, 'year').subtract(2, 'weeks').format('YYYY-MM-DD[T]HH:mm'),
       rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
     })).rejects.toThrow('Cannot handle more than a year of metrics');
   });
@@ -208,7 +229,7 @@ describe('service metrics test suite', () => {
       organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
       serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      rangeStart: moment().subtract(1, 'year').subtract(5, 'minutes').unix(),
+      rangeStart: moment().subtract(1, 'week').unix(),
       rangeStop: moment().unix(),
     })).rejects.toThrow('Cannot handle over a year old metrics');
   });

--- a/src/components/service-metrics/service-metrics.ts
+++ b/src/components/service-metrics/service-metrics.ts
@@ -164,11 +164,11 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
 function parseRange(start: string, stop: string): IRange {
   const rangeStart = moment(start);
   const rangeStop = moment(stop);
-  if (rangeStart.isBefore(rangeStop.clone().subtract(1, 'year'))) {
+  if (rangeStart.isBefore(rangeStop.clone().subtract(1, 'year').subtract(1, 'week'))) {
     throw new UserFriendlyError('Invalid time range provided. Cannot handle more than a year of metrics');
   }
 
-  if (rangeStop.isBefore(moment().subtract(1, 'years')) || rangeStart.isBefore(moment().subtract(1, 'years'))) {
+  if (rangeStop.isBefore(moment().subtract(1, 'years').subtract(1, 'week')) || rangeStart.isBefore(moment().subtract(1, 'years').subtract(1, 'week'))) {
     throw new UserFriendlyError('Invalid time range provided. Cannot handle over a year old metrics');
   }
 


### PR DESCRIPTION
What
----

At the moment, if the user chooses a time period from now and one year
ago, they might find themselves in a position where the minute has
passed, before the request was made and our code will reject it as it's
already 1 year and 1 minute of metrics.

We're adding some headroom in a shape of one week, just to ease the user
experience.

How to review
-------------

- Code review
- Sanity check
- Deploy to your env and test it manually?