### PR TITLE
Create org

### DIFF
--- a/src/components/app/app.test-helpers.ts
+++ b/src/components/app/app.test-helpers.ts
@@ -39,7 +39,7 @@ export function createTestContext(ctx?: {}): IContext {
       ['secret'],
     ),
     viewContext: {
-      csrf: '',
+      csrf: 'CSRF_TOKEN',
       location: config.location,
       isPlatformAdmin: false,
     },

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -240,6 +240,17 @@ const router = new Router([
     name: 'platform-admin.redirect',
     path: '/platform-admin',
   },
+  {
+    action: platformAdmin.createOrganizationForm,
+    name: 'platform-admin.create-organization.form',
+    path: '/platform-admin/create-org',
+  },
+  {
+    action: platformAdmin.createOrganization,
+    method: 'post',
+    name: 'platform-admin.create-organization',
+    path: '/platform-admin/create-org',
+  },
 ]);
 
 export default router;

--- a/src/components/errors/types.ts
+++ b/src/components/errors/types.ts
@@ -1,0 +1,4 @@
+export interface IValidationError {
+  readonly field: string;
+  readonly message: string;
+}

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import { capitalize } from '../../layouts';
 import { Tick } from '../../layouts/partials';
@@ -20,7 +20,7 @@ interface IDeleteConfirmationPageProperties {
 }
 
 interface ISuccessPageProperties {
-  readonly children: string;
+  readonly children: ReactNode;
   readonly linkTo: RouteLinker;
   readonly organizationGUID: string;
 }

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -10,6 +10,7 @@ import {
   OrganizationUserRoles,
 } from '../../lib/cf/types';
 import { RouteLinker } from '../app';
+import { IValidationError } from '../errors/types';
 
 interface IDeleteConfirmationPageProperties {
   readonly csrf: string;
@@ -55,11 +56,6 @@ interface IPermissionTableProperties {
   readonly organization: IOrganization;
   readonly spaces: ReadonlyArray<ISpace>;
   readonly values: IRoleValues;
-}
-
-export interface IValidationError {
-  readonly field: string;
-  readonly message: string;
 }
 
 interface IEditPageProperties extends IPermissionTableProperties {

--- a/src/components/platform-admin/controllers.test.tsx
+++ b/src/components/platform-admin/controllers.test.tsx
@@ -13,6 +13,7 @@ import { CLOUD_CONTROLLER_ADMIN } from '../auth/has-role';
 import { createOrganization, createOrganizationForm, viewHomepage } from './controllers';
 
 jest.mock('../../lib/cf');
+const mockOrg = { metadata: { annotations: { owner: 'TEST_OWNER' } } };
 
 const tokenKey = 'secret';
 
@@ -129,9 +130,15 @@ describe(createOrganizationForm, () => {
       const token = new Token(accessToken, [tokenKey]);
 
       ctx = createTestContext({ token });
+
+      // @ts-ignore
+      CloudFoundryClient.mockClear();
     });
 
     it('should print the creation form correctly', async () => {
+      // @ts-ignore
+      CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ mockOrg ]));
+
       const response = await createOrganizationForm(ctx, {});
 
       expect(response.body).toBeDefined();
@@ -187,6 +194,9 @@ describe(createOrganization, () => {
     });
 
     it('should throw errors when field validation fails', async () => {
+      // @ts-ignore
+      CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ mockOrg ]));
+
       const response = await createOrganization(ctx, {}, {});
 
       expect(response.status).toEqual(422);

--- a/src/components/platform-admin/controllers.test.tsx
+++ b/src/components/platform-admin/controllers.test.tsx
@@ -1,14 +1,18 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 import cheerio from 'cheerio';
 import jwt from 'jsonwebtoken';
 
 import { spacesMissingAroundInlineElements } from '../../layouts/react-spacing.test';
+import CloudFoundryClient from '../../lib/cf';
 import { IResponse } from '../../lib/router';
 import { createTestContext } from '../app/app.test-helpers';
 import { IContext } from '../app/context';
 import { Token } from '../auth';
 import { CLOUD_CONTROLLER_ADMIN } from '../auth/has-role';
 
