### PR TITLE
Slightly better calculator

### DIFF
--- a/src/components/calculator/controllers.test.tsx
+++ b/src/components/calculator/controllers.test.tsx
@@ -95,12 +95,12 @@ describe('calculator test suite', () => {
     const response = await getCalculator(ctx, {});
 
     expect(response.body).toContain('Pricing calculator');
-    expect(response.body).toMatch(/\bapp\b/);
-    expect(response.body).toMatch(/\bpostgres\b/);
-    expect(response.body).toMatch(/\bmysql\b/);
-    expect(response.body).toMatch(/\bredis\b/);
-    expect(response.body).toMatch(/\belasticsearch\b/);
-    expect(response.body).toMatch(/\baws-s3-bucket\b/);
+    expect(response.body).toMatch(/\bCompute\b/);
+    expect(response.body).toMatch(/\bPostgres\b/);
+    expect(response.body).toMatch(/\bMySQL\b/);
+    expect(response.body).toMatch(/\bRedis\b/);
+    expect(response.body).toMatch(/\bElasticsearch\b/);
+    expect(response.body).toMatch(/\bAmazon S3\b/);
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -189,6 +189,10 @@ describe('calculator test suite', () => {
           numberOfNodes: '1',
         },
         {
+          planGUID: '00000000-0000-0000-0000-000000000001',
+          numberOfNodes: '2',
+        },
+        {
           planGUID: '00000000-0000-0000-0000-000000000002',
           numberOfNodes: '2',
         },
@@ -197,7 +201,7 @@ describe('calculator test suite', () => {
 
     expect(response.body).toContain('app');
     expect(response.body).toContain('£19.98');
-    expect(response.body).toContain('postgres');
+    expect(response.body).toContain('Postgres');
     expect(response.body).toContain('£13.32');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
@@ -250,12 +254,12 @@ describe('calculator test suite', () => {
       ],
     });
 
-    expect(response.body).toContain('postgres');
-    expect(response.body).toContain('app');
+    expect(response.body).toContain('Postgres');
+    expect(response.body).toContain('Compute');
     if (response.body && typeof response.body === 'string') {
-      const idxPostgres = response.body.indexOf('postgres');
-      const idxApp = response.body.indexOf('app');
-      expect(idxPostgres > idxApp).toBeTruthy(); // expected postgres to appear after app
+      const idxPostgres = response.body.indexOf('Postgres');
+      const idxCompute = response.body.indexOf('Compute');
+      expect(idxPostgres > idxCompute).toBeTruthy(); // expected postgres to appear after app
     }
     expect(
       spacesMissingAroundInlineElements(response.body as string),
@@ -290,7 +294,7 @@ describe('calculator test suite', () => {
     ).toHaveLength(0);
   });
 
-  it('should show postgres plan wih version', async () => {
+  it('should show postgres plan and sort the versions', async () => {
     const rangeStart = moment()
       .startOf('month')
       .format('YYYY-MM-DD');
@@ -337,7 +341,16 @@ describe('calculator test suite', () => {
       );
 
     const response = await getCalculator(ctx, {});
-    expect(response.body).toMatch(/postgres\s+9.6/);
+    expect(response.body).toMatch(/Postgres/);
+
+    const planIndices = ['xlarge-9.6', 'medium-9.6', 'tiny-9.6']
+      .map(plan => response.body!.toString().indexOf(plan))
+    ;
+
+    const sortedPlanIndices = planIndices.slice().sort();
+
+    expect(planIndices).toEqual(sortedPlanIndices);
+
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -426,8 +439,8 @@ describe('calculator test suite', () => {
       );
 
     const response = await getCalculator(ctx, {});
-    expect(response.body).toContain('aws-s3-bucket');
-    expect(response.body).not.toMatch(/aws-s3-bucket\s+default/);
+    expect(response.body).toContain('Amazon S3');
+    expect(response.body).not.toMatch(/Amazon S3\s+default/);
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);

--- a/src/components/calculator/controllers.test.tsx
+++ b/src/components/calculator/controllers.test.tsx
@@ -262,7 +262,7 @@ describe('calculator test suite', () => {
     ).toHaveLength(0);
   });
 
-  it('should blacklist compose plan', async () => {
+  it('should filter out compose plans', async () => {
     const rangeStart = moment()
       .startOf('month')
       .format('YYYY-MM-DD');

--- a/src/components/calculator/controllers.tsx
+++ b/src/components/calculator/controllers.tsx
@@ -19,19 +19,17 @@ import * as formulaGrammar from './formulaGrammar.pegjs';
 
 interface IVersionedPricingPlan extends IPricingPlan {
   version: string;
-  variant: string;
 }
 
 function toVersionedPricingPlans(plan: IPricingPlan): IVersionedPricingPlan {
-  const parts = plan.planName.split('-');
-  const version = parts.slice(-1).join('');
-  const variant = parts.slice(0, -1).join('-');
+  let version = 'unknown';
 
-  return {
-    ...plan,
-    version,
-    variant,
-  };
+  const versions = plan.planName.match(/\d+(.[\d]+)?/);
+  if (versions !== null) {
+    version = version[0];
+  }
+
+  return { ...plan, version };
 }
 
 function safelistServices(p: IPricingPlan): boolean {

--- a/src/components/calculator/controllers.tsx
+++ b/src/components/calculator/controllers.tsx
@@ -48,7 +48,7 @@ function safelistServices(p: IPricingPlan): boolean {
   return safelist.some(name => name === p.serviceName);
 }
 
-function blacklistCompose(p: IPricingPlan): boolean {
+function filterComposeIOServices(p: IPricingPlan): boolean {
   return !/compose/.test(p.planName);
 }
 
@@ -95,7 +95,7 @@ export async function getCalculator(
     })
   )
     .filter(safelistServices)
-    .filter(blacklistCompose)
+    .filter(filterComposeIOServices)
     .map(toVersionedPricingPlans)
     .sort(bySize);
   const state = {

--- a/src/layouts/helpers.tsx
+++ b/src/layouts/helpers.tsx
@@ -20,7 +20,7 @@ export function percentage(value: number, ofValue: number): string {
   return `${result.toFixed(1)}%`;
 }
 
-export function bytesConvert(startingBytes: number): IConvertedBytes {
+export function bytesConvert(startingBytes: number, precision = 2): IConvertedBytes {
   let bytes = startingBytes;
   const units = ['KiB', 'MiB', 'GiB', 'TiB'];
 
@@ -37,12 +37,12 @@ export function bytesConvert(startingBytes: number): IConvertedBytes {
   return {
     long: longUnits[units[u]],
     short: units[u],
-    value: bytes.toFixed(2),
+    value: bytes.toFixed(precision),
   };
 }
 
-export function bytesToHuman(startingBytes: number): ReactElement {
-  const converted = bytesConvert(startingBytes);
+export function bytesToHuman(startingBytes: number, precision = 2): ReactElement {
+  const converted = bytesConvert(startingBytes, precision);
 
   return (
     <>

--- a/src/lib/billing/billing.ts
+++ b/src/lib/billing/billing.ts
@@ -214,7 +214,7 @@ function parsePricingPlan(plan: IPricingPlanResponse): IPricingPlan {
 
   return {
     serviceName,
-    planName: planName.join(''),
+    planName: planName.join('-'),
     planGUID: plan.plan_guid,
     validFrom: parseTimestamp(plan.valid_from),
     components: plan.components.map(parseComponentResponse),


### PR DESCRIPTION
What
----

The calculator became not particularly usable because it tried to separate out Postgres versions into separate rows, which was gross after adding high-iops plans.

Instead, let's aggregate the plans into rows, and also reformat the page to make it read better.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1482692/74135487-4c1fca80-4be4-11ea-9623-c059ad228ee6.png)|![image](https://user-images.githubusercontent.com/1482692/74135526-580b8c80-4be4-11ea-9972-240899cc4512.png)|

How to review
-------------

Check that the plans are sorted correctly:

![image](https://user-images.githubusercontent.com/1482692/74135406-2b577500-4be4-11ea-83f0-dd32199c4b0c.png)
_The plans should be sorted by version number, then by size_

Code review

CI

Have a noodle [on the calculator deployed to my dev env](https://admin.tlwr.dev.cloudpipeline.digital/calculator?rangeStart=2020-02-01&rangeStop=2020-02-29&items%5B0%5D%5BplanGUID%5D=b35302f3-ac97-4d74-876c-fd9b5df803a2&items%5B0%5D%5BnumberOfNodes%5D=&items%5B0%5D%5BmemoryInMB%5D=&items%5B1%5D%5BplanGUID%5D=0cc655f7-337b-4caf-9544-cbea6f30ccd4&items%5B1%5D%5BnumberOfNodes%5D=&items%5B1%5D%5BmemoryInMB%5D=&items%5B2%5D%5BplanGUID%5D=f4d4b95a-f55e-4593-8d54-3364c25798c4&items%5B2%5D%5BnumberOfNodes%5D=1&items%5B2%5D%5BmemoryInMB%5D=64&items%5B3%5D%5BplanGUID%5D=b6949ea7-5c98-4c69-b981-4b5318ea8b7c&items%5B3%5D%5BnumberOfNodes%5D=&items%5B3%5D%5BmemoryInMB%5D=&items%5B4%5D%5BplanGUID%5D=c84d1bef-9500-4ce9-88b2-c0bd421bbf8a)

Who can review
---------------

Not @tlwr
