### PR TITLE
Fix broken Invite team member page test

### DIFF
--- a/acceptance-tests/main.test.ts
+++ b/acceptance-tests/main.test.ts
@@ -141,7 +141,7 @@ describe('paas-admin', function () {
 
       it('should invite a user', async () => {
         await <any>browser.visit(`${PAAS_ADMIN_BASE_URL}/organisations/${orgGuid}/users/invite`);
-        browser.assert.text('h2', /Invite a new team member/);
+        browser.assert.text('h1', /Invite a new team member/);
         await <any>browser.fill('email', developerUserEmail);
         await <any>browser.check(`org_roles[${orgGuid}][managers][desired]`);
         await <any>browser.pressButton('Send invitation');


### PR DESCRIPTION
What
----

H2 was replaced with H1 which broke the test.
Updating the test to look for H1