-import { viewHomepage } from './controllers';
+import { createOrganization, createOrganizationForm, viewHomepage } from './controllers';
+
+jest.mock('../../lib/cf');
 
 const tokenKey = 'secret';
 
@@ -84,6 +88,131 @@ describe(viewHomepage, () => {
       expect(
         spacesMissingAroundInlineElements(response.body as string),
       ).toHaveLength(0);
+    });
+  });
+});
+
+describe(createOrganizationForm, () => {
+  describe('when not a platform admin', () => {
+    const time = Math.floor(Date.now() / 1000);
+    const rawToken = {
+      user_id: 'uaa-id-253',
+      scope: [],
+      exp: time + 24 * 60 * 60,
+      origin: 'uaa',
+    };
+    const accessToken = jwt.sign(rawToken, tokenKey);
+
+    const token = new Token(accessToken, [tokenKey]);
+    const ctx: IContext = createTestContext({ token });
+
+    it('should return an error', async () => {
+      await expect(viewHomepage(ctx, {})).rejects.toThrow(
+        /Not a platform admin/,
+      );
+    });
+  });
+
+  describe('when platform admin', () => {
+    let ctx: IContext;
+
+    beforeEach(() => {
+      const time = Math.floor(Date.now() / 1000);
+      const rawToken = {
+        user_id: 'uaa-id-253',
+        scope: [CLOUD_CONTROLLER_ADMIN],
+        exp: time + 24 * 60 * 60,
+        origin: 'uaa',
+      };
+      const accessToken = jwt.sign(rawToken, tokenKey);
+
+      const token = new Token(accessToken, [tokenKey]);
+
+      ctx = createTestContext({ token });
+    });
+
+    it('should print the creation form correctly', async () => {
+      const response = await createOrganizationForm(ctx, {});
+
+      expect(response.body).toBeDefined();
+      expect(response.body).toContain('CSRF_TOKEN');
+      expect(response.body).toContain('Create Organisation');
+      expect(response.body).toContain('id="organization"');
+      expect(response.body).toContain('id="owner"');
+      expect(response.body).toContain('<button');
+    });
+  });
+});
+
+describe(createOrganization, () => {
+  describe('when not a platform admin', () => {
+    const time = Math.floor(Date.now() / 1000);
+    const rawToken = {
+      user_id: 'uaa-id-253',
+      scope: [],
+      exp: time + 24 * 60 * 60,
+      origin: 'uaa',
+    };
+    const accessToken = jwt.sign(rawToken, tokenKey);
+
+    const token = new Token(accessToken, [tokenKey]);
+    const ctx: IContext = createTestContext({ token });
+
+    it('should return an error', async () => {
+      await expect(viewHomepage(ctx, {})).rejects.toThrow(
+        /Not a platform admin/,
+      );
+    });
+  });
+
+  describe('when platform admin', () => {
+    let ctx: IContext;
+
+    beforeEach(() => {
+      const time = Math.floor(Date.now() / 1000);
+      const rawToken = {
+        user_id: 'uaa-id-253',
+        scope: [CLOUD_CONTROLLER_ADMIN],
+        exp: time + 24 * 60 * 60,
+        origin: 'uaa',
+      };
+      const accessToken = jwt.sign(rawToken, tokenKey);
+
+      const token = new Token(accessToken, [tokenKey]);
+
+      ctx = createTestContext({ token });
+
+      // @ts-ignore
+      CloudFoundryClient.mockClear();
+    });
+
+    it('should throw errors when field validation fails', async () => {
+      const response = await createOrganization(ctx, {}, {});
+
+      expect(response.status).toEqual(422);
+      expect(response.body).toBeDefined();
+      expect(response.body).toContain('<form');
+      expect(response.body).toContain('There is a problem');
+      expect(response.body).not.toContain('Success');
+    });
+
+    it('should printout a success page', async () => {
+      // @ts-ignore
+      CloudFoundryClient.prototype.v3CreateOrganization.mockReturnValueOnce(Promise.resolve({ guid: 'ORG_GUID' }));
+      // @ts-ignore
+      CloudFoundryClient.prototype.v3CreateSpace.mockReturnValueOnce(Promise.resolve({}));
+
+      const response = await createOrganization(ctx, {}, {
+        organization: 'new-organization',
+        owner: 'Organisation Owner',
+      });
+
+      expect(CloudFoundryClient.prototype.v3CreateOrganization).toHaveBeenCalled();
+      expect(CloudFoundryClient.prototype.v3CreateSpace).toHaveBeenCalled();
+      expect(response.status).toBeUndefined();
+      expect(response.body).toBeDefined();
+      expect(response.body).not.toContain('<form');
+      expect(response.body).toContain('Success');
     });
   });
 });

