### PR TITLE
Change wording for Graphs

### DIFF
--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -234,8 +234,11 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
       </p>
 
       <p className="govuk-body">
-        Each point is an average over{' '}
-        <strong className="non-breaking">{props.period.humanize()}</strong>.
+        Each point on a graph is aggregated over
+        {' '}
+        <strong className="non-breaking">{props.period.humanize()}</strong>
+        {' '}
+        of data.
       </p>
 
       {props.persistancePeriod ? (


### PR DESCRIPTION
What
----

At the moment, there is a helper text on the top of the graphs page,
saying:

> Each point is an average over *2 hours*.

This is vague and sometimes not very well representative of the graphs
themselves.

We are making it a little more descriptive to say:

> Each point on a graph is aggregated over *2 hours* of data.

Which we hope will produce a more meaningful message for the tenants.

How to review
-------------

- Sanity check
