### PR TITLE
Unify declaration of links

### DIFF
--- a/src/components/account/access-denied.njk
+++ b/src/components/account/access-denied.njk
@@ -17,7 +17,7 @@
         If you have any queries, contact
         <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">support</a>.
       </p>
-      <a href="{{ linkTo("admin.home") }}">Back to account</a>
+      <a href="{{ linkTo("admin.home") }}" class="govuk-back-link">Back to account</a>
     </div>
   </div>
 {% endblock %}

--- a/src/components/account/successful-uplift.njk
+++ b/src/components/account/successful-uplift.njk
@@ -17,7 +17,7 @@
         <p>
           You can now log in using {{ providerName | capitalize }} SSO. You have not been logged out now.
         </p>
-        <a href="{{ linkTo("admin.home") }}">Back to account</a>
+        <a href="{{ linkTo("admin.home") }}" class="govuk-back-link">Back to account</a>
       </section>
     </div>
   </div>

--- a/src/components/account/temporarily-unavailable.njk
+++ b/src/components/account/temporarily-unavailable.njk
@@ -17,7 +17,7 @@
         If you have any queries, contact
         <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">support</a>.
       </p>
-      <a href="{{ linkTo("admin.home") }}">Back to account</a>
+      <a href="{{ linkTo("admin.home") }}" class="govuk-back-link">Back to account</a>
     </div>
   </div>
 {% endblock %}

--- a/src/components/account/unsuccessful-uplift.njk
+++ b/src/components/account/unsuccessful-uplift.njk
@@ -16,7 +16,7 @@
         Please contact
         <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">support</a>.
       </p>
-      <a href="{{ linkTo("admin.home") }}">Back to account</a>
+      <a href="{{ linkTo("admin.home") }}" class="govuk-back-link">Back to account</a>
     </div>
   </div>
 {% endblock %}

--- a/src/components/account/use-google-sso.njk
+++ b/src/components/account/use-google-sso.njk
@@ -22,7 +22,7 @@
           </p>
           <p>
             You will also need to
-            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
+            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function" class="govuk-link">
               use single sign-on at the command line
             </a>.
           </p>
@@ -42,13 +42,13 @@
           <p>
             You are currently set-up to use Google single sign-on.
             You will also need to
-            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
+            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function" class="govuk-link">
               use single sign-on at the command line
             </a>.
           </p>
           <p>
             If you would like to switch sign-on method, contact
-            <a href="https://www.cloud.service.gov.uk/support">support</a>.
+            <a href="https://www.cloud.service.gov.uk/support" class="govuk-link">support</a>.
           </p>
         </section>
       </div>
@@ -59,13 +59,13 @@
           <p>
             You are currently set up to use another single sign-on provider.
             You will also need to
-            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
+            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function" class="govuk-link">
               use single sign-on on at the command line
             </a>.
           </p>
           <p>
             If you would like begin using Microsoft single sign-on, contact
-            <a href="https://www.cloud.service.gov.uk/support">support</a>.
+            <a href="https://www.cloud.service.gov.uk/support" class="govuk-link">support</a>.
           </p>
         </section>
       </div>

--- a/src/components/account/use-microsoft-sso.njk
+++ b/src/components/account/use-microsoft-sso.njk
@@ -22,7 +22,7 @@
           </p>
           <p>
             You will also need to
-            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
+            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function" class="govuk-link">
               use single sign-on on at the command line
             </a>.
           </p>
@@ -42,13 +42,13 @@
           <p>
             You are currently set up to use Microsoft single sign-on.
             You will also need to
-            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
+            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function" class="govuk-link">
               use single sign-on on at the command line
             </a>.
           </p>
           <p>
             If you would like to switch sign-on method, contact
-            <a href="https://www.cloud.service.gov.uk/support">support</a>.
+            <a href="https://www.cloud.service.gov.uk/support" class="govuk-link">support</a>.
           </p>
         </section>
       </div>
@@ -59,13 +59,13 @@
           <p>
             You are currently set up to use another single sign-on provider.
             You will also need to
-            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function">
+            <a href="https://docs.cloud.service.gov.uk/get_started.html#use-the-single-sign-on-function" class="govuk-link">
               use single sign-on on at the command line
             </a>.
           </p>
           <p>
             If you would like begin using Microsoft single sign-on, contact
-            <a href="https://www.cloud.service.gov.uk/support">support</a>.
+            <a href="https://www.cloud.service.gov.uk/support" class="govuk-link">support</a>.
           </p>
         </section>
       </div>

--- a/src/components/applications/overview.njk
+++ b/src/components/applications/overview.njk
@@ -21,7 +21,7 @@
             This application needs upgrading or it may go offline
           </h2>
           <div class="govuk-error-summary__body">
