### PR TITLE
Only initialise javascript for components in use

### DIFF
--- a/src/components/applications/views.tsx
+++ b/src/components/applications/views.tsx
@@ -58,7 +58,7 @@ export function ApplicationTab(props: IApplicationTabProperties): ReactElement {
         {props.application.entity.name}
       </h1>
 
-      <div className="govuk-tabs" data-module="govuk-tabs">
+      <div className="govuk-tabs">
         <h2 className="govuk-tabs__title">Contents</h2>
 
         <ul className="govuk-tabs__list">

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -375,7 +375,7 @@ export function SpaceTab(props: ISpaceTabProperties): ReactElement {
         <span className="govuk-caption-l">Space</span> {props.space.entity.name}
       </h1>
 
-      <div className="govuk-tabs" data-module="govuk-tabs">
+      <div className="govuk-tabs">
         <h2 className="govuk-tabs__title">Contents</h2>
 
         <ul className="govuk-tabs__list">

--- a/src/frontend/javascript/init.js
+++ b/src/frontend/javascript/init.js
@@ -1,3 +1,29 @@
-(function() {
-  window.GOVUKFrontend.initAll();
-})();
+// there is ever only one header per page
+var $headerMenuButton = document.querySelector('[data-module="govuk-header"]');
+var GOVUKHeader = window.GOVUKFrontend.Header;
+if ($headerMenuButton) {
+  new GOVUKHeader($headerMenuButton).init();
+}
+
+var $buttons = document.querySelectorAll('[data-module="govuk-button"]');
+var GOVUKButton = window.GOVUKFrontend.Button;
+if ($buttons) {
+  for (var i = 0; i < $buttons.length; i++) {
+    new GOVUKButton($button).init();
+  };
+}
+
+var $details = document.querySelectorAll('[data-module="govuk-details"]');
+var GOVUKDetails = window.GOVUKFrontend.Details;
+if ($details) {
+  for (var i = 0; i < $details.length; i++) {
+    new GOVUKDetails($detail).init();
+  };
+}
+
+// there is ever only one error summuary per page
+var $errorSummary = document.querySelector('[data-module="govuk-error-summary"]');
+var GOVUKErrorSummary = window.GOVUKFrontend.ErrorSummary;
+if ($errorSummary) {
+  new GOVUKErrorSummary($errorSummary).init();
+}


### PR DESCRIPTION
## What
Initialise javascript for component we actually use, not all of them.
Remove the `data-module="govuk-tabs"` attribute from the tab components that are used links to other pages

## Why
At the moment we have a console error for the tabs component as we're only making it look like tabs, but links link to actual pages not content panels and the missing attribute throws an error

## How to review
- build locally, check pages with tabs
