### PR TITLE
Fix the menu handle on mobile devices

### DIFF
--- a/src/layouts/_header.scss
+++ b/src/layouts/_header.scss
@@ -1,35 +1,68 @@
 a.paas-govuk-tag {
-  @extend .govuk-tag;
+  @include govuk-media-query(tablet) {
+    display: inline-block;
 
-  &:visited, &:hover, &:link {
-    color: #fff;
-  }
+    outline: 2px solid transparent;
+    outline-offset: -2px;
 
-  &:hover {
-    border-bottom: 3px solid #fff;
-    margin-bottom: -3px;
-  }
+    color: govuk-colour("white");
+    background-color: govuk-colour("blue");
+    letter-spacing: 1px;
 
-  &.paas-govuk-tag-london {
-    background-color: #005ea5;
-  }
+    text-decoration: none;
+    text-transform: uppercase;
 
-  &.paas-govuk-tag-ireland {
-    background-color: #006435;
+    @if $govuk-use-legacy-font {
+      @include govuk-font($size: 16, $weight: bold, $line-height: 1.25);
+      padding-top: 4px;
+      padding-right: 8px;
+      padding-bottom: 1px;
+      padding-left: 8px;
+    } @else {
+      @include govuk-font($size: 16, $weight: bold, $line-height: 1);
+      padding-top: 5px;
+      padding-right: 8px;
+      padding-bottom: 4px;
+      padding-left: 8px;
+    }
+
+    &:visited, &:hover, &:link {
+      color: #fff;
+      text-decoration: none;
+    }
+
+    &:hover {
+      border-bottom: 3px solid #fff;
+      margin-bottom: -3px;
+    }
+
+    &.paas-govuk-tag-london {
+      background-color: #005ea5;
+    }
+
+    &.paas-govuk-tag-ireland {
+      background-color: #006435;
+    }
+
+    span {
+      display: none;
+    }
   }
 }
 
-/* GOV.UK Platform-as-a-Service is too long */
-.govuk-header__logo {
-  width: 50%;
-}
+@include govuk-media-query(tablet) {
+  /* GOV.UK Platform-as-a-Service is too long */
+  .govuk-header__logo {
+    width: 50%;
+  }
 
-.govuk-header__content {
-  width: 50%;
-  text-align: right;
-}
+  .govuk-header__content {
+    width: 50%;
+    text-align: right;
+  }
 
-/* Link to pricing on right edge of phase banner */
-.govuk-phase-banner__text {
-  width: 100%;
+  /* Link to pricing on right edge of phase banner */
+  .govuk-phase-banner__text {
+    width: 100%;
+  }
 }

--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -91,7 +91,7 @@ export function Header(params: IHeaderProperties): ReactElement {
           <button
             type="button"
             role="button"
-            className="govuk-header__menu-button js-header-toggle"
+            className="govuk-header__menu-button govuk-js-header-toggle"
             aria-controls="navigation"
             aria-label="Show or hide Top Level Navigation"
           >
@@ -126,10 +126,11 @@ export function Header(params: IHeaderProperties): ReactElement {
               <li className="govuk-header__navigation-item">
                 <a
                   href="https://www.cloud.service.gov.uk/sign-in"
-                  title="Switch region"
-                  className={`paas-govuk-tag paas-govuk-tag-${params.location.toLowerCase()}`}
+                  title="Switch to a different region"
+                  className={`govuk-header__link paas-govuk-tag paas-govuk-tag-${params.location.toLowerCase()}`}
+                  aria-label={`Current region: ${params.location.toLowerCase()}. Switch to a different region.`}
                 >
-                  {params.location}
+                  <span>Region:</span> {params.location}
                 </a>
               </li>
             </ul>


### PR DESCRIPTION
What
----

At the moment, this particular functionality is broken and prevents
administrators using the tool on mobile devices.

We're adding fixes to make sure the menu is mobile-first. This means, we
cannot just extend the `govuk-tag` class and have to set the values
manually.

We're also making some accessibility changes to the region link, to
indicate more precisely, what it's doing.

How to review
-------------

- Run locally
- Make sure the menu continues to be usable
- Resize your window pretending you're on mobile device, and attempt to use menu