### PR TITLE
Remove the internal session save call

### DIFF
--- a/src/components/account/oidc.ts
+++ b/src/components/account/oidc.ts
@@ -34,7 +34,6 @@ export default class OIDC {
       state,
       response_type: 'code',
     };
-    session.save();
 
     return redirectUrl;
   }
@@ -74,7 +73,6 @@ export default class OIDC {
       await uaa.setUserOrigin(ctx.token.userID, providerName, newUsername);
 
       ctx.session[KEY_STATE] = null;
-      ctx.session.save();
 
       return true;
     } catch (e) {

--- a/src/components/app/app.test-helpers.ts
+++ b/src/components/app/app.test-helpers.ts
@@ -17,10 +17,6 @@ class FakeSession implements CookieSessionInterfaces.CookieSessionObject {
   }
 
   readonly [propertyName: string]: any;
-
-  public save(): void {
-    // Does nothing
-  }
 }
 
 export function createTestContext(ctx?: {}): IContext {


### PR DESCRIPTION
What
----

We have upgraded the library that is responsible for OIDC and uplifting
of our users to SSO ways.[1]

The library has recently deprecated the `save()` function entirely and is
now relying on the express framework returning set-cookie on response to
the end user.[2]

The usage of the `save()` function was causing a TypeError in the
runtime, meaning people were not capable of uplifting their accounts.

[1]: https://github.com/expressjs/cookie-session/releases/tag/2.0.0-rc.1
[2]: https://github.com/expressjs/cookie-session#saving-a-session

How to review
-------------

- `npm run push`
- `cf logs paas-admin`
- Attempt to uplift yourself with non aliased email address...