### PR TITLE
[Support] Update SSO Org User's Email

### DIFF
--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -740,7 +740,7 @@ export async function updateUser(ctx: IContext, params: IParameters, body: objec
   }
 
   try {
-    errors.push(...validateValues({...userBody, email: user.entity.username}));
+    errors.push(...validateValues({...userBody, email: 'admin@example.com'}));
     if (errors.length > 0) {
       throw new ValidationError(errors);
     }


### PR DESCRIPTION
What
----

For SSO users, the username returned from CF is the user GUID. This hardcodes a
email so that the update function doesn't validate the email address.

We considered other fixes like a flag in the validate function or a call to UAA
but this is the simplest solution for now. A follow up story will be raised.

Prior to reactify, the email wasn't validated on update.
github.com/alphagov/paas-admin/blob/3e40f8dc8c13e7bac54e0a5e47b1feab65bfb5fc/src/components/org-users/org-users.ts#L807-L814

How to review
-------------

Code review

Who can review
---------------

Not me
