### PR TITLE
Update the way we handle (non)visited link text colour

### DIFF
--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -70,16 +70,6 @@ abbr {
 }
 
 
-a.govuk-link:not([href*="//"]) {
-  &:visited, &:link {
-    color: $govuk-link-colour;
-  }
-
-  &:active {
-    color: $govuk-link-active-colour;
-  }
-
-  &:hover {
-    color: $govuk-link-hover-colour;
-  }
+.govuk-link:not([href*="//"]) {
+  @include govuk-link-style-no-visited-state;
 }


### PR DESCRIPTION
## What
Update the (non)visited link text colour handling.

Update the way we handle (non) visited links colour, by making all links not show a visited state.

As this is an admin interface there is no need to distinguish between visited and non-visited links.

govuk-frontend has both a css class `.govuk-link--no-visited-state` and a [mixin](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/helpers/_links.scss#L146 )
available for such cases.

While we could add an additional class to every link, it probably makes more sense to use the mixin so that every future link is also covered.

Additionally, this change also fixes the "wrong" light-blue colour on non-visited links when focussed.

## Visual changes on non-visited link focus

**Before**
<img width="297" alt="Screenshot 2020-03-05 at 13 28 20" src="https://user-images.githubusercontent.com/3758555/75986346-d0b0f080-5ee5-11ea-8131-094b0c40202b.png">

**After**
<img width="295" alt="Screenshot 2020-03-05 at 13 29 46" src="https://user-images.githubusercontent.com/3758555/75986349-d1498700-5ee5-11ea-8028-56729dfad630.png">


## How to review
- Build locally
- keyboard tab to a visited external link, check text colour (should be black)
- keyboard tab to an internal link, check text colour (should be black)