-            <p style="margin-bottom: 0;">This application is using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2">performing the upgrade yourself</a>.</p>
+            <p style="margin-bottom: 0;">This application is using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2" class="govuk-link">performing the upgrade yourself</a>.</p>
           </div>
         </div>
       {% endif %}

--- a/src/components/errors/error.403.njk
+++ b/src/components/errors/error.403.njk
@@ -9,5 +9,5 @@
 
   <h1 class="govuk-heading-xl">Page not authorised</h1>
   <p class="govuk-body">If you entered a web address please check it was correct.</p>
-  <p>You can browse from the <a href="/">homepage</a> to find the information you need.</p>
+  <p>You can browse from the <a href="/" class="govuk-link">homepage</a> to find the information you need.</p>
 {% endblock %}

--- a/src/components/errors/error.404.njk
+++ b/src/components/errors/error.404.njk
@@ -9,5 +9,5 @@
 
   <h1 class="govuk-heading-xl">Page not found</h1>
   <p class="govuk-body">If you entered a web address please check it was correct.</p>
-  <p>You can browse from the <a href="/">homepage</a> to find the information you need.</p>
+  <p>You can browse from the <a href="/" class="govuk-link">homepage</a> to find the information you need.</p>
 {% endblock %}

--- a/src/components/service-metrics/elasticache-service-metrics.njk
+++ b/src/components/service-metrics/elasticache-service-metrics.njk
@@ -13,7 +13,7 @@
 
   <p class="govuk-body">
     Backing service metrics is a new feature under active development.
-    Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you have any feedback.
+    Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk" class="govuk-link">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you have any feedback.
   </p>
 </div>
 
@@ -25,13 +25,13 @@
         <li><a href="#cpu-utilisation" class="govuk-link">CPU utilisation</a></li>
         <li><a href="#memory-used" class="govuk-link">Memory used</a></li>
         <li><a href="#swap-memory-used" class="govuk-link">Swap memory used</a></li>
-        <li><a href="#evictions">Evictions</a></li>
-        <li><a href="#connection-count">Connection count</a></li>
-        <li><a href="#cache-hits">Cache hits</a></li>
-        <li><a href="#cache-misses">Cache misses</a></li>
-        <li><a href="#item-count">Item count</a></li>
-        <li><a href="#network-bytes-in">Network bytes in</a></li>
-        <li><a href="#network-bytes-out">Network bytes out</a></li>
+        <li><a href="#evictions" class="govuk-link">Evictions</a></li>
+        <li><a href="#connection-count" class="govuk-link">Connection count</a></li>
+        <li><a href="#cache-hits" class="govuk-link">Cache hits</a></li>
+        <li><a href="#cache-misses" class="govuk-link">Cache misses</a></li>
+        <li><a href="#item-count" class="govuk-link">Item count</a></li>
+        <li><a href="#network-bytes-in" class="govuk-link">Network bytes in</a></li>
+        <li><a href="#network-bytes-out" class="govuk-link">Network bytes out</a></li>
       </ul>
     </div>
 
@@ -47,7 +47,7 @@
     format: 'percentile',
     titleHTML: 'CPU Utilisation',
     descriptionHTML: 'How much computational work redis is doing. High CPU Utilisation may indicate you need to reduce your usage
-        or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans">update your service to use a bigger plan</a>.',
+        or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans" class="govuk-link">update your service to use a bigger plan</a>.',
     metric: metricGraphsById['mCPUUtilization']
   }) }}
 
@@ -67,7 +67,7 @@
     format: 'bytes',
     titleHTML: 'Swap memory used',
     descriptionHTML: 'If redis is running low on memory it will start to swap memory onto the hard disk. If redis is using more than 50 <abbr title="MegaBytes">MB</abbr>
-      of swap memory you may need to reduce your usage or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans">update your service to use a bigger plan</a>.',
+      of swap memory you may need to reduce your usage or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans" class="govuk-link">update your service to use a bigger plan</a>.',
     metric: metricGraphsById['mSwapUsage']
   }) }}
 

--- a/src/components/service-metrics/range-picker.njk
+++ b/src/components/service-metrics/range-picker.njk
@@ -29,22 +29,22 @@
 
     <ol class="govuk-list">
       <li>
-        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '1h'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 1 hour">Last 1 hour</a>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '1h'}) }}" class="govuk-link" title="last 1 hour">Last 1 hour</a>
       </li>
       <li>
-        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '3h'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 3 hours">Last 3 hours</a>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '3h'}) }}" class="govuk-link" title="last 3 hours">Last 3 hours</a>
       </li>
       <li>
