### PR TITLE
Update confirmation page titles, text and layout

### DIFF
--- a/acceptance-tests/main.test.ts
+++ b/acceptance-tests/main.test.ts
@@ -145,7 +145,7 @@ describe('paas-admin', function () {
         await <any>browser.fill('email', developerUserEmail);
         await <any>browser.check(`org_roles[${orgGuid}][managers][desired]`);
         await <any>browser.pressButton('Send invitation');
-        browser.assert.text('.govuk-panel__title', /Success!/);
+        browser.assert.text('.govuk-panel__title', /New team member successfully invited/);
       });
     });
 

--- a/src/components/org-users/cc-api.test.ts
+++ b/src/components/org-users/cc-api.test.ts
@@ -96,7 +96,7 @@ describe('permissions calling cc api', () => {
     );
 
     // expect(scope.isDone()).toBeTruthy();
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('Team member details successfully updated');
   });
 
   it('should make no requests when permission has been previously and still is set', async () => {
@@ -139,7 +139,7 @@ describe('permissions calling cc api', () => {
     );
 
     // expect(scope.isDone()).toBeTruthy();
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('Team member details successfully updated');
   });
 
   it('should make no requests when permission has been previously and still is unset', async () => {
@@ -185,6 +185,6 @@ describe('permissions calling cc api', () => {
       },
     );
 
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('Team member details successfully updated');
   });
 });

--- a/src/components/org-users/controllers.test.tsx
+++ b/src/components/org-users/controllers.test.tsx
@@ -469,7 +469,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Invited a new team member');
+    expect(response.body).toContain('New team member successfully invited');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -537,7 +537,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Invited a new team member');
+    expect(response.body).toContain('New team member successfully invited');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -605,7 +605,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Invited a new team member');
+    expect(response.body).toContain('New team member successfully invited');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -673,7 +673,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Invited a new team member');
+    expect(response.body).toContain('New team member successfully invited');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -741,7 +741,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Invited a new team member');
+    expect(response.body).toContain('New team member successfully invited');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -809,7 +809,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Invited a new team member');
+    expect(response.body).toContain('New team member successfully invited');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -868,7 +868,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Invited a new team member');
+    expect(response.body).toContain('New team member successfully invited');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -999,7 +999,7 @@ describe('org-users test suite', () => {
       {},
     );
 
-    expect(response.body).toContain('Invited a new team member');
+    expect(response.body).toContain('Team member successfully invited');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1062,7 +1062,7 @@ describe('org-users test suite', () => {
       {},
     );
 
-    expect(response.body).toContain('Deleted a team member');
+    expect(response.body).toContain('Team member successfully deleted');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1368,7 +1368,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1416,7 +1416,7 @@ describe('org-users test suite', () => {
         },
       },
     );
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1462,7 +1462,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
   });
 
   it('should update the user, remove OrgManager role and show success - User Edit', async () => {
@@ -1507,7 +1507,7 @@ describe('org-users test suite', () => {
         },
       },
     );
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1553,7 +1553,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1602,7 +1602,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1648,7 +1648,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1694,7 +1694,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -1740,7 +1740,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('Updated a team member');
+    expect(response.body).toContain('eam member details successfully updated');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);

--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -934,7 +934,7 @@ export async function updateUser(
       },
     );
 
