### PR TITLE
Use built in list classes

### DIFF
--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -809,7 +809,7 @@ export function OrganizationUsersPage(
                 )}
               </td>
               <td className="govuk-table__cell">
-                <ul className="plain">
+                <ul className="govuk-list govuk-!-margin-bottom-0">
                   {props.users[guid].spaces.map(space => (
                     <li key={space.metadata.guid}>
                       <a

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -26,11 +26,6 @@ $govuk-page-width: 1200px;
   text-align: right;
 }
 
-ul.plain {
-  list-style: none;
-  padding-left: inherit;
-}
-
 .org-summary-stat {
   .org-summary-stat__heading {
     margin-top: 15px;


### PR DESCRIPTION
## What
Replace custom list styles with classes provided by govuk-frontend.

We can now remove custom styles and improve accessibility by increasing the space between elements making them easier to click or tap

## How to review
- build locally, check team members page

## Visual changes

**Before**
<img width="1239" alt="Screenshot 2020-03-10 at 14 33 49" src="https://user-images.githubusercontent.com/3758555/76323412-975cf400-62dc-11ea-8986-e6c5ec5e4c02.png">


**After**
<img width="1226" alt="Screenshot 2020-03-10 at 14 30 56" src="https://user-images.githubusercontent.com/3758555/76323452-a479e300-62dc-11ea-9b34-1bd5e5f3f870.png">