-        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '12h'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 12 hours">Last 12 hours</a>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '12h'}) }}" class="govuk-link" title="last 12 hours">Last 12 hours</a>
       </li>
       <li>
-        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '24h'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 24 hours">Last 24 hours</a>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '24h'}) }}" class="govuk-link" title="last 24 hours">Last 24 hours</a>
       </li>
       <li>
-        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '7d'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 7 days">Last 7 days</a>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '7d'}) }}" class="govuk-link" title="last 7 days">Last 7 days</a>
       </li>
       <li>
-        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '30d'}) }}" class="govuk-link govuk-link--no-visited-state" title="last 30 days">Last 30 days</a>
+        <a href="{{ linkTo('admin.organizations.spaces.services.metrics.redirect', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, serviceGUID: service.metadata.guid, offset: '30d'}) }}" class="govuk-link" title="last 30 days">Last 30 days</a>
       </li>
     </ol>
 

--- a/src/components/service-metrics/rds-service-metrics.njk
+++ b/src/components/service-metrics/rds-service-metrics.njk
@@ -13,7 +13,7 @@
 
   <p class="govuk-body">
     Backing service metrics is a new feature under active development.
-    Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you have any feedback.
+    Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk" class="govuk-link">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you have any feedback.
   </p>
 </div>
 
@@ -51,7 +51,7 @@
     format: 'percentile',
     titleHTML: 'CPU Utilisation',
     descriptionHTML: 'How much computational work your database is doing. High CPU Utilisation may indicate you need to optimise your database queries
-      or <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.',
+      or <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.',
     metric: metricGraphsById['mCPUUtilization']
   }) }}
 
@@ -59,7 +59,7 @@
     id: 'database-connections',
     titleHTML: 'Database Connections',
     descriptionHTML: 'How many open connections there are to your database. High values may indicate problems with your applications&apos; connection management, or that you need to
-        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.
+        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.
         Zero values may indicate the database is unavailable, or that your applications cannot connect to the database.',
     metric: metricGraphsById['mDatabaseConnections']
   }) }}
@@ -69,7 +69,7 @@
     format: 'bytes',
     titleHTML: 'Freeable Memory',
     descriptionHTML: 'How much <abbr title="Random Access Memory">RAM</abbr> the <abbr title="Virtual Machine">VM</abbr> your database is running on has remaining. Values near zero may indicate you need to optimise your database queries or
-        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.',
+        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.',
     metric: metricGraphsById['mFreeableMemory']
   }) }}
 
@@ -79,7 +79,7 @@
     descriptionHTML: 'How many read operations your database is performing per second. Databases are limited to a number of <abbr title="Input / Output Operations per Second">IOPS</abbr>
         (read + write) based on how big their hard disk is. You get 3 <abbr title="Input / Output Operations per Second">IOPS</abbr> per <abbr title="GibiByte">GiB</abbr>, so a 100 GiB
         database would be limited to 300 IOPS. If it looks like your database is hitting its IOPS limit you may need to
-        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.',
+        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.',
     metric: metricGraphsById['mReadIOPS']
   }) }}
 
@@ -89,7 +89,7 @@
     descriptionHTML: 'How many write operations your database is performing per second. Databases are limited to a number of <abbr title="Input / Output Operations per Second">IOPS</abbr>
         (read + write) based on how big their hard disk is. You get 3 <abbr title="Input / Output Operations per Second">IOPS</abbr> per <abbr title="GibiByte">GiB</abbr>, so a 100 GiB
         database would be limited to 300 IOPS. If it looks like your database is hitting its IOPS limit you may need to
-        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan">update your service to use a bigger plan</a>.',
+        <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.',
     metric: metricGraphsById['mWriteIOPS']
   }) }}
 </div>

--- a/src/components/service-metrics/unsupported-service-metrics.njk
+++ b/src/components/service-metrics/unsupported-service-metrics.njk
@@ -12,7 +12,7 @@
 
 <p>Backing service metrics is a new feature under active development. Expect frequent changes.</p>
 
-<p>Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>
+<p>Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk" class="govuk-link">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>
 if you have any feedback.</p>
 </div>
 

--- a/src/components/spaces/_tabbed_layout.njk
+++ b/src/components/spaces/_tabbed_layout.njk
@@ -16,7 +16,7 @@
       <a href="{{ linkTo('admin.organizations.spaces.applications.list', {
         organizationGUID: organization.metadata.guid,
         spaceGUID: space.metadata.guid
-      }) }}">
+      }) }}" class="govuk-link">
         Applications
       </a>
     </li>
@@ -24,7 +24,7 @@
       <a href="{{ linkTo('admin.organizations.spaces.services.list', {
         organizationGUID: organization.metadata.guid,
         spaceGUID: space.metadata.guid
