### PR TITLE
[#169504332] Download metrics data as a CSV

### DIFF
--- a/config/nunjucks.config.js
+++ b/config/nunjucks.config.js
@@ -108,6 +108,27 @@ function configure(env) {
     return `${bytes.toFixed(2)}<abbr title="${longUnits[units[u]]}">${units[u]}</abbr>`;
   });
 
+  env.addFilter('bytestohumancsv', (bytes) => {
+    const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+    const thresh = 1024;
+
+    if(Math.abs(bytes) < thresh) {
+      return `${bytes.toFixed(0)}B`;
+    }
+
+    let u = -1;
+    while(Math.abs(bytes) >= thresh && u < units.length - 1) {
+        bytes /= thresh;
+        ++u;
+    }
+
+    return `${bytes.toFixed(2)}${units[u]}`;
+  });
+
+  env.addFilter('nan', (num) => {
+    return isNaN(num);
+  });
+
   env.addFilter('percentage', (num, denom) => {
     const percentage = 100 * (num / denom)
     return `${percentage.toFixed(1)}%`

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -79,6 +79,11 @@ const router = new Router([
     path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/metrics',
   },
   {
+    action: serviceMetrics.downloadServiceMetrics,
+    name: 'admin.organizations.spaces.services.metrics.download',
+    path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/metrics/download',
+  },
+  {
     action: serviceMetrics.resolveServiceMetrics,
     name: 'admin.organizations.spaces.services.metrics.redirect',
     path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/metrics/:offset',

--- a/src/components/service-metrics/cloudfront-service-metrics-csv.njk
+++ b/src/components/service-metrics/cloudfront-service-metrics-csv.njk
@@ -1,0 +1,14 @@
+{%- macro fmt(val, units) -%}
+  {%- if units === 'Bytes' -%}
+    {%- if val | nan %}{{ 0 | bytestohumancsv }}{% else %}{{ val | bytestohumancsv }}{% endif %}
+  {%- elseif units === 'Percent' -%}
+    {%- if val | nan %}{{ 0 | round(2) }}%{% else %}{{ val | round(2) }}%{% endif %}
+  {%- else -%}
+    {%- if val | nan %}{{ 0 | round(2) }}{% else %}{{ val | round(2) }}{% endif %}
+  {%- endif -%}
+{%- endmacro -%}
+Service,Time,Value{{ "\n" -}}
+{% for series in metricData.seriesArray[0].metrics -%}
+  {%- set row = [serviceLabel, series.date | dateTime, fmt(series.value, metricData.units)] -%}
+  {{- row | join(",") }}{{ "\n" -}}
+{% endfor -%}

--- a/src/components/service-metrics/cloudfront-service-metrics.njk
+++ b/src/components/service-metrics/cloudfront-service-metrics.njk
@@ -43,7 +43,8 @@
     format: 'number',
     titleHTML: 'Requests',
     descriptionHTML: 'How many HTTP requests your CDN route service has served.',
-    metric: metricGraphsById['mRequests']
+    metric: metricGraphsById['mRequests'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -51,7 +52,8 @@
     format: 'percentile',
     titleHTML: 'Total error rate',
     descriptionHTML: 'The percentages of HTTP responses with either a 4XX or 5XX HTTP status code, which can represent a client or a server error.',
-    metric: metricGraphsById['mTotalErrorRate']
+    metric: metricGraphsById['mTotalErrorRate'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -59,7 +61,8 @@
     format: 'percentile',
     titleHTML: '4xx error rate',
     descriptionHTML: 'The percentages of HTTP responses with a 4XX HTTP status code, which represents a client error.',
-    metric: metricGraphsById['m4xxErrorRate']
+    metric: metricGraphsById['m4xxErrorRate'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -67,7 +70,8 @@
     format: 'percentile',
     titleHTML: '5xx error rate',
     descriptionHTML: 'The percentages of HTTP responses with a 5XX HTTP status code, which represents a server error.',
-    metric: metricGraphsById['m5xxErrorRate']
+    metric: metricGraphsById['m5xxErrorRate'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -75,7 +79,8 @@
     format: 'bytes',
     titleHTML: 'Bytes uploaded',
     descriptionHTML: 'The number of bytes sent to your applications by the CDN route service.',
-    metric: metricGraphsById['mBytesUploaded']
+    metric: metricGraphsById['mBytesUploaded'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -83,7 +88,8 @@
     format: 'bytes',
     titleHTML: 'Bytes downloaded',
     descriptionHTML: 'The number of bytes received from your applications by the CDN route service.',
-    metric: metricGraphsById['mBytesDownloaded']
+    metric: metricGraphsById['mBytesDownloaded'],
+    downloadLink: downloadLink
   }) }}
 </div>
 

--- a/src/components/service-metrics/elasticache-service-metrics-csv.njk
+++ b/src/components/service-metrics/elasticache-service-metrics-csv.njk
@@ -1,0 +1,16 @@
+{%- macro fmt(val, units) -%}
+  {%- if units === 'Bytes' -%}
+    {%- if val | nan %}{{ 0 | bytestohumancsv }}{% else %}{{ val | bytestohumancsv }}{% endif %}
+  {%- elseif units === 'Percent' -%}
+    {%- if val | nan %}{{ 0 | round(2) }}%{% else %}{{ val | round(2) }}%{% endif %}
+  {%- else -%}
+    {%- if val | nan %}{{ 0 | round(2) }}{% else %}{{ val | round(2) }}{% endif %}
+  {%- endif -%}
+{%- endmacro -%}
+Service,Instance,Time,Value{{ "\n" -}}
+{% for metric in metricData.seriesArray -%}
+  {%- for series in metric.metrics -%}
+  {%- set row = [serviceLabel, metric.label, series.date | dateTime, fmt(series.value, metricData.units)] -%}
+  {{- row | join(",") }}{{ "\n" -}}
+  {%- endfor -%}
+{% endfor -%}

--- a/src/components/service-metrics/elasticache-service-metrics.njk
+++ b/src/components/service-metrics/elasticache-service-metrics.njk
@@ -48,7 +48,8 @@
     titleHTML: 'CPU Utilisation',
     descriptionHTML: 'How much computational work redis is doing. High CPU Utilisation may indicate you need to reduce your usage
         or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans" class="govuk-link">update your service to use a bigger plan</a>.',
-    metric: metricGraphsById['mCPUUtilization']
+    metric: metricGraphsById['mCPUUtilization'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -59,7 +60,8 @@
       internal buffers. If redis reaches its memory limit and cannot evict any
       keys it will return errors when executing commands that increase memory
       use.',
-    metric: metricGraphsById['mBytesUsedForCache']
+    metric: metricGraphsById['mBytesUsedForCache'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -68,7 +70,8 @@
     titleHTML: 'Swap memory used',
     descriptionHTML: 'If redis is running low on memory it will start to swap memory onto the hard disk. If redis is using more than 50 <abbr title="MegaBytes">MB</abbr>
       of swap memory you may need to reduce your usage or <a href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans" class="govuk-link">update your service to use a bigger plan</a>.',
-    metric: metricGraphsById['mSwapUsage']
+    metric: metricGraphsById['mSwapUsage'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -76,7 +79,8 @@
     titleHTML: 'Evictions',
     descriptionHTML: 'Redis will evict keys when it reaches its configured memory limit. It will try to remove less recently used keys first, but only among keys
       that have an EXPIRE set. If there are no keys left to evict redis will return errors when executing commands that increase memory use.',
-    metric: metricGraphsById['mEvictions']
+    metric: metricGraphsById['mEvictions'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -84,28 +88,32 @@
     titleHTML: 'Connection count',
     descriptionHTML: 'How many open connections there are to redis. High values may indicate problems with your applications&apos; connection management.
       Zero values may indicate that redis is unavailable, or that your applications cannot connect to the database.',
-    metric: metricGraphsById['mCurrConnections']
+    metric: metricGraphsById['mCurrConnections'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
     id: 'cache-hits',
     titleHTML: 'Cache hits',
     descriptionHTML: 'The number of successful key lookups.',
-    metric: metricGraphsById['mCacheHits']
+    metric: metricGraphsById['mCacheHits'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
     id: 'cache-misses',
     titleHTML: 'Cache misses',
     descriptionHTML: 'The number of unsuccessful key lookups.',
-    metric: metricGraphsById['mCacheMisses']
+    metric: metricGraphsById['mCacheMisses'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
     id: 'item-count',
     titleHTML: 'Item count',
     descriptionHTML: 'The number of items in redis.',
-    metric: metricGraphsById['mCurrItems']
+    metric: metricGraphsById['mCurrItems'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -113,7 +121,8 @@
     format: 'bytes',
     titleHTML: 'Network bytes in',
     descriptionHTML: 'The number of bytes redis has read from the network.',
-    metric: metricGraphsById['mNetworkBytesIn']
+    metric: metricGraphsById['mNetworkBytesIn'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -121,7 +130,8 @@
     format: 'bytes',
     titleHTML: 'Network bytes out',
     descriptionHTML: 'The number of bytes sent by redis.',
-    metric: metricGraphsById['mNetworkBytesOut']
+    metric: metricGraphsById['mNetworkBytesOut'],
+    downloadLink: downloadLink
   }) }}
 </div>
 

--- a/src/components/service-metrics/metric.macro.njk
+++ b/src/components/service-metrics/metric.macro.njk
@@ -10,6 +10,9 @@
         <p>{{ params.descriptionHTML | safe }}</p>
 
         <div>{{ params.metric.graph | safe }}</div>
+
+        {% set csvlink =  [params.downloadLink, '&metric=', params.metric.id] %}
+        <a href="{{ csvlink | join }}" class="govuk-link" title="Download as a CSV">Download as a CSV</a>
     </div>
     <div class="govuk-grid-column-one-third-from-desktop">
       <table class="govuk-table">

--- a/src/components/service-metrics/rds-service-metrics-csv.njk
+++ b/src/components/service-metrics/rds-service-metrics-csv.njk
@@ -1,0 +1,14 @@
+{%- macro fmt(val, units) -%}
+  {%- if units === 'Bytes' -%}
+    {%- if val | nan %}{{ 0 | bytestohumancsv }}{% else %}{{ val | bytestohumancsv }}{% endif %}
+  {%- elseif units === 'Percent' -%}
+    {%- if val | nan %}{{ 0 | round(2) }}%{% else %}{{ val | round(2) }}%{% endif %}
+  {%- else -%}
+    {%- if val | nan %}{{ 0 | round(2) }}{% else %}{{ val | round(2) }}{% endif %}
+  {%- endif -%}
+{%- endmacro -%}
+Service,Time,Value{{ "\n" -}}
+{% for series in metricData.seriesArray[0].metrics -%}
+  {%- set row = [serviceLabel, series.date | dateTime, fmt(series.value, metricData.units)] -%}
+  {{- row | join(",") }}{{ "\n" -}}
+{% endfor -%}

--- a/src/components/service-metrics/rds-service-metrics.njk
+++ b/src/components/service-metrics/rds-service-metrics.njk
@@ -43,7 +43,8 @@
     format: 'bytes',
     titleHTML: 'Free disk space',
     descriptionHTML: 'How much hard disk space your database has remaining. If your database runs out of disk space it will stop working.',
-    metric: metricGraphsById['mFreeStorageSpace']
+    metric: metricGraphsById['mFreeStorageSpace'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -52,7 +53,8 @@
     titleHTML: 'CPU Utilisation',
     descriptionHTML: 'How much computational work your database is doing. High CPU Utilisation may indicate you need to optimise your database queries
       or <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.',
-    metric: metricGraphsById['mCPUUtilization']
+    metric: metricGraphsById['mCPUUtilization'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -61,7 +63,8 @@
     descriptionHTML: 'How many open connections there are to your database. High values may indicate problems with your applications&apos; connection management, or that you need to
         <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.
         Zero values may indicate the database is unavailable, or that your applications cannot connect to the database.',
-    metric: metricGraphsById['mDatabaseConnections']
+    metric: metricGraphsById['mDatabaseConnections'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -70,7 +73,8 @@
     titleHTML: 'Freeable Memory',
     descriptionHTML: 'How much <abbr title="Random Access Memory">RAM</abbr> the <abbr title="Virtual Machine">VM</abbr> your database is running on has remaining. Values near zero may indicate you need to optimise your database queries or
         <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.',
-    metric: metricGraphsById['mFreeableMemory']
+    metric: metricGraphsById['mFreeableMemory'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -80,7 +84,8 @@
         (read + write) based on how big their hard disk is. You get 3 <abbr title="Input / Output Operations per Second">IOPS</abbr> per <abbr title="GibiByte">GiB</abbr>, so a 100 GiB
         database would be limited to 300 IOPS. If it looks like your database is hitting its IOPS limit you may need to
         <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.',
-    metric: metricGraphsById['mReadIOPS']
+    metric: metricGraphsById['mReadIOPS'],
+    downloadLink: downloadLink
   }) }}
 
   {{ metric({
@@ -90,7 +95,8 @@
         (read + write) based on how big their hard disk is. You get 3 <abbr title="Input / Output Operations per Second">IOPS</abbr> per <abbr title="GibiByte">GiB</abbr>, so a 100 GiB
         database would be limited to 300 IOPS. If it looks like your database is hitting its IOPS limit you may need to
         <a href="https://docs.cloud.service.gov.uk/deploying_services/postgresql/#upgrade-postgresql-service-plan" class="govuk-link">update your service to use a bigger plan</a>.',
-    metric: metricGraphsById['mWriteIOPS']
+    metric: metricGraphsById['mWriteIOPS'],
+    downloadLink: downloadLink
   }) }}
 </div>
 

--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -306,7 +306,6 @@ describe('service metrics test suite', () => {
     expect(lines.length).toBeLessThan(400);
 
     const [{}, first, ...{}] = lines;
-
     const [{}, firstDate, {}] = first.split(',');
     expect(moment(firstDate).diff(rangeStart)).toBeLessThanOrEqual(60 * 1000);
   });
@@ -352,8 +351,57 @@ describe('service metrics test suite', () => {
     expect(lines.length).toBeLessThan(450);
 
     const [{}, first, ...{}] = lines;
-
     const [{}, {}, firstDate, {}] = first.split(',');
+    expect(moment(firstDate).diff(rangeStart)).toBeLessThanOrEqual(60 * 1000);
+  });
+
+  it('should download a cloudfront csv', async () => {
+    nock('https://aws-tags.example.com/')
+      .post('/').reply(200, getStubResourcesByTag())
+    ;
+
+    nock('https://aws-cloudwatch.example.com/')
+      .post('/').times(2).reply(200, getStubCloudwatchMetricsData([
+        {id: 'mRequests', label: ''},
+        {id: 'mTotalErrorRate', label: ''},
+      ]))
+    ;
+
+    mockService({
+      ...data.serviceObj,
+      entity: {
+        ...data.serviceObj.entity,
+        label: 'cdn-route',
+      },
+    });
+
+    const rangeStop = moment();
+    const rangeStart = rangeStop.subtract(1, 'hour');
+
+    const response = await downloadServiceMetrics({
+      ...ctx,
+      linkTo: (_name, params) => querystring.stringify(params),
+    }, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      metric: 'mRequests',
+      rangeStart: rangeStart.format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: rangeStop.format('YYYY-MM-DD[T]HH:mm'),
+    });
+
+    expect(response.mimeType).toEqual('text/csv');
+    expect(response.download.name).toMatch(/cloudfront-metrics.*\.csv/);
+    expect(response.download.data).toMatch(/Service,Time,Value/);
+    expect(response.download.data).toMatch(new RegExp(`cdn-route,${rangeStart.format('YYYY-MM-DD[T]HH:mm')},\\d+`));
+
+    const lines = response.download.data.split('\n');
+
+    expect(lines.length).toBeGreaterThan(2);
+    expect(lines.length).toBeLessThan(450);
+
+    const [{}, first, ...{}] = lines;
+    const [{}, firstDate, ...{}] = first.split(',');
     expect(moment(firstDate).diff(rangeStart)).toBeLessThanOrEqual(60 * 1000);
   });
 

--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -293,7 +293,7 @@ describe('service metrics test suite', () => {
     });
 
     expect(response.mimeType).toEqual('text/csv');
-    expect(response.download.name).toMatch(/rds-metrics.*\.csv/);
+    expect(response.download.name).toMatch(/postgres-metrics.*\.csv/);
     expect(response.download.data).toMatch(/Service,Time,Value/);
     expect(response.download.data).toMatch(new RegExp(`postgres,${rangeStart.format('YYYY-MM-DD[T]HH:mm')},\\d+B`));
 
@@ -341,7 +341,7 @@ describe('service metrics test suite', () => {
     });
 
     expect(response.mimeType).toEqual('text/csv');
-    expect(response.download.name).toMatch(/elasticache-metrics.*\.csv/);
+    expect(response.download.name).toMatch(/redis-metrics.*\.csv/);
     expect(response.download.data).toMatch(/Service,Instance,Time,Value/);
     expect(response.download.data).toMatch(new RegExp(`redis,,${rangeStart.format('YYYY-MM-DD[T]HH:mm')},\\d+`));
 
@@ -391,7 +391,7 @@ describe('service metrics test suite', () => {
     });
 
     expect(response.mimeType).toEqual('text/csv');
-    expect(response.download.name).toMatch(/cloudfront-metrics.*\.csv/);
+    expect(response.download.name).toMatch(/cdn-route-metrics.*\.csv/);
     expect(response.download.data).toMatch(/Service,Time,Value/);
     expect(response.download.data).toMatch(new RegExp(`cdn-route,${rangeStart.format('YYYY-MM-DD[T]HH:mm')},\\d+`));
 

--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 
-import {resolveServiceMetrics, viewServiceMetrics} from '.';
+import {downloadServiceMetrics, resolveServiceMetrics, viewServiceMetrics} from '.';
 
 import moment from 'moment';
 import querystring from 'querystring';
@@ -266,5 +266,124 @@ describe('service metrics test suite', () => {
       rangeStart: moment().subtract(1, 'week').unix(),
       rangeStop: moment().unix(),
     })).rejects.toThrow('Cannot handle over a year old metrics');
+  });
+
+  it('should download a postgres csv', async () => {
+    nock('https://aws.example.com/')
+      .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
+        {id: 'mFreeStorageSpace', label: ''},
+        {id: 'mCPUUtilization', label: ''},
+      ]));
+
+    mockService(data.serviceObj);
+
+    const rangeStop = moment();
+    const rangeStart = rangeStop.subtract(1, 'hour');
+
+    const response = await downloadServiceMetrics({
+      ...ctx,
+      linkTo: (_name, params) => querystring.stringify(params),
+    }, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      metric: 'mFreeStorageSpace',
+      rangeStart: rangeStart.format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: rangeStop.format('YYYY-MM-DD[T]HH:mm'),
+    });
+
+    expect(response.mimeType).toEqual('text/csv');
+    expect(response.download.name).toMatch(/rds-metrics.*\.csv/);
+    expect(response.download.data).toMatch(/Service,Time,Value/);
+    expect(response.download.data).toMatch(new RegExp(`postgres,${rangeStart.format('YYYY-MM-DD[T]HH:mm')},\\d+B`));
+
+    const lines = response.download.data
+      .split('\n')
+      .filter(line => line.length > 0)
+    ;
+
+    expect(lines.length).toBeGreaterThan(2);
+    expect(lines.length).toBeLessThan(400);
+
+    const [{}, first, ...{}] = lines;
+
+    const [{}, firstDate, {}] = first.split(',');
+    expect(moment(firstDate).diff(rangeStart)).toBeLessThanOrEqual(60 * 1000);
+  });
+
+  it('should download a redis csv', async () => {
+    nock('https://aws.example.com/')
+    .post('/').times(2).reply(200, getStubCloudwatchMetricsData([
+      {id: 'mCacheHits', label: ''},
+      {id: 'mCacheMisses', label: ''},
+    ]));
+
+    mockService({
+      ...data.serviceObj,
+      entity: {
+        ...data.serviceObj.entity,
+        label: 'redis',
+      },
+    });
+
+    const rangeStop = moment();
+    const rangeStart = rangeStop.subtract(1, 'hour');
+
+    const response = await downloadServiceMetrics({
+      ...ctx,
+      linkTo: (_name, params) => querystring.stringify(params),
+    }, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      metric: 'mCacheHits',
+      rangeStart: rangeStart.format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: rangeStop.format('YYYY-MM-DD[T]HH:mm'),
+    });
+
+    expect(response.mimeType).toEqual('text/csv');
+    expect(response.download.name).toMatch(/elasticache-metrics.*\.csv/);
+    expect(response.download.data).toMatch(/Service,Instance,Time,Value/);
+    expect(response.download.data).toMatch(new RegExp(`redis,,${rangeStart.format('YYYY-MM-DD[T]HH:mm')},\\d+`));
+
+    const lines = response.download.data.split('\n');
+
+    expect(lines.length).toBeGreaterThan(2);
+    expect(lines.length).toBeLessThan(450);
+
+    const [{}, first, ...{}] = lines;
+
+    const [{}, {}, firstDate, {}] = first.split(',');
+    expect(moment(firstDate).diff(rangeStart)).toBeLessThanOrEqual(60 * 1000);
+  });
+
+  it('should fail to download csv if no data returned from cloudwatch', async () => {
+    await expect(downloadServiceMetrics({
+      ...ctx,
+      linkTo: (_name, params) => querystring.stringify(params),
+    }, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+      metric: 'mFreeStorageSpace',
+      rangeStart: moment().subtract(1, 'hour').format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
+      })).rejects.toThrow(/No response from Cloudwatch/);
+  });
+
+  it('should redirect if no range or metric provided for csv download', async () => {
+    const response = await downloadServiceMetrics({
+      ...ctx,
+      linkTo: (_name, params) => querystring.stringify(params),
+    }, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+    });
+
+    expect(response.body).not.toBeDefined();
+    expect(response.status).toEqual(302);
+    expect(response.redirect).toContain('rangeStart');
+    expect(response.redirect).toContain('rangeStop');
   });
 });