--- a/src/components/platform-admin/controllers.tsx
+++ b/src/components/platform-admin/controllers.tsx
@@ -28,12 +28,25 @@ function throwErrorIfNotAdmin({ token }: { token: Token }): void {
 export async function createOrganizationForm(ctx: IContext, _params: IParameters): Promise<IResponse> {
   throwErrorIfNotAdmin(ctx);
 
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const orgs = await cf.v3Organizations();
+  const owners = Array.from(new Set(orgs
+    .filter(org => !!org.metadata.annotations.owner)
+    .map(org => ({ name: org.name, owner: org.metadata.annotations.owner! }))
+    .sort()));
+
   const template = new Template(ctx.viewContext, TITLE_CREATE_ORG);
 
   return {
     body: template.render(<CreateOrganizationPage
       csrf={ctx.viewContext.csrf}
       linkTo={ctx.linkTo}
+      owners={owners}
     />),
   };
 }
@@ -43,26 +56,33 @@ export async function createOrganization(
 ): Promise<IResponse> {
   throwErrorIfNotAdmin(ctx);
 
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
   const template = new Template(ctx.viewContext, TITLE_CREATE_ORG);
 
   const errors = validateNewOrganization(body);
   if (errors.length > 0) {
+    const orgs = await cf.v3Organizations();
+    const owners = Array.from(new Set(orgs
+      .filter(org => !!org.metadata.annotations.owner)
+      .map(org => ({ name: org.name, owner: org.metadata.annotations.owner! }))
+      .sort()));
+
     return {
       body: template.render(<CreateOrganizationPage
         errors={errors}
         csrf={ctx.viewContext.csrf}
         linkTo={ctx.linkTo}
         values={body}
+        owners={owners}
       />),
       status: 422,
     };
   }
-
-  const cf = new CloudFoundryClient({
-    accessToken: ctx.token.accessToken,
-    apiEndpoint: ctx.app.cloudFoundryAPI,
-    logger: ctx.app.logger,
-  });
 
   const organization = await cf.v3CreateOrganization({
     name: body.organization!,

--- a/src/components/platform-admin/controllers.tsx
+++ b/src/components/platform-admin/controllers.tsx
@@ -2,19 +2,93 @@ import React from 'react';
 
 import { IParameters, IResponse, NotAuthorisedError } from '../../lib/router';
 
+import CloudFoundryClient from '../../lib/cf';
 import { Template } from '../../layouts';
+import { Token } from '../auth';
 import { IContext } from '../app/context';
-import { PlatformAdministratorPage } from './views';
+
+import { validateNewOrganization } from './validators';
+import {
+  CreateOrganizationPage,
+  CreateOrganizationSuccessPage,
+  INewOrganizationUserBody,
+  PlatformAdministratorPage,
+} from './views';
+
+const TITLE_CREATE_ORG = 'Create Organisation';
+
+function throwErrorIfNotAdmin({ token }: { token: Token }): void {
+  if (token.hasAdminScopes()) {
+    return;
+  }
+
+  throw new NotAuthorisedError('Not a platform admin');
+}
+
+export async function createOrganizationForm(ctx: IContext, _params: IParameters): Promise<IResponse> {
+  throwErrorIfNotAdmin(ctx);
+
+  const template = new Template(ctx.viewContext, TITLE_CREATE_ORG);
+
+  return {
+    body: template.render(<CreateOrganizationPage
+      csrf={ctx.viewContext.csrf}
+      linkTo={ctx.linkTo}
+    />),
+  };
+}
+
+export async function createOrganization(
+  ctx: IContext, _params: IParameters, body: INewOrganizationUserBody,
+): Promise<IResponse> {
+  throwErrorIfNotAdmin(ctx);
+
+  const template = new Template(ctx.viewContext, TITLE_CREATE_ORG);
+
+  const errors = validateNewOrganization(body);
+  if (errors.length > 0) {
+    return {
+      body: template.render(<CreateOrganizationPage
+        errors={errors}
+        csrf={ctx.viewContext.csrf}
+        linkTo={ctx.linkTo}
+        values={body}
+      />),
+      status: 422,
+    };
+  }
+
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const organization = await cf.v3CreateOrganization({
+    name: body.organization!,
+    metadata: {
+      annotations: { owner: body.owner! },
+    },
+  });
+
+  await cf.v3CreateSpace({
+    name: 'sandbox',
+    relationships: { organization: { data: { guid: organization.guid } } },
+  });
+
+  return {
+    body: template.render(<CreateOrganizationSuccessPage
+      linkTo={ctx.linkTo}
+      organizationGUID={organization.guid}
+    />),
+  };
+}
 
 export async function viewHomepage(
   ctx: IContext,
   _params: IParameters,
 ): Promise<IResponse> {
-  const token = ctx.token;
-
-  if (!token.hasAdminScopes()) {
-    throw new NotAuthorisedError('Not a platform admin');
-  }
+  throwErrorIfNotAdmin(ctx);
 
   const template = new Template(ctx.viewContext, 'Platform Administrator');
 

--- a/src/components/platform-admin/validators.test.ts
+++ b/src/components/platform-admin/validators.test.ts
@@ -1,0 +1,27 @@
+import { validateNewOrganization } from './validators';
+
+describe(validateNewOrganization, () => {
+  it('should return no validation errors when correct input has been provided', () => {
+    const validation = validateNewOrganization({
+      organization: 'new-organization',
+      owner: 'Organization Owner',
+    });
+
+    expect(validation).toHaveLength(0);
+  });
+
+  it('should return validation errors when nothing has been submitted', () => {
+    const validation = validateNewOrganization({});
+
+    expect(validation).toHaveLength(2);
+  });
+
+  it('should return validation errors when organisation name does not meet our standards', () => {
+    const validation = validateNewOrganization({
+      organization: 'new_organization',
+      owner: 'Organization Owner',
+    });
+
+    expect(validation).toHaveLength(1);
+  });
+});

--- a/src/components/platform-admin/validators.ts
+++ b/src/components/platform-admin/validators.ts
@@ -1,0 +1,22 @@
+import { SLUG_REGEX } from '../../layouts';
+import { IValidationError } from '../errors/types';
+
+import { INewOrganizationUserBody } from './views';
+
+export function validateNewOrganization(body: INewOrganizationUserBody): ReadonlyArray<IValidationError> {
+  const errors: Array<IValidationError> = [];
+
+  if (!body.organization) {
+    errors.push({ field: 'organization', message: 'Organisation name is a required field' });
+  }
+
+  if (body.organization && !body.organization.match(SLUG_REGEX)) {
+    errors.push({ field: 'organization', message: 'Organisation name must be all lowercase and hyphen separated' });
+  }
+
+  if (!body.owner) {
+    errors.push({ field: 'owner', message: 'Owner is a required field' });
+  }
+
+  return errors;
+}

--- a/src/components/platform-admin/views.test.tsx
+++ b/src/components/platform-admin/views.test.tsx
@@ -10,7 +10,7 @@ function linker(route: string, params?: IParameters): string {
 
 describe(CreateOrganizationPage, () => {
   it('should have csrf token', () => {
-    const markup = shallow(<CreateOrganizationPage csrf="CSRF_TOKEN" linkTo={linker} />);
+    const markup = shallow(<CreateOrganizationPage csrf="CSRF_TOKEN" linkTo={linker} owners={[]} />);
 
     expect(markup.render().find('[name=_csrf]')).toHaveLength(1);
     expect(markup.render().find('[name=_csrf]').prop('value')).toEqual('CSRF_TOKEN');
@@ -21,11 +21,16 @@ describe(CreateOrganizationPage, () => {
       csrf="CSRF_TOKEN"
       linkTo={linker}
       values={{ organization: '<script>alert("pwnd by test");</script>' }}
+      owners={[{ name: `<em>hacking</em>`, owner: '<strong>Hackers</strong>' }]}
     />);
 
     expect(markup.find('input#organization')).toHaveLength(1);
     expect(markup.find('input#organization').html()).not.toContain('<script>');
     expect(markup.find('input#organization').html()).toContain('&lt;script&gt;');
+    expect(markup.find('table').html()).not.toContain('<strong>');
+    expect(markup.find('table').html()).toContain('&lt;strong&gt;');
+    expect(markup.find('table').html()).not.toContain('<em>');
+    expect(markup.find('table').html()).toContain('&lt;em&gt;');
     expect(markup.find('input#organization').html()).toContain('&quot;pwnd by test&quot;');
   });
 
@@ -34,6 +39,7 @@ describe(CreateOrganizationPage, () => {
       csrf="CSRF_TOKEN"
       linkTo={linker}
       errors={[ { field: 'organization', message: 'required field' } ]}
+      owners={[]}
     />);
 
     expect(markup.find('.govuk-error-summary')).toHaveLength(1);

--- a/src/components/platform-admin/views.test.tsx
+++ b/src/components/platform-admin/views.test.tsx
@@ -1,0 +1,51 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { IParameters } from '../../lib/router';
+import { CreateOrganizationPage, CreateOrganizationSuccessPage } from './views';
+
+function linker(route: string, params?: IParameters): string {
+  return `__LINKS_TO__${route}_WITH_${(new URLSearchParams(params)).toString()}`;
+}
+
+describe(CreateOrganizationPage, () => {
+  it('should have csrf token', () => {
+    const markup = shallow(<CreateOrganizationPage csrf="CSRF_TOKEN" linkTo={linker} />);
+
+    expect(markup.render().find('[name=_csrf]')).toHaveLength(1);
+    expect(markup.render().find('[name=_csrf]').prop('value')).toEqual('CSRF_TOKEN');
+  });
+
+  it('should correctly handle XSS attack', () => {
+    const markup = shallow(<CreateOrganizationPage
+      csrf="CSRF_TOKEN"
+      linkTo={linker}
+      values={{ organization: '<script>alert("pwnd by test");</script>' }}
+    />);
+
+    expect(markup.find('input#organization')).toHaveLength(1);
+    expect(markup.find('input#organization').html()).not.toContain('<script>');
+    expect(markup.find('input#organization').html()).toContain('&lt;script&gt;');
+    expect(markup.find('input#organization').html()).toContain('&quot;pwnd by test&quot;');
+  });
+
+  it('should correctly printout errors', () => {
+    const markup = shallow(<CreateOrganizationPage
+      csrf="CSRF_TOKEN"
+      linkTo={linker}
+      errors={[ { field: 'organization', message: 'required field' } ]}
+    />);
+
+    expect(markup.find('.govuk-error-summary')).toHaveLength(1);
+    expect(markup.find('.govuk-error-summary').text()).toContain('required field');
+  });
+});
+
+describe(CreateOrganizationSuccessPage, () => {
+  it('should correctly compose a success page', () => {
+    const markup = shallow(<CreateOrganizationSuccessPage linkTo={linker} organizationGUID="ORG_GUID" />);
+
+    expect(markup.html())
+      .toContain('href="__LINKS_TO__admin.organizations.users.invite_WITH_organizationGUID=ORG_GUID"');
+  });
+});

--- a/src/components/platform-admin/views.tsx
+++ b/src/components/platform-admin/views.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { RouteLinker } from '../app';
 import { IValidationError } from '../errors/types';
@@ -22,6 +22,13 @@ interface IFormProperties extends IProperties {
   readonly csrf: string;
   readonly errors?: ReadonlyArray<IValidationError>;
   readonly values?: INewOrganizationUserBody;
+}
+
+interface ICreateOrganizationPageProperties extends IFormProperties {
+  readonly owners: ReadonlyArray<{
+    readonly name: string;
+    readonly owner: string;
+  }>;
 }
 
 function Costs(props: IFormProperties): ReactElement {
@@ -202,9 +209,7 @@ export function PlatformAdministratorPage(
   );
 }
 
-export function CreateOrganizationPage(props: IFormProperties): ReactElement {
-  const codeStyling: CSSProperties = { whiteSpace: 'nowrap' };
-
+export function CreateOrganizationPage(props: ICreateOrganizationPageProperties): ReactElement {
   return (<div className="govuk-grid-row">
     <form method="post" className="govuk-grid-column-one-half">
       <h1 className="govuk-heading-xl">Create an Organisation</h1>
@@ -238,11 +243,8 @@ export function CreateOrganizationPage(props: IFormProperties): ReactElement {
           Organisation name
         </label>
         <span id="organization-hint" className="govuk-hint">
-          This needs to be all lowercase and hyphen separated meaningful name of the organisation. For instance:
-          {' '}
-          <code style={codeStyling}>govuk-paas</code>
-          {' '}or{' '}
-          <code style={codeStyling}>cabinet-office-digital</code>.
+          This needs to be all lowercase and hyphen separated meaningful name of the organisation.
+          You can also refer to the section on the side for some examples.
         </span>
         <input id="organization" name="organization" className="govuk-input" aria-describedby="organization-hint"
           type="text" defaultValue={props.values?.organization} required={true} pattern={SLUG_REGEX} />
@@ -253,11 +255,7 @@ export function CreateOrganizationPage(props: IFormProperties): ReactElement {
           Owner
         </label>
         <span id="owner-hint" className="govuk-hint">
-          The name of a party owning that organisation. For instance:
-          {' '}
-          <code style={codeStyling}>Government Digital Service</code>
-          {' '}or{' '}
-          <code style={codeStyling}>Cabinet Office</code>.
+          The name of a party owning that organisation. You can also refer to the section on the side for some examples.
         </span>
         <input id="owner" name="owner" className="govuk-input" aria-describedby="owner-hint" type="text"
           defaultValue={props.values?.owner} required={true} />
@@ -267,6 +265,24 @@ export function CreateOrganizationPage(props: IFormProperties): ReactElement {
         Create Organisation
       </button>
     </form>
+
+    <div className="govuk-grid-column-one-half">
+      <table className="govuk-table">
+        <caption className="govuk-table__caption">Existing owners</caption>
+        <thead className="govuk-table__head">
+          <tr className="govuk-table__row">
+            <th scope="col" className="govuk-table__header">Name</th>
+            <th scope="col" className="govuk-table__header">Owner</th>
+          </tr>
+        </thead>
+        <tbody className="govuk-table__body">
+          {props.owners.map((org, index) => <tr key={index} className="govuk-table__row">
+              <td className="govuk-table__cell">{org.name}</td>
+              <td className="govuk-table__cell">{org.owner}</td>
+            </tr>)}
+        </tbody>
+      </table>
+    </div>
   </div>);
 }
 

--- a/src/layouts/constants.test.ts
+++ b/src/layouts/constants.test.ts
@@ -1,0 +1,15 @@
+import { SLUG_REGEX } from './constants';
+
+describe(SLUG_REGEX, () => {
+  it('should only match the approved slugs', () => {
+    expect('organisationname'.match(SLUG_REGEX)).not.toBeNull();
+    expect('organisation-name'.match(SLUG_REGEX)).not.toBeNull();
+    expect('very-long-organisation-name-please'.match(SLUG_REGEX)).not.toBeNull();
+    expect('OrganisationName'.match(SLUG_REGEX)).toBeNull();
+    expect('Organisation-Name'.match(SLUG_REGEX)).toBeNull();
+    expect('Organisation_Name'.match(SLUG_REGEX)).toBeNull();
+    expect('Organisation Name'.match(SLUG_REGEX)).toBeNull();
+    expect('organisation_name'.match(SLUG_REGEX)).toBeNull();
+    expect('organisation name'.match(SLUG_REGEX)).toBeNull();
+  });
+});

--- a/src/layouts/constants.ts
+++ b/src/layouts/constants.ts
@@ -6,3 +6,5 @@ export const KIBIBYTE = 1024;
 export const MEBIBYTE = KIBIBYTE * 1024;
 export const GIBIBYTE = MEBIBYTE * 1024;
 export const TEBIBYTE = GIBIBYTE * 1024;
+
+export const SLUG_REGEX = '^([a-z0-9-]+)$';

--- a/src/lib/cf/cf.test.data.ts
+++ b/src/lib/cf/cf.test.data.ts
@@ -1161,3 +1161,67 @@ export const stacksWithoutCflinuxfs2 = `{
     }
   ]
 }`;
+
+export const v3Organisation = `{
+  "guid": "ORG_GUID",
+  "created_at": "2017-02-01T01:33:58Z",
+  "updated_at": "2017-02-01T01:33:58Z",
+  "name": "organization-name",
+  "suspended": false,
+  "relationships": {
+    "quota": {
+      "data": {
+        "guid": "ORG_QUOTA_GUID"
+      }
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/organizations/ORG_GUID"
+    },
+    "domains": {
+      "href": "https://api.example.org/v3/organizations/ORG_GUID/domains"
+    },
+    "default_domain": {
+      "href": "https://api.example.org/v3/organizations/ORG_GUID/domains/default"
+    },
+    "quota": {
+      "href": "https://api.example.org/v3/organization_quotas/ORG_QUOTA_GUID"
+    }
+  },
+  "metadata": {
+    "labels": {},
+    "annotations": {
+      "owner": "ORG_OWNER_ANNOTATION"
+    }
+  }
+}`;
+
+export const v3Space = `{
+  "guid": "SPACE_GUID",
+  "created_at": "2017-02-01T01:33:58Z",
+  "updated_at": "2017-02-01T01:33:58Z",
+  "name": "space-name",
+  "relationships": {
+    "organization": {
+      "data": {
+        "guid": "ORG_GUID"
+      }
+    },
+    "quota": {
+      "data": null
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/spaces/SPACE_GUID"
+    },
+    "organization": {
+      "href": "https://api.example.org/v3/organizations/ORG_GUID"
+    }
+  },
+  "metadata": {
+    "labels": {},
+    "annotations": {}
+  }
+}`;

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -759,4 +759,36 @@ describe('lib/cf test suite', () => {
 
     expect(cflinuxfs2StackGUID).toEqual(undefined);
   });
+
+  it('should be able to create organisation using v3 api', async () => {
+    nockCF.post('/v3/organizations').reply(201, data.v3Organisation);
+
+    const client = new CloudFoundryClient(config);
+    const organization = await client.v3CreateOrganization({
+      name: 'some-org-name',
+      metadata: { annotations: { owner: 'organisation-owner' } },
+    });
+
+    expect(organization).toHaveProperty('guid');
+    expect(organization.guid).toEqual('ORG_GUID');
+  });
+
+  it('should be able to create space using v3 api', async () => {
+    nockCF.post('/v3/spaces').reply(201, data.v3Space);
+
+    const client = new CloudFoundryClient(config);
+    const space = await client.v3CreateSpace({
+      name: 'some-org-name',
+      relationships: {
+        organization: {
+          data: {
+            guid: 'ORG_GUID',
+          },
+        },
+      },
+    });
+
+    expect(space).toHaveProperty('guid');
+    expect(space.guid).toEqual('SPACE_GUID');
+  });
 });

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -152,6 +152,16 @@ export default class CloudFoundryClient {
     return response.data;
   }
 
+  public async v3CreateOrganization(orgRequest: cf.IV3OrganizationRequest): Promise<cf.IV3OrganizationResource> {
+    const response = await this.request(
+      'post',
+      '/v3/organizations',
+      orgRequest,
+    );
+
+    return response.data;
+  }
+
   public async organizations(): Promise<ReadonlyArray<cf.IOrganization>> {
     const response = await this.request('get', '/v2/organizations');
 
@@ -209,6 +219,16 @@ export default class CloudFoundryClient {
     const response = await this.request(
       'get',
       `/v2/quota_definitions/${quotaGUID}`,
+    );
+
+    return response.data;
+  }
+
+  public async v3CreateSpace(spaceRequest: cf.IV3SpaceRequest): Promise<cf.IV3SpaceResource> {
+    const response = await this.request(
+      'post',
+      '/v3/spaces',
+      spaceRequest,
     );
 
     return response.data;

--- a/src/lib/cf/types.ts
+++ b/src/lib/cf/types.ts
@@ -1,3 +1,7 @@
+interface IKeyValuePairs {
+  readonly [key: string]: any;
+}
+
 export interface IMetadata {
   readonly guid: string;
   readonly url: string;
@@ -149,6 +153,15 @@ export interface IOrganizationRequest {
   readonly quota_definition_guid: string;
 }
 
+export interface IV3OrganizationRequest {
+  readonly name: string;
+  readonly metadata?: {
+    readonly annotations?: IKeyValuePairs;
+    readonly labels?: IKeyValuePairs;
+  };
+  readonly suspended?: boolean;
+}
+
 export interface IOrganization {
   readonly entity: {
     readonly app_events_url: string;
@@ -191,15 +204,17 @@ interface IV3Pagination {
   previous?: IV3Link;
 }
 
+interface IV3Relation {
+  readonly data: {
+    readonly guid: string;
+  };
+}
+
 export interface IV3OrganizationResource extends IV3Metadata {
   name: string;
   suspended: boolean;
   relationships: {
-    quota: {
-      data: {
-        guid: string;
-      };
-    };
+    quota: IV3Relation;
   };
   links: {
     self: IV3Link;
@@ -351,6 +366,18 @@ export interface IServiceSummary {
   };
 }
 
+export interface IV3SpaceRequest {
+  readonly name: string;
+  readonly relationships: {
+    readonly organization: IV3Relation;
+  };
+  readonly metadata?: {
+    readonly annotations?: IKeyValuePairs;
+    readonly labels?: IKeyValuePairs;
+  };
+  readonly suspended?: boolean;
+}
+
 export interface ISpace {
   readonly entity: {
     readonly allow_ssh: boolean;
@@ -371,6 +398,23 @@ export interface ISpace {
     readonly staging_security_groups_url: string;
   };
   readonly metadata: IMetadata;
+}
+
+export interface IV3SpaceResource extends IV3Metadata {
+  readonly guid: string;
+  readonly name: string;
+  readonly relationships: {
+    readonly organization: IV3Relation;
+    readonly quota: IV3Relation;
+  };
+  readonly links: {
+    readonly self: IV3Link;
+    readonly organization: IV3Link;
+  };
+  readonly metadata: {
+    readonly labels: IKeyValuePairs;
+    readonly annotations: IKeyValuePairs;
+  };
 }
 
 export interface ISpaceQuota {
@@ -447,7 +491,7 @@ export interface IUserSummary {
 
 export interface IUserServices {
   readonly entity: {
-    readonly credentials: { [i: string]: string };
+    readonly credentials: IKeyValuePairs;
     readonly name: string;
     readonly route_service_url: string | null;
     readonly routes_url: string;


### PR DESCRIPTION
What
----

We'd like to be deprecating more custom scripts from our repos and move
operational "one time" things to pazmin.

This functionality will allow us to create new organisations that
include the sandbox and tag it with an owner used in different section
of the system.

It will not invite users by default.

Potential improvements could be made around the "Owner" box, as we most
likely have a list of "owners" that we could display instead.

That will however do for now.

This implementation also uses v3 API which means we are only making one
call to create organisation and one call to create space, where as
script performs 7 calls all together which separately tag the
organisation and manage user admin.

How to review
-------------

- Code review
- Deploy to your env (or see rafalp)
- As platform operator, navigate to Patform Admin > Create organisation
- Play around with a form
- Establish if this is good enough