### PR TITLE
[#170800032] Fix the instance label

### DIFF
--- a/src/components/charts/line-graph.test.ts
+++ b/src/components/charts/line-graph.test.ts
@@ -98,6 +98,6 @@ describe(summariseSerie, () => {
   it('should fallback to default label if cannot match pattern', () => {
     const summary = summariseSerie({ ...metricSerie, label: 'cf MetricName' });
 
-    expect(summary.label).toEqual('001');
+    expect(summary.label).toEqual('cf MetricName');
   });
 });

--- a/src/components/charts/line-graph.ts
+++ b/src/components/charts/line-graph.ts
@@ -139,7 +139,7 @@ export function drawLineGraph(
 export function summariseSerie(serie: IMetricSerie): IMetricSerieSummary {
   const matches = serie.label.match(/-(\d{3})/);
 
-  const label = matches && matches.length > 1 ? matches[1] : '001';
+  const label = matches && matches.length > 1 ? matches[1] : serie.label;
 
   const latestMetric = serie.metrics.reduce((value, m) => !isNaN(m.value) ? m.value : value, 0);
   const maxMetric = serie.metrics.reduce((value, m) => m.value > value ? m.value : value, 0);

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -35,6 +35,8 @@ import {
   UnsupportedServiceMetricsPage,
 } from './views';
 
+const PERSISTANCE_MESSAGE_370_DAYS = '370 days';
+
 interface IRange {
   readonly period: moment.Duration;
   readonly rangeStart: moment.Moment;
@@ -144,6 +146,7 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
     rangeStop,
   });
   let metrics: ReadonlyArray<IMetricProperties>;
+  let persistancePeriod: string | undefined;
 
   switch (serviceLabel) {
     case 'cdn-route':
@@ -203,6 +206,7 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
         ),
       ).getData(elasticsearchMetricNames, params.serviceGUID, period, rangeStart, rangeStop);
 
+      persistancePeriod = PERSISTANCE_MESSAGE_370_DAYS;
       metrics = elasticSearchMetrics(
         elasticSearchMetricSeries,
         mapValues(elasticSearchMetricSeries, s => s.map(summariseSerie)),
@@ -214,7 +218,11 @@ export async function viewServiceMetrics(ctx: IContext, params: IParameters): Pr
   }
 
   return {
-    body: template.render(<MetricPage {...defaultTemplateParams} metrics={metrics} />),
+    body: template.render(<MetricPage
+      {...defaultTemplateParams}
+      metrics={metrics}
+      persistancePeriod={persistancePeriod}
+    />),
   };
 }
 

