### PR TITLE
[#170455868] CDN broker metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,38 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/client-resource-groups-tagging-api-node": {
+      "version": "0.1.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-resource-groups-tagging-api-node/-/client-resource-groups-tagging-api-node-0.1.0-preview.2.tgz",
+      "integrity": "sha512-ZRZ6bOfuCoSzy+iQ3GmD7ukyIMKdN6k0p8HIMyVvnaZHsV/GBEdzAYucGojAGLYIBtb9IVVCA5i9ADPxRrSqiQ==",
+      "requires": {
+        "@aws-sdk/config-resolver": "^0.1.0-preview.5",
+        "@aws-sdk/core-handler": "^0.1.0-preview.5",
+        "@aws-sdk/credential-provider-node": "^0.1.0-preview.6",
+        "@aws-sdk/hash-node": "^0.1.0-preview.5",
+        "@aws-sdk/json-builder": "^0.1.0-preview.5",
+        "@aws-sdk/json-error-unmarshaller": "^0.1.0-preview.6",
+        "@aws-sdk/json-parser": "^0.1.0-preview.5",
+        "@aws-sdk/middleware-content-length": "^0.1.0-preview.5",
+        "@aws-sdk/middleware-header-default": "^0.1.0-preview.5",
+        "@aws-sdk/middleware-serializer": "^0.1.0-preview.5",
+        "@aws-sdk/middleware-stack": "^0.1.0-preview.6",
+        "@aws-sdk/node-http-handler": "^0.1.0-preview.6",
+        "@aws-sdk/protocol-json-rpc": "^0.1.0-preview.6",
+        "@aws-sdk/region-provider": "^0.1.0-preview.5",
+        "@aws-sdk/retry-middleware": "^0.1.0-preview.5",
+        "@aws-sdk/signature-v4": "^0.1.0-preview.6",
+        "@aws-sdk/signing-middleware": "^0.1.0-preview.6",
+        "@aws-sdk/stream-collector-node": "^0.1.0-preview.5",
+        "@aws-sdk/types": "^0.1.0-preview.5",
+        "@aws-sdk/url-parser-node": "^0.1.0-preview.5",
+        "@aws-sdk/util-base64-node": "^0.1.0-preview.3",
+        "@aws-sdk/util-body-length-node": "^0.1.0-preview.4",
+        "@aws-sdk/util-user-agent-node": "^0.1.0-preview.6",
+        "@aws-sdk/util-utf8-node": "^0.1.0-preview.3",
+        "tslib": "^1.8.0"
+      }
+    },
     "@aws-sdk/config-resolver": {
       "version": "0.1.0-preview.7",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-0.1.0-preview.7.tgz",
@@ -147,6 +179,38 @@
         "tslib": "^1.8.0"
       }
     },
