### PR TITLE
Tweak the integration pipeline task

### DIFF
--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -14,7 +14,7 @@ run:
     - -ex
     - -c
     - |
-      NODE_ENV=development npm install
+      NODE_ENV=development npm ci
+      TEST_TIMEOUT=60000 npm test
       npm run build
-      TEST_TIMEOUT=60000 NODE_ENV=development npm test
-      TEST_TIMEOUT=60000 NODE_ENV=production npm test
+


### PR DESCRIPTION
What
----

Instead of using the `npm install` we can start using the `npm ci`,
which could get faster and safer when doing these kind of scenarios in
the CI environment. [See more here](https://docs.npmjs.com/cli/ci.html).

We're also removing an extra set of `npm run test`, which in my belief
is just slowing the entire process down.

How to review
-------------

- Sanity check
- Expect a green tick - go into pipeline see if expected test are run