### PR TITLE
Update empty table cell announcements

### DIFF
--- a/src/components/org-users/views.test.tsx
+++ b/src/components/org-users/views.test.tsx
@@ -317,7 +317,7 @@ describe(OrganizationUsersPage, () => {
       username: 'user-name',
     } as unknown) as IUserRoles,
     USER_GUID_2: ({
-      orgRoles: ['org_manager', 'billing_manager', 'org_auditor'],
+      orgRoles: ['org_manager', 'billing_manager'],
       spaces: [],
       username: 'user-name-2',
     } as unknown) as IUserRoles,
@@ -339,7 +339,8 @@ describe(OrganizationUsersPage, () => {
     expect($('td').text()).not.toContain('Origin-name');
     expect($('td').text()).not.toContain('Password');
     expect($('li').text()).toContain(space.entity.name);
-    expect($('.tick-symbol').length).toEqual(3);
+    expect($('.tick-symbol').length).toEqual(2);
+    expect($('.govuk-table__body td:nth-child(4)').text()).toContain('no');
   });
 
   it('should produce the org users view when being privileged', () => {

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode } from 'react';
 
 import { capitalize } from '../../layouts';
-import { Tick } from '../../layouts/partials';
+import { NoTick, Tick } from '../../layouts/partials';
 import {
   IOrganization,
   IOrganizationUserRoles,
@@ -784,28 +784,28 @@ export function OrganizationUsersPage(
                     capitalize(props.userOriginMapping[guid])
                   )
                 ) : (
-                  <></>
+                  <NoTick />
                 )}
               </td>
               <td className="govuk-table__cell">
                 {props.users[guid].orgRoles.includes('org_manager') ? (
                   <Tick />
                 ) : (
-                  <></>
+                  <NoTick />
                 )}
               </td>
               <td className="govuk-table__cell">
                 {props.users[guid].orgRoles.includes('billing_manager') ? (
                   <Tick />
                 ) : (
-                  <></>
+                  <NoTick />
                 )}
               </td>
               <td className="govuk-table__cell">
                 {props.users[guid].orgRoles.includes('org_auditor') ? (
                   <Tick />
                 ) : (
-                  <></>
+                  <NoTick />
                 )}
               </td>
               <td className="govuk-table__cell">

--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -287,3 +287,7 @@ export function Tick(): ReactElement {
     </Fragment>
     );
 }
+
+export function NoTick(): ReactElement {
+  return <span className="govuk-visually-hidden">no</span>;
+}


### PR DESCRIPTION
## What

Replace and empty cell for user roles that don't apply with a visually-hidden text "No" so that screenreaders announce when something doesn't apply.

A new `NoTick` (better name sought) element was created and added to the cells when the condition is met.

Test was updated to check for the presence of the word "No" in a cell where the role was not set.

## How to review
- deploy to dev
- add a user with a one role missing
- check the team members page table for the cell to contain
`<span className="govuk-visually-hidden">no</span>` element
 - BONUS: use Voiceover in Safari (CMD +F5) to check the table announcements

## Screenreader announcements

**Before**
- Jaws, Windows, Internet Explorer
"Org billing manager"

- NVDA, Windows, Firefox
"Org billing manager, column 4"

- Microsoft Narrator, Windows, Edge
"column header, org billing manager"

- VoiceOver on macOS
"Org billing manager, **blank**"
<img width="583" alt="Screenshot 2020-03-11 at 13 16 21" src="https://user-images.githubusercontent.com/3758555/76420924-ccc81700-639a-11ea-8a37-c42692d99362.png">


**After**

- Jaws, Windows, Internet Explorer
"Org billing manager, **no**"

- NVDA, Windows, Firefox
"Org billing manager, column 4, **no**"

- Microsoft Narrator, Windows, Edge
"column header, org billing manager, **no**"

- VoiceOver on macOS
"Org billing manager, **no**"

<img width="591" alt="Screenshot 2020-03-11 at 13 15 09" src="https://user-images.githubusercontent.com/3758555/76420984-e49f9b00-639a-11ea-8912-b095b0c1e5bd.png">


