### PR TITLE
Update govuk-frontend to v3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8758,9 +8758,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.5.0.tgz",
-      "integrity": "sha512-4tNKgcChO1bMNsrTz2UsK4fDMmU9R87UDxy/KhKIMbnhsuJLVuArDveYLkZuUsZ6B3eaCbl5gmI8i/Q/Mi680A=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.6.0.tgz",
+      "integrity": "sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A=="
     },
     "graceful-fs": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "express-pino-logger": "^4.0.0",
     "express-static-gzip": "^2.0.6",
     "fnv-plus": "^1.3.1",
-    "govuk-frontend": "^3.5.0",
+    "govuk-frontend": "^3.6.0",
     "helmet": "^3.21.3",
     "jmespath": "^0.15.0",
     "jsdom": "^16.2.0",


### PR DESCRIPTION
## What

Release notes
https://github.com/alphagov/govuk-frontend/releases/tag/v3.6.0

## How to review
- run locally, check nothing is broken