--- a/src/components/service-metrics/service-metrics.test.ts
+++ b/src/components/service-metrics/service-metrics.test.ts
@@ -269,7 +269,7 @@ describe('service metrics test suite', () => {
   });
 
   it('should download a postgres csv', async () => {
-    nock('https://aws.example.com/')
+    nock('https://aws-cloudwatch.example.com/')
       .post('/').times(1).reply(200, getStubCloudwatchMetricsData([
         {id: 'mFreeStorageSpace', label: ''},
         {id: 'mCPUUtilization', label: ''},
@@ -312,7 +312,7 @@ describe('service metrics test suite', () => {
   });
 
   it('should download a redis csv', async () => {
-    nock('https://aws.example.com/')
+    nock('https://aws-cloudwatch.example.com/')
     .post('/').times(2).reply(200, getStubCloudwatchMetricsData([
       {id: 'mCacheHits', label: ''},
       {id: 'mCacheMisses', label: ''},

--- a/src/components/service-metrics/service-metrics.ts
+++ b/src/components/service-metrics/service-metrics.ts
@@ -280,12 +280,14 @@ export async function downloadServiceMetrics(ctx: IContext, params: IParameters)
       rangeStop,
   };
 
+  const name = `${serviceLabel}-metrics-${params.metric}-${params.rangeStart}-${params.rangeStop}.csv`;
+
   switch (metricGraphData.serviceType) {
     case 'rds':
       return {
         mimeType: 'text/csv',
         download: {
-          name: `rds-metrics-${params.metric}-${params.rangeStart}-${params.rangeStop}.csv`,
+          name,
           data: rdsMetricsTemplate.render({
             metricData,
             ...defaultTemplateParams,
@@ -296,7 +298,7 @@ export async function downloadServiceMetrics(ctx: IContext, params: IParameters)
       return {
         mimeType: 'text/csv',
         download: {
-          name: `elasticache-metrics-${params.metric}-${params.rangeStart}-${params.rangeStop}.csv`,
+          name,
           data: elasticacheMetricsTemplate.render({
             metricData,
             ...defaultTemplateParams,
@@ -307,7 +309,7 @@ export async function downloadServiceMetrics(ctx: IContext, params: IParameters)
       return {
         mimeType: 'text/csv',
         download: {
-          name: `cloudfront-metrics-${params.metric}-${params.rangeStart}-${params.rangeStop}.csv`,
+          name,
           data: cloudfrontMetricsTemplate.render({
             metricData,
             ...defaultTemplateParams,


### PR DESCRIPTION
What
----

This adds a link below each chart to download redis and rds backing service
metrics as a CSV. This is so we can provide an alternative for assistive
technology users.

How to review
-------------

Code review

Who can review
---------------

Not me
