### PR TITLE
Update to team members page

### DIFF
--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -666,17 +666,38 @@ export function OrganizationUsersPage(
   return (
     <>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">
-          <h1 className="govuk-heading-l">Team members</h1>
+        <div className="govuk-grid-column-full">
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              <h1 className="govuk-heading-l">Team members</h1>
 
-          <p className="govuk-body">
-            Organisation level users can manage and/or view information
-            regarding user accounts, billing, resource quota for the
-            organisation and spaces. To edit a member&apos;s role go to their
-            profile page.
-          </p>
-
-          <details className="govuk-details" role="group">
+              <p className="govuk-body">
+                Organisation level users can manage and/or view information
+                regarding user accounts, billing, resource quota for the
+                organisation and spaces. To edit a member&apos;s role go to their
+                profile page.
+              </p>
+            </div>
+            {props.privileged ? (
+              <div className="govuk-grid-column-one-third text-right">
+                <a
+                  href={props.linkTo('admin.organizations.users.invite', {
+                    organizationGUID: props.organizationGUID,
+                  })}
+                  role="button"
+                  draggable="false"
+                  className="govuk-button"
+                  data-module="govuk-button"
+                >
+                  Invite a new team member
+                </a>
+              </div>
+              ) : (
+                <></>
+              )
+            }
+            <div className="govuk-grid-column-two-thirds">
+              <details className="govuk-details" role="group">
             <summary
               className="govuk-details__summary"
               role="button"
@@ -714,24 +735,8 @@ export function OrganizationUsersPage(
               </p>
             </div>
           </details>
-        </div>
-
-        <div className="govuk-grid-column-one-third text-right">
-          {props.privileged ? (
-            <a
-              href={props.linkTo('admin.organizations.users.invite', {
-                organizationGUID: props.organizationGUID,
-              })}
-              role="button"
-              draggable="false"
-              className="govuk-button"
-              data-module="govuk-button"
-            >
-              Invite a new team member
-            </a>
-          ) : (
-            <></>
-          )}
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -740,6 +740,8 @@ export function OrganizationUsersPage(
         </div>
       </div>
 
+      <h2 className="govuk-heading-m">Current team members</h2>
+
       <table className="govuk-table user-list">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">


### PR DESCRIPTION
What
----

## Update invite button tab order

Audit identified the invite button being after the details element in the tab order, where ideally it should be before it. 
To keep the current design, the layout structure needed to be updated to move it before the details element in the order.

**Before**
- no change to desktop
- mobile:  
<img width="488" alt="Screenshot 2020-03-13 at 12 59 20" src="https://user-images.githubusercontent.com/3758555/76623479-78a06c80-652b-11ea-9d1f-29f9d203ee3f.png">

**After**
- no change to desktop
- mobile:  
<img width="490" alt="Screenshot 2020-03-13 at 12 59 06" src="https://user-images.githubusercontent.com/3758555/76623530-940b7780-652b-11ea-93ea-579cfb383bba.png">


## Add a heading before the user table

To aid screenreaders identifying the page structure, we've added a H2 heading before the table of current users, so that we give a quick overview of the page and the ability to skip to the heading.

**Before**
<img width="1236" alt="Screenshot 2020-03-13 at 13 01 20" src="https://user-images.githubusercontent.com/3758555/76623640-c61cd980-652b-11ea-9768-e1d58d168b16.png">

**After**
<img width="1237" alt="Screenshot 2020-03-13 at 13 01 01" src="https://user-images.githubusercontent.com/3758555/76623661-d0d76e80-652b-11ea-9adf-469cc6a618fd.png">


How to review
-------------

- check my dev (jani) or build locally
- go to org ->  team members page

