### PR TITLE
 Update tab link class

### DIFF
--- a/src/components/applications/views.tsx
+++ b/src/components/applications/views.tsx
@@ -43,7 +43,7 @@ export function Tab(props: ITabProperties) {
 
   return (
     <li className={classess.join(' ')}>
-      <a href={props.href} className="govuk-link">
+      <a href={props.href} className="govuk-tabs__tab">
         {props.children}
       </a>
     </li>

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -35,7 +35,7 @@ export function Tab(props: ITabProperties) {
 
   return (
     <li className={classess.join(' ')}>
-      <a href={props.href} className="govuk-link">
+      <a href={props.href} className="govuk-tabs__tab">
         {props.children}
       </a>
     </li>


### PR DESCRIPTION
## What
Use the correct `govuk-tabs__tab` class instead of `govuk-link` as per https://design-system.service.gov.uk/components/tabs/

## Why
This ensures the contents list spacing on mobile is sufficient enough to conform to
[Understanding Success Criterion 2.5.5: Target Size](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html) WCAG criteria.

## Visual changes

### Before

**Mobile**
<img width="164" alt="Screenshot 2020-03-05 at 11 02 36" src="https://user-images.githubusercontent.com/3758555/75975691-e23bcd80-5ed0-11ea-9cec-238177f0e4ef.png">

**Desktop**
<img width="980" alt="Screenshot 2020-03-05 at 11 02 23" src="https://user-images.githubusercontent.com/3758555/75975685-e10aa080-5ed0-11ea-9735-4e892e5f7480.png">




### After

**Mobile**
<img width="193" alt="Screenshot 2020-03-05 at 11 00 53" src="https://user-images.githubusercontent.com/3758555/75975585-aacd2100-5ed0-11ea-8752-d8fa9fb34c7f.png">

**Desktop**
<img width="1030" alt="Screenshot 2020-03-05 at 11 01 03" src="https://user-images.githubusercontent.com/3758555/75975586-ab65b780-5ed0-11ea-9a81-b923ac8f44a8.png">


## How to review

Build locally