-      }) }}">
+      }) }}" class="govuk-link">
         Backing services
       </a>
     </li>
@@ -32,7 +32,7 @@
       <a href="{{ linkTo('admin.organizations.spaces.events.view', {
         organizationGUID: organization.metadata.guid,
         spaceGUID: space.metadata.guid
-      }) }}">
+      }) }}" class="govuk-link">
         Events
       </a>
     </li>

--- a/src/components/spaces/applications.njk
+++ b/src/components/spaces/applications.njk
@@ -19,13 +19,13 @@
           Application(s) need upgrading or they may go offline
         </h2>
         <div class="govuk-error-summary__body">
-          <p>Some applications in this space are using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2">performing the upgrade yourself</a>.</p>
+          <p>Some applications in this space are using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2" class="govuk-link">performing the upgrade yourself</a>.</p>
           <p>The following applications are affected:</p>
           <ul class="govuk-list govuk-error-summary__list">
             {% for application in applications %}
               {% if application.entity.stack_guid === cflinuxfs2StackGUID %}
                 <li>
-                  <a href="{{ linkTo('admin.organizations.spaces.applications.view', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, applicationGUID: application.metadata.guid}) }}" color="#b10e1e">{{ application.entity.name }}</a>
+                  <a href="{{ linkTo('admin.organizations.spaces.applications.view', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid, applicationGUID: application.metadata.guid}) }}" class="govuk-link" color="#b10e1e">{{ application.entity.name }}</a>
                 </li>
               {% endif %}
             {% endfor %}

--- a/src/components/spaces/spaces.njk
+++ b/src/components/spaces/spaces.njk
@@ -40,7 +40,7 @@
       </p>
 
       <p class="govuk-body">
-        <a href="https://docs.cloud.service.gov.uk/managing_apps.html#quotas">
+        <a href="https://docs.cloud.service.gov.uk/managing_apps.html#quotas" class="govuk-link">
           Learn more about quotas
         </a>
       </p>
@@ -62,7 +62,7 @@
       </p>
 
       <p class="govuk-body">
-        <a href="{{ linkTo('admin.organizations.users', {organizationGUID: organization.metadata.guid}) }}">
+        <a href="{{ linkTo('admin.organizations.users', {organizationGUID: organization.metadata.guid}) }}" class="govuk-link">
           View
           {% if isAdmin or isManager %} and manage {% endif %}
           team members
@@ -138,13 +138,13 @@
         Application(s) need upgrading or they may go offline
       </h2>
       <div class="govuk-error-summary__body">
-        <p>Some spaces below in this space are using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2">performing the upgrade yourself</a>.</p>
+        <p>Some spaces below in this space are using the <code>cflinuxfs2</code> stack, which is now deprecated. For security reasons we will soon be force-upgrading apps to <code>cflinuxfs3</code>. It is possible that this will break your application. You can prevent this happening by <a href="https://docs.cloud.service.gov.uk/guidance.html#upgrading-from-cflinuxfs2" class="govuk-link">performing the upgrade yourself</a>.</p>
         <p>Applications in the following spaces are affected:</p>
         <ul class="govuk-list govuk-error-summary__list">
           {% for space in spaces %}
             {% if space.entity.cflinuxfs2UpgradeNeeded %}
               <li>
-                <a href="{{ linkTo('admin.organizations.spaces.applications.list', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid}) }}" color="#b10e1e">{{ space.entity.name }}</a>
+                <a href="{{ linkTo('admin.organizations.spaces.applications.list', {organizationGUID: organization.metadata.guid, spaceGUID: space.metadata.guid}) }}" color="#b10e1e" class="govuk-link">{{ space.entity.name }}</a>
               </li>
             {% endif %}
           {% endfor %}

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -67,3 +67,8 @@ abbr {
     border-left: 1px solid $govuk-border-colour;
   }
 }
+
+
+a.govuk-link:not([href*="//"]):visited {
+  color: $govuk-link-colour;
+}


### PR DESCRIPTION
What
----

A lot of links across the board don't implement the `govuk-link` class.
Which in theory is not an issue, but means we're not truly using the
design system and there may be edge cases that Design System covers
where we forget about them. Let's trust our friends from the Design
System team!

Rafal is also going mad with the ":visited" variants of links which
aren't content but more of a navigation function. It appears odd, that
you only ever visit one of say three of the spaces on the list. Adding
the `govuk-link--no-visited-state` will provide us with the eye-candy
and potentially better navigation around the system, and will make Rafal
happy!

How to review
-------------

- Sanity check
- Make sure the `govuk-link--no-visited-state` class is added to sensible links and not content 🤔 (assuming you are on the same wave lengths with Rafal)