### PR TITLE
Conditionally show table of applications on the space page

### DIFF
--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -155,6 +155,22 @@ describe(ApplicationsPage, () => {
     const $ = cheerio.load(markup.html());
     expect($('p').text()).toContain('This space contains 2 applications');
   });
+
+  it('should not display a table of applications if there no applications', () => {
+    const markup = shallow(
+      <ApplicationsPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.applications.events.view'
+        }
+        organizationGUID="ORG_GUID"
+        space={space}
+        applications={[]}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-table')).toHaveLength(0);
+  });
 });
 
 describe(BackingServicePage, () => {

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -429,85 +429,89 @@ export function ApplicationsPage(
         This space contains {props.applications.length}{' '}
         {props.applications.length === 1 ? 'application' : 'applications'}
       </p>
-
-      <table className="govuk-table">
-        <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
-            <th className="govuk-table__header name" scope="col">
-              Application name
-            </th>
-            <th className="govuk-table__header" scope="col">
-              Instances
-            </th>
-            <th className="govuk-table__header" scope="col">
-              Memory
-            </th>
-            <th className="govuk-table__header" scope="col">
-              Disk
-            </th>
-            <th className="govuk-table__header" scope="col">
-              Status
-            </th>
-            <th className="govuk-table__header" scope="col">
-              URLs
-            </th>
-          </tr>
-        </thead>
-        <tbody className="govuk-table__body">
-          {props.applications.map(application => (
-            <tr key={application.metadata.guid} className="govuk-table__row">
-              <td className="govuk-table__cell">
-                <a
-                  href={props.linkTo(
-                    'admin.organizations.spaces.applications.view',
-                    {
-                      applicationGUID: application.metadata.guid,
-                      organizationGUID: props.organizationGUID,
-                      spaceGUID: props.space.metadata.guid,
-                    },
-                  )}
-                  className="govuk-link"
-                >
-                  {application.entity.name}
-                </a>
-              </td>
-              <td
-                className="govuk-table__cell"
-                title={`${application.summary.running_instances} running / ${application.summary.instances} desired`}
-              >
-                {application.summary.running_instances} /{' '}
-                {application.summary.instances}
-              </td>
-              <td
-                className="govuk-table__cell"
-                title={`Total: ${(application.summary.memory *
-                  application.summary.instances) /
-                  KIBIBYTE}GiB`}
-              >
-                {application.summary.instances} &times;{' '}
-                {help.bytesToHuman(application.summary.memory * MEBIBYTE)}
-              </td>
-              <td
-                className="govuk-table__cell"
-                title={`Total: ${(application.summary.disk_quota *
-                  application.summary.instances) /
-                  KIBIBYTE}GiB`}
-              >
-                {application.summary.instances} &times;{' '}
-                {help.bytesToHuman(application.summary.disk_quota * MEBIBYTE)}
-              </td>
-              <td className="govuk-table__cell">
-                {application.summary.state.toLowerCase()}
-              </td>
-              <td className="govuk-table__cell">
-                {application.urls.map((url, index) => (
-                  <AppLink key={index} href={url} />
-                ))}
-              </td>
+      {props.applications.length > 0 ? (
+        <table className="govuk-table">
+          <thead className="govuk-table__head">
+            <tr className="govuk-table__row">
+              <th className="govuk-table__header name" scope="col">
+                Application name
+              </th>
+              <th className="govuk-table__header" scope="col">
+                Instances
+              </th>
+              <th className="govuk-table__header" scope="col">
+                Memory
+              </th>
+              <th className="govuk-table__header" scope="col">
+                Disk
+              </th>
+              <th className="govuk-table__header" scope="col">
+                Status
+              </th>
+              <th className="govuk-table__header" scope="col">
+                URLs
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="govuk-table__body">
+            {props.applications.map(application => (
+              <tr key={application.metadata.guid} className="govuk-table__row">
+                <td className="govuk-table__cell">
+                  <a
+                    href={props.linkTo(
+                      'admin.organizations.spaces.applications.view',
+                      {
+                        applicationGUID: application.metadata.guid,
+                        organizationGUID: props.organizationGUID,
+                        spaceGUID: props.space.metadata.guid,
+                      },
+                    )}
+                    className="govuk-link"
+                  >
+                    {application.entity.name}
+                  </a>
+                </td>
+                <td
+                  className="govuk-table__cell"
+                  title={`${application.summary.running_instances} running / ${application.summary.instances} desired`}
+                >
+                  {application.summary.running_instances} /{' '}
+                  {application.summary.instances}
+                </td>
+                <td
+                  className="govuk-table__cell"
+                  title={`Total: ${(application.summary.memory *
+                    application.summary.instances) /
+                    KIBIBYTE}GiB`}
+                >
+                  {application.summary.instances} &times;{' '}
+                  {help.bytesToHuman(application.summary.memory * MEBIBYTE)}
+                </td>
+                <td
+                  className="govuk-table__cell"
+                  title={`Total: ${(application.summary.disk_quota *
+                    application.summary.instances) /
+                    KIBIBYTE}GiB`}
+                >
+                  {application.summary.instances} &times;{' '}
+                  {help.bytesToHuman(application.summary.disk_quota * MEBIBYTE)}
+                </td>
+                <td className="govuk-table__cell">
+                  {application.summary.state.toLowerCase()}
+                </td>
+                <td className="govuk-table__cell">
+                  {application.urls.map((url, index) => (
+                    <AppLink key={index} href={url} />
+                  ))}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        ) : (
+          <></>
+        )
+      }
     </SpaceTab>
   );
 }


### PR DESCRIPTION
What
----

Conditionally show the space applications table on the space page.

If there are no applications running, avoid showing an empty table.

How to review
-------------
- Code review
- Deploy to your env (or see jani dev env -> _govuk-paas_ org -> _Tools_ space)

**Before**
<img width="1236" alt="Screenshot 2020-03-12 at 13 32 05" src="https://user-images.githubusercontent.com/3758555/76528725-2ac33000-6469-11ea-9818-925b19dcbcee.png">


**After**
<img width="1240" alt="Screenshot 2020-03-12 at 13 32 24" src="https://user-images.githubusercontent.com/3758555/76528740-30207a80-6469-11ea-964c-260a8bbc6942.png">