--- a/src/components/service-metrics/metrics.tsx
+++ b/src/components/service-metrics/metrics.tsx
@@ -172,6 +172,7 @@ export function rdsMetrics(
     {
       id: 'read-iops',
       title: <>Read <abbr title="Input / Output Operations per Second">IOPS</abbr></>,
+      titleText: 'Read Input / Output Operations per Second',
       description: <>
         How many read operations your database is performing per second. Databases are limited to a number of <abbr
           title="Input / Output Operations per Second">IOPS</abbr> (read + write) based on how big their hard disk is.
@@ -192,6 +193,7 @@ export function rdsMetrics(
     {
       id: 'write-iops',
       title: <>Write <abbr title="Input / Output Operations per Second">IOPS</abbr></>,
+      titleText: 'Write Input / Output Operations per Second',
       description: <>
         How many write operations your database is performing per second. Databases are limited to a number of <abbr
           title="Input / Output Operations per Second">IOPS</abbr> (read + write) based on how big their hard disk is.

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -134,9 +134,14 @@ function Metric(props: IMetricProperties): ReactElement {
           <thead className="govuk-table__head">
             <tr className="govuk-table__row">
               <th scope="col" className={`govuk-table__header ${props.summaries.length === 1 ? 'govuk-visually-hidden' : ''}`}><small>Instance</small></th>
-              {props.summaries.map(series => (
-                <th key={series.label} scope="col" className={`govuk-table__header govuk-table__header--numeric ${props.summaries.length === 1 ? 'govuk-visually-hidden' : ''}`}>
-                  <small>{series.label}</small>
+              {props.summaries.map((series, index) => (
+                <th key={index} scope="col" className={`govuk-table__header govuk-table__header--numeric ${props.summaries.length === 1 ? 'govuk-visually-hidden' : ''}`}>
+                  <small>
+                    {series.label.length > 3
+                      ? <abbr title={series.label}>{String(index).padStart(3, '0')}</abbr>
+                      : series.label
+                    }
+                  </small>
                 </th>
               ))}
             </tr>

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -40,6 +40,7 @@ interface IRangePickerProperties {
   readonly linkTo: RouteLinker;
   readonly service: IServiceInstance;
   readonly period: moment.Duration;
+  readonly persistancePeriod?: string;
 }
 
 interface IPageProperties {
@@ -52,6 +53,7 @@ interface IPageProperties {
 
 interface IMetricPageProperties extends IPageProperties {
   readonly csrf: string;
+  readonly persistancePeriod?: string;
   readonly rangeStart: Date;
   readonly rangeStop: Date;
   readonly serviceLabel: string;
@@ -176,6 +178,13 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
         Each point is an average over <strong className="non-breaking">{props.period.humanize()}</strong>.
       </p>
 
+      {props.persistancePeriod
+        ? <p className="govuk-body">
+            These metrics are retained for up to <strong>{props.persistancePeriod}</strong>.
+            While metrics are experimental, we cannot guarantee a minimum metrics retention period.
+          </p>
+        : <></>}
+
       <details className="govuk-details" data-module="govuk-details">
         <summary className="govuk-details__summary">
           <span className="govuk-details__summary-text">
@@ -283,7 +292,7 @@ export function MetricPage(props: IMetricPageProperties): ReactElement {
       <div className="govuk-width-container">
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds-from-desktop">
-            <p>Currently the available metrics for {props.serviceLabel} are:</p>
+            <p className="govuk-body">Currently the available metrics for {props.serviceLabel} are:</p>
             <ul className="govuk-list">
               {props.metrics.map(metric => (
                 <li key={metric.id}>
@@ -303,6 +312,7 @@ export function MetricPage(props: IMetricPageProperties): ReactElement {
               period={props.period}
               linkTo={props.linkTo}
               service={props.service}
+              persistancePeriod={props.persistancePeriod}
             />
           </div>
         </div>

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -26,6 +26,7 @@ export interface IMetricProperties {
   readonly units: string;
   readonly format?: string;
   readonly title: ReactNode;
+  readonly titleText?: string;
   readonly description: ReactNode;
   readonly chart: SVGElement;
   readonly summaries: ReadonlyArray<IMetricSerieSummary>;
@@ -128,7 +129,9 @@ function Metric(props: IMetricProperties): ReactElement {
 
           <MetricChart chart={props.chart.outerHTML} />
 
-          <a href={downloadLink.toString()} className="govuk-link">Download as a CSV</a>
+          <a href={downloadLink.toString()} className="govuk-link">
+            Download "{props.titleText || props.title}" as a CSV
+          </a>
       </div>
       <div className="govuk-grid-column-one-third-from-desktop">
         <table className="govuk-table">

--- a/src/components/services/controllers.tsx
+++ b/src/components/services/controllers.tsx
@@ -53,7 +53,7 @@ export async function viewService(ctx: IContext, params: IParameters): Promise<I
     body: template.render(<ServicePage
       routePartOf={ctx.routePartOf}
       linkTo={ctx.linkTo}
-      service={service}
+      service={summarisedService}
       organizationGUID={organization.metadata.guid}
       spaceGUID={space.metadata.guid}
     />),


### PR DESCRIPTION
What
----

At the moment, the regex sniffing out the instance number is not taking
an effect which is essentially causing the default `001` to kick in.

This is not that great from the user perspective as misleading and
repeated information is being presented.

We're adjusting the Regex allowing us to correctly get the number out of
the label.

As I'm not very good at regex, I've written a test case that will help
establish issues like that in the future...

How to review
-------------

- Deploy to your env
- Create HA redis
- View its metrics page and see summary table
- Expect `001` and `002`
