### PR TITLE
Show the admin fee on the reports pages

### DIFF
--- a/src/components/reports/views.test.tsx
+++ b/src/components/reports/views.test.tsx
@@ -171,6 +171,7 @@ describe(OrganizationsReport, () => {
 describe(CostReport, () => {
   const totalBillables = {
     exVAT: 62.97,
+    exVATWithAdminFee: 69.267,
     incVAT: 75.56,
   };
 
@@ -180,6 +181,7 @@ describe(CostReport, () => {
     quotaGUID: 'quota-guid',
     quotaName: 'quota-name',
     exVAT: 62.97,
+    exVATWithAdminFee: 69.267,
     incVAT: 75.56,
   };
 
@@ -187,6 +189,7 @@ describe(CostReport, () => {
     quotaGUID: 'quota-guid',
     quotaName: 'quota-name',
     exVAT: 62.97,
+    exVATWithAdminFee: 69.267,
     incVAT: 75.56,
   };
 
@@ -204,6 +207,7 @@ describe(CostReport, () => {
     expect($('h2').text()).toContain('2 Billable events');
     expect($('h2').text()).toContain('75.56 Total including VAT');
     expect($('h2').text()).toContain('62.97 Total excluding VAT');
+    expect($('h2').text()).toContain('69.27 Total excluding VAT including fee');
     expect($('h1').text()).toContain(
       'Billables by organisation for January 2020',
     );
@@ -211,9 +215,11 @@ describe(CostReport, () => {
     expect($('th').text()).toContain('org-name');
     expect($('td').text()).toContain('75.56');
     expect($('td').text()).toContain('62.97');
+    expect($('td').text()).toContain('69.27');
     expect($('th').text()).toContain('quota-name');
     expect($('td').text()).toContain('75.56');
     expect($('td').text()).toContain('62.97');
+    expect($('td').text()).toContain('69.27');
   });
 });
 
@@ -222,6 +228,7 @@ describe(CostByServiceReport, () => {
     serviceGroup: 'service-group',
     incVAT: 75.56,
     exVAT: 62.97,
+    exVATWithAdminFee: 69.267,
   };
 
   const billablesByOrganisationAndService = {
@@ -230,6 +237,7 @@ describe(CostByServiceReport, () => {
     serviceGroup: 'service-group',
     incVAT: 75.56,
     exVAT: 62.97,
+    exVATWithAdminFee: 69.267,
   };
 
   const billablesByOrganisationAndSpaceAndService = {
@@ -240,6 +248,7 @@ describe(CostByServiceReport, () => {
     serviceGroup: 'service-group',
     incVAT: 75.56,
     exVAT: 62.97,
+    exVATWithAdminFee: 69.267,
   };
 
   it('should parse the cost by service report', () => {
@@ -265,6 +274,7 @@ describe(CostByServiceReport, () => {
     expect($('td').text()).toContain('service-group');
     expect($('td').text()).toContain('75.56');
     expect($('td').text()).toContain('62.97');
+    expect($('td').text()).toContain('69.27');
     expect($('td').text()).toContain('org-name');
     expect($('td').text()).toContain('space-name');
   });

--- a/src/components/reports/views.tsx
+++ b/src/components/reports/views.tsx
@@ -25,6 +25,7 @@ interface IOrganizationsReportProperties {
 interface ICostable {
   readonly incVAT: number;
   readonly exVAT: number;
+  readonly exVATWithAdminFee: number;
 }
 
 interface IOrgCostRecord extends ICostable {
@@ -259,6 +260,12 @@ export function CostReport(props: ICostReportProperties): ReactElement {
             <span className="govuk-caption-m">Total excluding VAT</span>
           </h2>
         </div>
+        <div className="govuk-grid-column-one-quarter">
+          <h2 className="govuk-heading-m">
+            £{props.totalBillables.exVATWithAdminFee.toFixed(2)}{' '}
+            <span className="govuk-caption-m">Total excluding VAT including fee</span>
+          </h2>
+        </div>
       </div>
 
       <h1 className="govuk-heading-l">
@@ -286,6 +293,12 @@ export function CostReport(props: ICostReportProperties): ReactElement {
             >
               Excluding VAT
             </th>
+            <th
+              className="govuk-table__header govuk-table__header--numeric"
+              scope="col"
+            >
+              Excluding VAT including fee
+            </th>
           </tr>
         </thead>
         <tbody className="govuk-table__body">
@@ -300,6 +313,9 @@ export function CostReport(props: ICostReportProperties): ReactElement {
               </td>
               <td className="govuk-table__cell govuk-table__cell--numeric">
                 £{record.exVAT.toFixed(2)}
+              </td>
+              <td className="govuk-table__cell govuk-table__cell--numeric">
+                £{record.exVATWithAdminFee.toFixed(2)}
               </td>
             </tr>
           ))}
@@ -327,6 +343,12 @@ export function CostReport(props: ICostReportProperties): ReactElement {
             >
               Excluding VAT
             </th>
+            <th
+              className="govuk-table__header govuk-table__header--numeric"
+              scope="col"
+            >
+              Excluding VAT including fee
+            </th>
           </tr>
         </thead>
         <tbody className="govuk-table__body">
@@ -340,6 +362,9 @@ export function CostReport(props: ICostReportProperties): ReactElement {
               </td>
               <td className="govuk-table__cell govuk-table__cell--numeric">
                 £{record.exVAT.toFixed(2)}
+              </td>
+              <td className="govuk-table__cell govuk-table__cell--numeric">
+                £{record.exVATWithAdminFee.toFixed(2)}
               </td>
             </tr>
           ))}
@@ -372,6 +397,12 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
             >
               Excluding VAT
             </th>
+            <th
+              className="govuk-table__header govuk-table__header--numeric"
+              scope="col"
+            >
+              Excluding VAT including fee
+            </th>
           </tr>
         </thead>
         <tbody className="govuk-table__body">
@@ -383,6 +414,9 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
               </td>
               <td className="govuk-table__cell govuk-table__cell--numeric">
                 £{record.exVAT.toFixed(2)}
+              </td>
+              <td className="govuk-table__cell govuk-table__cell--numeric">
+                £{record.exVATWithAdminFee.toFixed(2)}
               </td>
             </tr>
           ))}
@@ -415,6 +449,12 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
             >
               Excluding VAT
             </th>
+            <th
+              className="govuk-table__header govuk-table__header--numeric"
+              scope="col"
+            >
+              Excluding VAT including fee
+            </th>
           </tr>
         </thead>
         <tbody className="govuk-table__body">
@@ -429,6 +469,9 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
               </td>
               <td className="govuk-table__cell govuk-table__cell--numeric">
                 £{record.exVAT.toFixed(2)}
+              </td>
+              <td className="govuk-table__cell govuk-table__cell--numeric">
+                £{record.exVATWithAdminFee.toFixed(2)}
               </td>
             </tr>
           ))}
@@ -464,6 +507,12 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
             >
               Excluding VAT
             </th>
+            <th
+              className="govuk-table__header govuk-table__header--numeric"
+              scope="col"
+            >
+              Excluding VAT including fee
+            </th>
           </tr>
         </thead>
         <tbody className="govuk-table__body">
@@ -479,6 +528,9 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
               </td>
               <td className="govuk-table__cell govuk-table__cell--numeric">
                 £{record.exVAT.toFixed(2)}
+              </td>
+              <td className="govuk-table__cell govuk-table__cell--numeric">
+                £{record.exVATWithAdminFee.toFixed(2)}
               </td>
             </tr>
           ))}


### PR DESCRIPTION
What
----

There has been some confusion about the admin fee being present or not present on each page

This PR adds a new column on the reports:
- cost
- cost by service
pages, which show the cost excluding VAT, including admin fee, which is what the PMO team charge our users

![image](https://user-images.githubusercontent.com/1482692/73679880-31fd5e00-46b3-11ea-9782-1fba7dcec614.png)
_Screenshot of cost report in my development environment_

![image](https://user-images.githubusercontent.com/1482692/73679925-44779780-46b3-11ea-931a-7b09b795002a.png)
_Screenshot of cost by service report in my development environment_


How to review
-------------

Code review

Check out my dev env

Who can review
---------------

Not @tlwr