### PR TITLE
Remove £ from billing CSVs

### DIFF
--- a/src/components/reports/pmo-org-spend.csv.njk
+++ b/src/components/reports/pmo-org-spend.csv.njk
@@ -1,4 +1,4 @@
-Billing month,Org,Region,Unique ID,Spend without VAT
+Billing month,Org,Region,Unique ID,Spend in GBP without VAT
 {%- for billablesForOrg in billablesByOrganisation %}
-{{ month }},{{ billablesForOrg.org.name }},{{ location }},{{ billablesForOrg.org.guid }},£{{ (billablesForOrg.exVAT + (billablesForOrg.exVAT * adminFee)) | currency(2) }}
+{{ month }},{{ billablesForOrg.org.name }},{{ location }},{{ billablesForOrg.org.guid }},{{ (billablesForOrg.exVAT + (billablesForOrg.exVAT * adminFee)) | currency(2) }}
 {%- endfor %}

--- a/src/components/reports/pmo-org-spend.test.ts
+++ b/src/components/reports/pmo-org-spend.test.ts
@@ -43,7 +43,7 @@ describe('csv organisation monthly spend report for the pmo team', () => {
     const response = await reports.viewPmoOrgSpendReportCSV(ctx, {rangeStart});
     expect(response.download).not.toBeUndefined();
     expect(response.download!.data)
-      .toEqual(`Billing month,Org,Region,Unique ID,Spend without VAT\n`);
+      .toEqual(`Billing month,Org,Region,Unique ID,Spend in GBP without VAT\n`);
   });
 
   it('should name the CSV appropriately', async () => {
@@ -116,7 +116,7 @@ describe('csv organisation monthly spend report for the pmo team', () => {
       'Org': 'Org One',
       'Region': 'Ireland',
       'Unique ID': 'org-one',
-      'Spend without VAT': '£1.10',
+      'Spend in GBP without VAT': '1.10',
     });
   });
 
@@ -180,14 +180,14 @@ describe('csv organisation monthly spend report for the pmo team', () => {
       'Org': 'Org One',
       'Region': 'Ireland',
       'Unique ID': 'org-one',
-      'Spend without VAT': '£1211.10',
+      'Spend in GBP without VAT': '1211.10',
     });
     expect(records).toContainEqual({
       'Billing month': rangeStart.format('MMMM YYYY'),
       'Org': 'Org Two',
       'Region': 'Ireland',
       'Unique ID': 'org-two',
-      'Spend without VAT': '£11011.00',
+      'Spend in GBP without VAT': '11011.00',
     });
   });
 
@@ -215,7 +215,7 @@ describe('csv organisation monthly spend report for the pmo team', () => {
       'Org': 'Org With Nothing Billed',
       'Region': 'Ireland',
       'Unique ID': 'org-with-nothing-billed',
-      'Spend without VAT': '£0.00',
+      'Spend in GBP without VAT': '0.00',
     });
   });
 });


### PR DESCRIPTION
What
----

The £ character isn't in the ASCII charset, so by including it in the
CSV we're running the risk of other bits of software (e.g. Microsoft
Excel) getting confused about the encoding and showing garbled text.

In practice I'm not sure whether this could actually cause problems -
most text encodings agree that `0xa3` is `£`, and the ones that don't
are mostly from IBM mainframes and other relics of the 1980s.

We have had some reports of weird minus characters n Excel though, and
it seems like there's no real user need for the £ sign if the currency
is in the heading.

How to review
-------------

* Code review is probably enough

Who can review
---------------

Not @richardtowers