### PR TITLE
Conditionally show backing services table

### DIFF
--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -220,6 +220,25 @@ describe(BackingServicePage, () => {
     const $ = cheerio.load(markup.html());
     expect($('p').text()).toContain('This space contains 1 backing service');
   });
+
+  it('should not display a table of backing service if there no backing services', () => {
+    const noServices = ([] as unknown) as ReadonlyArray<
+      IEnchancedServiceInstance | IStripedUserServices
+    >;
+    const markup = shallow(
+      <BackingServicePage
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.applications.events.view'
+        }
+        organizationGUID="ORG_GUID"
+        services={noServices}
+        space={space}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-table')).toHaveLength(0);
+  });
 });
 
 describe(SpacesPage, () => {

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -527,54 +527,59 @@ export function BackingServicePage(
         {props.services.length === 1 ? 'service' : 'services'}
       </p>
 
-      <table className="govuk-table">
-        <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
-            <th className="govuk-table__header name" scope="col">
-              Service name
-            </th>
-            <th className="govuk-table__header" scope="col">
-              Type
-            </th>
-            <th className="govuk-table__header" scope="col">
-              Plan
-            </th>
-            <th className="govuk-table__header" scope="col">
-              State
-            </th>
-          </tr>
-        </thead>
-        <tbody className="govuk-table__body">
-          {props.services.map(service => (
-            <tr key={service.metadata.guid} className="govuk-table__row">
-              <td className="govuk-table__cell name">
-                <a
-                  href={props.linkTo(
-                    'admin.organizations.spaces.services.view',
-                    {
-                      organizationGUID: props.organizationGUID,
-                      serviceGUID: service.metadata.guid,
-                      spaceGUID: props.space.metadata.guid,
-                    },
-                  )}
-                  className="govuk-link"
-                >
-                  {service.entity.name}
-                </a>
-              </td>
-              <td className="govuk-table__cell label">
-                {service.definition?.entity.label || 'User Provided Service'}
-              </td>
-              <td className="govuk-table__cell plan">
-                {service.plan?.entity.name || 'N/A'}
-              </td>
-              <td className="govuk-table__cell status">
-                {service.entity.last_operation?.state || 'N/A'}
-              </td>
+      {props.services.length > 0 ? (
+        <table className="govuk-table">
+          <thead className="govuk-table__head">
+            <tr className="govuk-table__row">
+              <th className="govuk-table__header name" scope="col">
+                Service name
+              </th>
+              <th className="govuk-table__header" scope="col">
+                Type
+              </th>
+              <th className="govuk-table__header" scope="col">
+                Plan
+              </th>
+              <th className="govuk-table__header" scope="col">
+                State
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="govuk-table__body">
+            {props.services.map(service => (
+              <tr key={service.metadata.guid} className="govuk-table__row">
+                <td className="govuk-table__cell name">
+                  <a
+                    href={props.linkTo(
+                      'admin.organizations.spaces.services.view',
+                      {
+                        organizationGUID: props.organizationGUID,
+                        serviceGUID: service.metadata.guid,
+                        spaceGUID: props.space.metadata.guid,
+                      },
+                    )}
+                    className="govuk-link"
+                  >
+                    {service.entity.name}
+                  </a>
+                </td>
+                <td className="govuk-table__cell label">
+                  {service.definition?.entity.label || 'User Provided Service'}
+                </td>
+                <td className="govuk-table__cell plan">
+                  {service.plan?.entity.name || 'N/A'}
+                </td>
+                <td className="govuk-table__cell status">
+                  {service.entity.last_operation?.state || 'N/A'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        ) : (
+          <></>
+        )
+      }
     </SpaceTab>
   );
 }


### PR DESCRIPTION
What
----

Only show a table of backing services if any backing services exist.
At the moment we show an empty table, which might be confusing for screenreaders.

How to review
-------------
- push to dev environment
- check a space with no backing services page
- table should not be present in the DOM

Visual change
--------------

**Before**

<img width="957" alt="Screenshot 2020-03-12 at 09 45 36" src="https://user-images.githubusercontent.com/3758555/76508729-c5f6de00-6446-11ea-90b7-84131ee7a60b.png">

**After**

<img width="965" alt="Screenshot 2020-03-12 at 09 45 50" src="https://user-images.githubusercontent.com/3758555/76508742-cc855580-6446-11ea-8a8e-2277a9c04197.png">