+    "@aws-sdk/json-builder": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/json-builder/-/json-builder-0.1.0-preview.7.tgz",
+      "integrity": "sha512-gGrViVpR688e/3zQEXi7xb7/q4Nrz5w9DclJi6f32OHBphDkpv1SpHvf2WgA0949daU4QVKkyh0F6K2NygZtgg==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
+        "@aws-sdk/is-iterable": "^0.1.0-preview.3",
+        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/json-error-unmarshaller": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/json-error-unmarshaller/-/json-error-unmarshaller-0.1.0-preview.8.tgz",
+      "integrity": "sha512-yCua3FUxKIahjDugSdQMj8g+DNT+R5gViL2CYZ05kXaUla+Qml8UDV5bPr/z21FM91Oe2d532eORXixWnWCVOQ==",
+      "requires": {
+        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7"
+      }
+    },
+    "@aws-sdk/json-parser": {
+      "version": "0.1.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/json-parser/-/json-parser-0.1.0-preview.7.tgz",
+      "integrity": "sha512-EOcBUct4jkkUky+h3nw+jRo/eSREUFgqr0k9Cqcqsf6rSHN7+TCXT9tyo8CLpvDUPsbJj+Wmoylce04wU5HQkQ==",
+      "requires": {
+        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
     "@aws-sdk/middleware-content-length": {
       "version": "0.1.0-preview.7",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-0.1.0-preview.7.tgz",
@@ -200,6 +264,18 @@
       "integrity": "sha512-8yKkR78XC3fvdd+ePohfLuZHKBL7e3k+t82JL775phiXO94WHiz/hlvm6tGhNz5zKzz72yLrJPCyoQAZLrxrTg==",
       "requires": {
         "@aws-sdk/types": "^0.1.0-preview.7",
+        "tslib": "^1.8.0"
+      }
+    },
+    "@aws-sdk/protocol-json-rpc": {
+      "version": "0.1.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-json-rpc/-/protocol-json-rpc-0.1.0-preview.8.tgz",
+      "integrity": "sha512-HF7g/xE/mGLzaYqO5tDFqxFvHS4vbuLAmRsWnUKsNBzg+G9+r6XK+4+PrUKwEJT69lNXezUetjwuemqnycsStA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
+        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
+        "@aws-sdk/types": "^0.1.0-preview.7",
+        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7",
         "tslib": "^1.8.0"
       }
     },
@@ -6174,8 +6250,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6193,13 +6268,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6212,18 +6285,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6326,8 +6396,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6337,7 +6406,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6350,20 +6418,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6380,7 +6445,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6453,8 +6517,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6464,7 +6527,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6540,8 +6602,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6571,7 +6632,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6589,7 +6649,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6628,13 +6687,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-node": "^0.1.0-preview.2",
+    "@aws-sdk/client-resource-groups-tagging-api-node": "0.1.0-preview.2",
     "axios": "^0.19.0",
     "base32-encode": "^1.1.1",
     "compression": "^1.7.4",

--- a/src/components/app/app.test.config.ts
+++ b/src/components/app/app.test.config.ts
@@ -37,6 +37,7 @@ export const config: IAppConfig = {
   oidcProviders: providers,
   domainName: 'https://admin.example.com/',
   awsRegion: 'eu-west-1',
-  awsCloudwatchEndpoint: 'https://aws.example.com/',
+  awsCloudwatchEndpoint: 'https://aws-cloudwatch.example.com/',
+  awsResourceTaggingAPIEndpoint: 'https://aws-tags.example.com',
   adminFee: 0.1,
 };

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -38,6 +38,7 @@ export interface IAppConfig {
   readonly domainName: string;
   readonly awsRegion: string;
   readonly awsCloudwatchEndpoint?: string;
+  readonly awsResourceTaggingAPIEndpoint?: string;
   readonly adminFee: number;
 }
 

--- a/src/components/service-metrics/cloudfront-service-metrics.njk
+++ b/src/components/service-metrics/cloudfront-service-metrics.njk
@@ -1,0 +1,90 @@
+{% extends "../services/_tabbed_layout.njk" %}
+{% from "govuk-frontend/govuk/components/tag/macro.njk" import govukTag %}
+{% from "./metric.macro.njk" import metric %}
+
+{% block pageTitle %}
+  {{ service.entity.name }} - Service Metrics
+{% endblock %}
+
+{% block insideTabs %}
+
+<div class="border-bottom-box">
+  <p>{{ govukTag({text: "experimental"}) }}</p>
+
+  <p class="govuk-body">
+    Backing service metrics is a new feature under active development.
+    Please email us at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk" class="govuk-link">gov-uk-paas-support@digital.cabinet-office.gov.uk</a> if you have any feedback.
+  </p>
+</div>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <p>Currently the available metrics for {{serviceLabel}} are:</p>
+      <ul class="govuk-list">
+        <li><a href="#requests" class="govuk-link">Requests</a></li>
+        <li><a href="#total-error-rate" class="govuk-link">Total error rate</a></li>
+        <li><a href="#4xx-error-rate" class="govuk-link">4xx error rate</a></li>
+        <li><a href="#5xx-error-rate" class="govuk-link">5xx error rate</a></li>
+        <li><a href="#bytes-uploaded" class="govuk-link">Bytes uploaded</a></li>
+        <li><a href="#bytes-downloaded" class="govuk-link">Bytes downloaded</a></li>
+      </ul>
+    </div>
+
+    <div class="govuk-grid-column-one-third-from-desktop">
+      {% include "./range-picker.njk" %}
+    </div>
+  </div>
+</div>
+
+<div class="govuk-width-container">
+  {{ metric({
+    id: 'requests',
+    format: 'number',
+    titleHTML: 'Requests',
+    descriptionHTML: 'How many HTTP requests your CDN route service has served.',
+    metric: metricGraphsById['mRequests']
+  }) }}
+
+  {{ metric({
+    id: 'total-error-rate',
+    format: 'percentile',
+    titleHTML: 'Total error rate',
+    descriptionHTML: 'The percentages of HTTP responses with either a 4XX or 5XX HTTP status code, which can represent a client or a server error.',
+    metric: metricGraphsById['mTotalErrorRate']
+  }) }}
+
+  {{ metric({
+    id: '4xx-error-rate',
+    format: 'percentile',
+    titleHTML: '4xx error rate',
+    descriptionHTML: 'The percentages of HTTP responses with a 4XX HTTP status code, which represents a client error.',
+    metric: metricGraphsById['m4xxErrorRate']
+  }) }}
+
+  {{ metric({
+    id: '5xx-error-rate',
+    format: 'percentile',
+    titleHTML: '5xx error rate',
+    descriptionHTML: 'The percentages of HTTP responses with a 5XX HTTP status code, which represents a server error.',
+    metric: metricGraphsById['m5xxErrorRate']
+  }) }}
+
+  {{ metric({
+    id: 'bytes-uploaded',
+    format: 'bytes',
+    titleHTML: 'Bytes uploaded',
+    descriptionHTML: 'The number of bytes sent to your applications by the CDN route service.',
+    metric: metricGraphsById['mBytesUploaded']
+  }) }}
+
+  {{ metric({
+    id: 'bytes-downloaded',
+    format: 'bytes',
+    titleHTML: 'Bytes downloaded',
+    descriptionHTML: 'The number of bytes received from your applications by the CDN route service.',
+    metric: metricGraphsById['mBytesDownloaded']
+  }) }}
+</div>
+
+{% endblock %}

--- a/src/lib/aws/aws-tags.test.data.ts
+++ b/src/lib/aws/aws-tags.test.data.ts
@@ -1,0 +1,15 @@
+export function getStubResourcesByTag(): string {
+  return JSON.stringify({
+    ResourceTagMappingList: [
+      {
+        ComplianceDetails: {
+          ComplianceStatus: true,
+          KeysWithNoncompliantValues: [],
+          NoncompliantKeys: [],
+        },
+        ResourceARN: 'arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5',
+        Tags: [],
+      },
+    ],
+  });
+}

--- a/src/lib/aws/cloudwatch-metric-data.ts
+++ b/src/lib/aws/cloudwatch-metric-data.ts
@@ -52,7 +52,12 @@ export class CloudwatchMetricDataClient {
     switch (serviceLabel) {
       case 'cdn-route':
         serviceType = 'cloudfront';
-        const distributionId = await getCloudFrontDistributionId(serviceGUID);
+
+        const distributionId = await getCloudFrontDistributionId(
+          this.resourceGroupsTaggingAPIClient,
+          serviceGUID,
+        );
+
         getMetricDataInputs = getCloudFrontMetricDataInput(distributionId, period, startTime, endTime);
         cloudWatchClient = this.cloudFrontCloudWatchClient;
         break;

--- a/src/lib/aws/cloudwatch-metric-data.ts
+++ b/src/lib/aws/cloudwatch-metric-data.ts
@@ -14,7 +14,7 @@ import {
 interface IMetricPropertiesById {
   readonly [key: string]: {
     name: string;
-    stat?: 'Average' | 'Sum',
+    stat: 'Average' | 'Sum',
     format: string;
     units: 'Bytes' | 'Percent' | 'Number' | 'Milliseconds';
     title: string;
@@ -91,36 +91,42 @@ export class CloudwatchMetricDataClient {
 const rdsMetricPropertiesById: IMetricPropertiesById = {
   mFreeStorageSpace: {
     name: 'FreeStorageSpace',
+    stat: 'Average',
     format: '.2s',
     units: 'Bytes',
     title: 'bytes of free disk space',
   },
   mCPUUtilization: {
     name: 'CPUUtilization',
+    stat: 'Average',
     format: '.1r',
     units: 'Percent',
     title: 'percentage CPU Utilisation',
   },
   mDatabaseConnections: {
     name: 'DatabaseConnections',
+    stat: 'Average',
     format: '.1r',
     units: 'Number',
     title: 'number of database connections',
   },
   mFreeableMemory: {
     name: 'FreeableMemory',
+    stat: 'Average',
     format: '.2s',
     units: 'Bytes',
     title: 'bytes of freeable memory (RAM)',
   },
   mReadIOPS: {
     name: 'ReadIOPS',
+    stat: 'Average',
     format: '.2r',
     units: 'Number',
     title: 'number of read IOPS',
   },
   mWriteIOPS: {
     name: 'WriteIOPS',
+    stat: 'Average',
     format: '.2r',
     units: 'Number',
     title: 'number of write IOPS',
@@ -130,60 +136,70 @@ const rdsMetricPropertiesById: IMetricPropertiesById = {
 const elasticacheMetricPropertiesById: IMetricPropertiesById = {
   mCPUUtilization: {
     name: 'CPUUtilization',
+    stat: 'Average',
     format: '.2r',
     units: 'Percent',
     title: 'percentage CPU Utilisation',
   },
   mBytesUsedForCache: {
     name: 'BytesUsedForCache',
+    stat: 'Average',
     format: '.2s',
     units: 'Bytes',
     title: 'bytes used for the cache',
   },
   mSwapUsage: {
     name: 'SwapUsage',
+    stat: 'Average',
     format: '.2s',
     units: 'Bytes',
     title: 'bytes used in swap memory',
   },
   mEvictions: {
     name: 'Evictions',
+    stat: 'Average',
     format: '.2r',
     units: 'Number',
     title: 'number of keys evicted by Redis',
   },
   mCurrConnections: {
     name: 'CurrConnections',
+    stat: 'Average',
     format: '.2r',
     units: 'Number',
     title: 'number of connections to Redis',
   },
   mCacheHits: {
     name: 'CacheHits',
+    stat: 'Average',
     format: '.2r',
     units: 'Number',
     title: 'number of cache hits',
   },
   mCacheMisses: {
     name: 'CacheMisses',
+    stat: 'Average',
     format: '.2r',
     units: 'Number',
     title: 'number of cache misses',
   },
   mCurrItems: {
     name: 'CurrItems',
+    stat: 'Average',
     format: '.2r',
     units: 'Number',
     title: 'number of items in Redis',
   },
   mNetworkBytesIn: {
     name: 'NetworkBytesIn',
+    stat: 'Average',
     format: '.2s',
     units: 'Bytes',
     title: 'number of bytes redis has read from the network',
   },
   mNetworkBytesOut: {
     name: 'NetworkBytesOut',
+    stat: 'Average',
     format: '.2s',
     units: 'Bytes',
     title: 'number of bytes sent by redis',
@@ -277,7 +293,7 @@ export function getRdsMetricDataInput(
           Dimensions: [{Name: 'DBInstanceIdentifier', Value: getRdsDbInstanceIdentifier(serviceGUID)}],
         },
         Period: period.asSeconds(),
-        Stat: rdsMetricPropertiesById[metricId].stat || 'Average',
+        Stat: rdsMetricPropertiesById[metricId].stat,
       },
     })),
     StartTime: startTime.toDate(),
@@ -304,7 +320,7 @@ export function getCloudFrontMetricDataInput(
           ],
         },
         Period: period.asSeconds(),
-        Stat: cloudfrontMetricPropertiesById[metricId].stat || 'Average',
+        Stat: cloudfrontMetricPropertiesById[metricId].stat,
       },
     })),
     StartTime: startTime.toDate(),

--- a/src/lib/aws/identifiers.test.ts
+++ b/src/lib/aws/identifiers.test.ts
@@ -59,7 +59,7 @@ describe('AWS identifiers', () => {
 
       send.mockReturnValue(Promise.resolve({}));
 
-      expect(getCloudFrontDistributionId({ send } as any, 'a-service-guid'))
+      await expect(getCloudFrontDistributionId({ send } as any, 'a-service-guid'))
         .rejects
         .toThrow(/Could not get tags for CloudFront distribution/)
       ;
@@ -75,7 +75,7 @@ describe('AWS identifiers', () => {
 
       send.mockReturnValue(Promise.resolve({ ResourceTagMappingList: [] }));
 
-      expect(getCloudFrontDistributionId({ send } as any, 'a-service-guid'))
+      await expect(getCloudFrontDistributionId({ send } as any, 'a-service-guid'))
         .rejects
         .toThrow(/Could not get tags for CloudFront distribution/)
       ;
@@ -91,7 +91,7 @@ describe('AWS identifiers', () => {
 
       send.mockReturnValue(Promise.resolve({ ResourceTagMappingList: [{}] }));
 
-      expect(getCloudFrontDistributionId({ send } as any, 'a-service-guid'))
+      await expect(getCloudFrontDistributionId({ send } as any, 'a-service-guid'))
         .rejects
         .toThrow(/Could not get ARN for CloudFront distribution/)
       ;
@@ -109,7 +109,7 @@ describe('AWS identifiers', () => {
         ResourceARN: 'arn:aws:cloudfront::123456789012:distribution',
       }] }));
 
-      expect(getCloudFrontDistributionId({ send } as any, 'a-service-guid'))
+      await expect(getCloudFrontDistributionId({ send } as any, 'a-service-guid'))
         .rejects
         .toThrow(/Malformed ARN/)
       ;

--- a/src/lib/aws/identifiers.ts
+++ b/src/lib/aws/identifiers.ts
@@ -1,3 +1,9 @@
+import {
+  GetResourcesCommand,
+  GetResourcesOutput,
+  ResourceGroupsTaggingAPIClient,
+} from '@aws-sdk/client-resource-groups-tagging-api-node';
+
 import base32Encode from 'base32-encode';
 import fnv from 'fnv-plus';
 
@@ -10,4 +16,36 @@ export function getElasticacheReplicationGroupId(serviceInstanceGUID: string): s
   const hashBuffer = Buffer.from(hashHexString, 'hex');
   const hashBase32String = base32Encode(hashBuffer, 'RFC4648', {padding: false});
   return `cf-${hashBase32String.toLowerCase()}`;
+}
+
+export async function getCloudFrontDistributionId(serviceGUID: string): Promise<string> {
+  const rg = new ResourceGroupsTaggingAPIClient({region: 'us-east-1'});
+
+  const arn = await (
+    rg
+      .send(
+        new GetResourcesCommand({TagFilters: [{
+          Key: 'ServiceInstance',
+          Values: [serviceGUID],
+        }]}),
+      )
+      .then((d: GetResourcesOutput) => {
+        if (typeof d.ResourceTagMappingList === 'undefined') {
+          throw new Error(`Could not get tags for CloudFront distribution ${serviceGUID}`);
+        }
+        return d.ResourceTagMappingList[0].ResourceARN;
+      })
+  );
+
+  if (typeof arn === 'undefined') {
+    throw new Error(`Could not get ARN for CloudFront distribution ${serviceGUID}`);
+  }
+
+  const distributionIdMatches = arn.match(/(?!\/)[A-Z0-9]+$/);
+
+  if (distributionIdMatches === null) {
+    throw new Error(`Malformed ARN ${arn} for CloudFront distribution ${serviceGUID}`);
+  }
+
+  return distributionIdMatches[0];
 }

--- a/src/lib/aws/identifiers.ts
+++ b/src/lib/aws/identifiers.ts
@@ -18,9 +18,10 @@ export function getElasticacheReplicationGroupId(serviceInstanceGUID: string): s
   return `cf-${hashBase32String.toLowerCase()}`;
 }
 
-export async function getCloudFrontDistributionId(serviceGUID: string): Promise<string> {
-  const rg = new ResourceGroupsTaggingAPIClient({region: 'us-east-1'});
-
+export async function getCloudFrontDistributionId(
+  rg: ResourceGroupsTaggingAPIClient,
+  serviceGUID: string,
+): Promise<string> {
   const arn = await (
     rg
       .send(
@@ -30,7 +31,7 @@ export async function getCloudFrontDistributionId(serviceGUID: string): Promise<
         }]}),
       )
       .then((d: GetResourcesOutput) => {
-        if (typeof d.ResourceTagMappingList === 'undefined') {
+        if (typeof d.ResourceTagMappingList === 'undefined' || d.ResourceTagMappingList.length === 0) {
           throw new Error(`Could not get tags for CloudFront distribution ${serviceGUID}`);
         }
         return d.ResourceTagMappingList[0].ResourceARN;

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,6 +99,7 @@ async function main() {
     oidcProviders: providers,
     domainName: expectEnvVariable('DOMAIN_NAME'),
     awsCloudwatchEndpoint: process.env.AWS_CLOUDWATCH_ENDPOINT,
+    awsResourceTaggingAPIEndpoint: process.env.AWS_RESOURCE_TAGGING_API_ENDPOINT,
     adminFee: .1,
   };
 


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/170455868)

What
----

We provide CDNs to our users via CloudFront, and a small number (6) of metrics are collected in CloudWatch. We should show these metrics to our users.

CDN route services are CloudFront distributions, which are keyed by Distribution IDs. The canonical mapping between a service GUID and a distribution ID is in the CDN broker database.

We have modified the CDN broker to tag (`ServiceInstance`) with the Cloud Foundry service instance GUID: https://github.com/alphagov/paas-cdn-broker-boshrelease/pull/22

There is another PR to allow Pazmin to query AWS to find CloudFront distributions by tag: https://github.com/alphagov/paas-aws-account-wide-terraform/pull/200

The following PR allows users to look up the basic metrics provided by CloudFront in CloudWatch.

![image](https://user-images.githubusercontent.com/1482692/71627033-3633e880-2be8-11ea-99e2-a55ac5530b17.png)
_An image of the CDN metrics in my development environment, this is real data, which is why it looks so bad_

![image](https://user-images.githubusercontent.com/1482692/71627379-0259c280-2bea-11ea-8404-127a26fdd65e.png)
_An image where I have focused on my generated data_

How to review
-------------

🐝 Do not just merge this PR 🐝 

1. Do a code review
1. See that the tests pass
1. Check out my dev environment where I have [created a CDN route and generated some data](https://admin.tlwr.dev.cloudpipeline.digital/organisations/85a9bbf2-4d62-479c-a97b-ac3295a659cb/spaces/10278b2c-dd43-4aba-8047-c02c4054041c/services/773ea926-9cdb-4b25-bf68-b9593bfa8b91/metrics?rangeStart=2019-12-24T14%3A52&rangeStop=2019-12-31T14%3A52) and [zoomed in on the data](https://admin.tlwr.dev.cloudpipeline.digital/organisations/85a9bbf2-4d62-479c-a97b-ac3295a659cb/spaces/10278b2c-dd43-4aba-8047-c02c4054041c/services/773ea926-9cdb-4b25-bf68-b9593bfa8b91/metrics?_csrf=NSwiMJTS-dM4A1rP6uNw4zbOKyvI-q93zivw&rangeStart=2019-12-27T15%3A10&rangeStop=2019-12-27T16%3A30)
1. Review and deploy this PR https://github.com/alphagov/paas-aws-account-wide-terraform/pull/200

Once the above is done, we need to ensure that every CloudFront distribution has the correct `ServiceInstance` tag, which we can do via the AWS CLI as a one-off.

Someone who is good at words should have a look at my descriptions and the HTML to double check what I have written makes sense.

Who can review
---------------

Not @tlwr