### PR TITLE
Increase left axis padding

### DIFF
--- a/src/components/charts/line-graph.ts
+++ b/src/components/charts/line-graph.ts
@@ -20,7 +20,7 @@ const padding = {
   top: 25,
   right: 30,
   bottom: 132,
-  left: 50,
+  left: 90,
 };
 
 export function drawLineGraph(


### PR DESCRIPTION
What
----

There is a potential to us to have labels so big, out run the available
space.

Though, we hope it will be `100B` which is 4 characters long, it's
potentially possible to get `999.99GiB` which is quickly 9 characters
long...

Increasing padding, should give some extra room, but will make smaller
labels look ugly.

How to review
-------------

- Sanity check
- Propose better approach