-    const template = new Template(ctx.viewContext, 'Updated a team member');
+    const template = new Template(ctx.viewContext, 'Team member details successfully updated');
     template.breadcrumbs = fromOrg(ctx, organization, [
       {
         href: ctx.linkTo('admin.organizations.users', {
@@ -950,8 +950,9 @@ export async function updateUser(
         <SuccessPage
           linkTo={ctx.linkTo}
           organizationGUID={organization.metadata.guid}
+          heading={'Team member details successfully updated'}
+          text={'We have updated the team member details.'}
         >
-          We have updated the user
         </SuccessPage>,
       ),
     };

--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -565,15 +565,16 @@ export async function inviteUser(
       }
     }
 
-    template.title = 'Invited a new team member';
+    template.title = 'New team member successfully invited';
 
     return {
       body: template.render(
         <SuccessPage
           linkTo={ctx.linkTo}
           organizationGUID={organization.metadata.guid}
+          heading={'New team member successfully invited'}
+          text={'An email with your invitation has been sent.'}
         >
-          We have sent your invitation
         </SuccessPage>,
       ),
     };

--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -685,7 +685,7 @@ export async function resendInvitation(
     url: invitation.inviteLink,
   });
 
-  const template = new Template(ctx.viewContext, 'Invited a new team member');
+  const template = new Template(ctx.viewContext, 'Team member successfully invited');
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
       href: ctx.linkTo('admin.organizations.users', {
@@ -701,8 +701,9 @@ export async function resendInvitation(
       <SuccessPage
         linkTo={ctx.linkTo}
         organizationGUID={organization.metadata.guid}
+        heading={'Team member successfully invited'}
+        text={'An email with your invitation has been sent.'}
       >
-        We have sent your invitation
       </SuccessPage>,
     ),
   };

--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -1103,7 +1103,7 @@ export async function deleteUser(
     false,
   );
 
-  const template = new Template(ctx.viewContext, 'Deleted a team member');
+  const template = new Template(ctx.viewContext, 'Team member successfully deleted');
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
       href: ctx.linkTo('admin.organizations.users', {
@@ -1119,8 +1119,9 @@ export async function deleteUser(
       <SuccessPage
         linkTo={ctx.linkTo}
         organizationGUID={organization.metadata.guid}
+        heading={'Team member successfully deleted'}
+        text={' We have unassigned this member from your organisation.'}
       >
-        We have unassigned this member from your organisation.
       </SuccessPage>,
     ),
   };

--- a/src/components/org-users/views.test.tsx
+++ b/src/components/org-users/views.test.tsx
@@ -15,6 +15,7 @@ import {
   OrganizationUsersPage,
   Permission,
   PermissionTable,
+  SuccessPage,
 } from './views';
 
 describe(Permission, () => {
@@ -358,5 +359,33 @@ describe(OrganizationUsersPage, () => {
     expect($('td:first-of-type a').length).toEqual(2);
     expect($('td').text()).toContain('Origin-name');
     expect($('td').text()).toContain('Password');
+  });
+});
+
+describe(SuccessPage, () => {
+  const markup = shallow(
+    <SuccessPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        organizationGUID="ORG_GUID"
+        heading={'confirmation panel heading'}
+        text={'confirmation panel text'}
+      >
+        children text
+      </SuccessPage>,
+  );
+
+  it('should have a confirmation panel title', () => {
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-panel__title').text()).toContain('confirmation panel heading');
+  });
+
+  it('should have a confirmation panel text', () => {
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-panel__body').text()).toContain('confirmation panel text');
+  });
+
+  it('should have props children text if provided', () => {
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-body').text()).toContain('children text');
   });
 });

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -401,7 +401,16 @@ export function DeleteConfirmationPage(
 export function SuccessPage(props: ISuccessPageProperties): ReactElement {
   return (
     <div className="govuk-grid-row">
-      <div className="govuk-grid-column-full govuk-!-pt-r1 text-right">
+      <div className="govuk-grid-column-two-thirds">
+        <div className="govuk-panel govuk-panel--confirmation">
+          <h1 className="govuk-panel__title">{props.heading}</h1>
+          <div className="govuk-panel__body">{props.text}</div>
+        </div>
+        {props.children ?
+          <p className="govuk-body">{props.children}</p>
+          : <></>
+        }
+        <h2 className="govuk-heading-m">More actions</h2>
         <a
           href={props.linkTo('admin.organizations.users.invite', {
             organizationGUID: props.organizationGUID,
@@ -413,14 +422,6 @@ export function SuccessPage(props: ISuccessPageProperties): ReactElement {
         >
           Invite a new team member
         </a>
-      </div>
-
-      <div className="govuk-grid-column-full">
-        <div className="govuk-panel govuk-panel--confirmation">
-          <h1 className="govuk-panel__title">{props.heading}</h1>
-          <div className="govuk-panel__body">{props.text}</div>
-        </div>
-        {props.children}
       </div>
     </div>
   );

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -20,6 +20,8 @@ interface IDeleteConfirmationPageProperties {
 }
 
 interface ISuccessPageProperties {
+  readonly heading: string;
+  readonly text: string;
   readonly children: ReactNode;
   readonly linkTo: RouteLinker;
   readonly organizationGUID: string;
@@ -415,9 +417,10 @@ export function SuccessPage(props: ISuccessPageProperties): ReactElement {
 
       <div className="govuk-grid-column-full">
         <div className="govuk-panel govuk-panel--confirmation">
-          <h1 className="govuk-panel__title">Success!</h1>
-          <div className="govuk-panel__body">{props.children}</div>
+          <h1 className="govuk-panel__title">{props.heading}</h1>
+          <div className="govuk-panel__body">{props.text}</div>
         </div>
+        {props.children}
       </div>
     </div>
   );

--- a/src/components/platform-admin/controllers.test.tsx
+++ b/src/components/platform-admin/controllers.test.tsx
@@ -222,7 +222,7 @@ describe(createOrganization, () => {
       expect(response.status).toBeUndefined();
       expect(response.body).toBeDefined();
       expect(response.body).not.toContain('<form');
-      expect(response.body).toContain('Success');
+      expect(response.body).toContain('New organisation successfully created');
     });
   });
 });

--- a/src/components/platform-admin/views.tsx
+++ b/src/components/platform-admin/views.tsx
@@ -287,9 +287,12 @@ export function CreateOrganizationPage(props: ICreateOrganizationPageProperties)
 }
 
 export function CreateOrganizationSuccessPage(props: ICreateOrganizationSuccessPageProperties): ReactElement {
-  return (<SuccessPage linkTo={props.linkTo} organizationGUID={props.organizationGUID}>
-    We have created a new organisation!
-    <br />
-    You still need to invite people and assign permissions.
+  return (
+    <SuccessPage 
+    linkTo={props.linkTo} 
+    organizationGUID={props.organizationGUID}
+    heading={'New organisation successfully created'}
+    text={'You still need to invite people and assign permissions.'}
+    >
   </SuccessPage>);
 }


### PR DESCRIPTION
What
----

Update title to match the page heading and update the page layout to move the "Invite" CTA below the success message

Once things settle we're going to see the content clinic for some advice. 

## Changes
<details>
<summary>Update title and page content</summary>

At the moment title and page heading we're different, whereas they should mirror each other to satisfy [WCAG 2.1 criteria](https://www.w3.org/WAI/WCAG21/Understanding/page-titled)  

**Before**
<img width="1252" alt="before" src="https://user-images.githubusercontent.com/3758555/76775118-ccfe5300-679c-11ea-8ab0-ddb9d71b8bd7.png">


**After**
<img width="859" alt="titles" src="https://user-images.githubusercontent.com/3758555/76944763-79554c00-68f9-11ea-8147-50dcdef2fa85.png">

</details>

<details>
<summary>Update page layout</summary>

The "Invite a new team member" call to action was before the main heading.
We've moved it below, under it's own level 2 heading

**Before**
 - mobile
<img width="539" alt="Screenshot 2020-03-16 at 16 00 55" src="https://user-images.githubusercontent.com/3758555/76777822-b823be80-67a0-11ea-9c8e-6614e5fe1cc6.png">

- desktop
<img width="1061" alt="Screenshot 2020-03-16 at 16 00 49" src="https://user-images.githubusercontent.com/3758555/76777818-b78b2800-67a0-11ea-9aad-2069ad153764.png">

**After**

- mobile 
<img width="401" alt="Screenshot 2020-03-18 at 09 20 08" src="https://user-images.githubusercontent.com/3758555/76944904-b28dbc00-68f9-11ea-9484-aa910a75c9ac.png">



- desktop
<img width="859" alt="desktop" src="https://user-images.githubusercontent.com/3758555/76944848-a0138280-68f9-11ea-8482-d40f4774caf7.png">

</details>

How to review
-------------
- suggest reviewing per commit
- check code
- view my admin dev
- check page title and success page heading, text and layout make sense for Invite, Update and Deletion of users


