### PR TITLE
Mobile tables

### DIFF
--- a/src/components/application-events/views.tsx
+++ b/src/components/application-events/views.tsx
@@ -130,41 +130,42 @@ export function ApplicationEventsPage(
         spaceGUID={props.spaceGUID}
         pagination={props.pagination}
       />
-
-      <table className="govuk-table">
-        <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
-            <th className="govuk-table__header">Date</th>
-            <th className="govuk-table__header">Actor</th>
-            <th className="govuk-table__header">Event</th>
-            <th className="govuk-table__header">Details</th>
-          </tr>
-        </thead>
-        <tbody className="govuk-table__body">
-          {props.events.map(event => (
-            <EventListItem
-              key={event.guid}
-              actor={
-                props.actorEmails[event.actor.guid] ||
-                event.actor.name || <code>{event.actor.guid}</code>
-              }
-              date={event.updated_at}
-              href={props.linkTo(
-                'admin.organizations.spaces.applications.event.view',
-                {
-                  applicationGUID: props.application.metadata.guid,
-                  eventGUID: event.guid,
-                  organizationGUID: props.organizationGUID,
-                  spaceGUID: props.spaceGUID,
-                },
-              )}
-              type={
-                eventTypeDescriptions[event.type] || <code>{event.type}</code>
-              }
-            />
-          ))}
-        </tbody>
-      </table>
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
+          <thead className="govuk-table__head">
+            <tr className="govuk-table__row">
+              <th className="govuk-table__header">Date</th>
+              <th className="govuk-table__header">Actor</th>
+              <th className="govuk-table__header">Event</th>
+              <th className="govuk-table__header">Details</th>
+            </tr>
+          </thead>
+          <tbody className="govuk-table__body">
+            {props.events.map(event => (
+              <EventListItem
+                key={event.guid}
+                actor={
+                  props.actorEmails[event.actor.guid] ||
+                  event.actor.name || <code>{event.actor.guid}</code>
+                }
+                date={event.updated_at}
+                href={props.linkTo(
+                  'admin.organizations.spaces.applications.event.view',
+                  {
+                    applicationGUID: props.application.metadata.guid,
+                    eventGUID: event.guid,
+                    organizationGUID: props.organizationGUID,
+                    spaceGUID: props.spaceGUID,
+                  },
+                )}
+                type={
+                  eventTypeDescriptions[event.type] || <code>{event.type}</code>
+                }
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
 
       <Pagination
         application={props.application}

--- a/src/components/applications/views.tsx
+++ b/src/components/applications/views.tsx
@@ -137,7 +137,8 @@ export function ApplicationPage(
             {props.application.entity.name}
           </h1>
 
-          <table className="govuk-table">
+          <div className="scrollable-table-container">
+            <table className="govuk-table">
             <caption className="govuk-table__caption">
               Application details
             </caption>
@@ -220,7 +221,7 @@ export function ApplicationPage(
               </tr>
             </tbody>
           </table>
-
+          </div>
           <CommandLineAlternative context="for all of your apps">
             cf apps
           </CommandLineAlternative>

--- a/src/components/calculator/views.tsx
+++ b/src/components/calculator/views.tsx
@@ -250,7 +250,8 @@ export function CalculatorPage(props: ICalculatorPageProperties): ReactElement {
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds paas-service-list">
-          <table className="govuk-table">
+          <div className="scrollable-table-container">
+            <table className="govuk-table">
             <thead>
               <th>Service</th>
               <th>Select options</th>
@@ -271,6 +272,7 @@ export function CalculatorPage(props: ICalculatorPageProperties): ReactElement {
               )}
             </tbody>
           </table>
+          </div>
         </div>
 
         <div className="govuk-grid-column-one-third paas-summary-section">

--- a/src/components/org-users/_org-users.scss
+++ b/src/components/org-users/_org-users.scss
@@ -8,30 +8,32 @@
  }
 }
 
-table.user-list {
-  .name {
-    min-width: 280px;
-    width: 20%;
-  }
+.user-list-table {
+  @include govuk-media-query($from:desktop) {
+    .name {
+      min-width: 280px;
+      width: 20%;
+    }
 
-  .authentication {
-    width: 15%;
-  }
+    .authentication {
+      width: 15%;
+    }
 
-  th.is-billing-manager {
-    width: 15%;
-  }
+    th.is-billing-manager {
+      width: 15%;
+    }
 
-  th.is-org-manager {
-    width: 15%;
-  }
+    th.is-org-manager {
+      width: 15%;
+    }
 
-  th.is-org-auditor {
-    width: 15%;
-  }
+    th.is-org-auditor {
+      width: 15%;
+    }
 
-  th.spaces {
-    width: 20%;
+    th.spaces {
+      width: 20%;
+    }
   }
 }
 

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -701,7 +701,8 @@ export function OrganizationUsersPage(
             </div>
           </div>
           <h2 className="govuk-heading-m">Current team members</h2>
-          <table className="govuk-table user-list">
+          <div className="scrollable-table-container">
+            <table className="govuk-table user-list-table">
             <thead className="govuk-table__head">
               <tr className="govuk-table__row">
                 <th className="govuk-table__header name" scope="col">
@@ -806,6 +807,7 @@ export function OrganizationUsersPage(
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -61,7 +61,8 @@ export function OrganizationsPage(
         {singleOrg ? 'organisation' : 'organisations'} which you can access.
       </p>
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th
@@ -77,6 +78,7 @@ export function OrganizationsPage(
         </thead>
         <tbody className="govuk-table__body">{organizations}</tbody>
       </table>
+      </div>
 
       <p className="govuk-body">
         To request new GOV.UK PaaS organisations,{' '}

--- a/src/components/platform-admin/views.tsx
+++ b/src/components/platform-admin/views.tsx
@@ -267,7 +267,8 @@ export function CreateOrganizationPage(props: ICreateOrganizationPageProperties)
     </form>
 
     <div className="govuk-grid-column-one-half">
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <caption className="govuk-table__caption">Existing owners</caption>
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
@@ -282,6 +283,7 @@ export function CreateOrganizationPage(props: ICreateOrganizationPageProperties)
             </tr>)}
         </tbody>
       </table>
+      </div>
     </div>
   </div>);
 }

--- a/src/components/reports/views.tsx
+++ b/src/components/reports/views.tsx
@@ -130,7 +130,8 @@ export function OrganizationsReport(
 
       <p className="govuk-body">Sorted by age; oldest first.</p>
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header">Organisation</th>
@@ -178,6 +179,7 @@ export function OrganizationsReport(
           ))}
         </tbody>
       </table>
+      </div>
 
       <h2 className="govuk-heading-m">Billable accounts</h2>
 
@@ -189,7 +191,8 @@ export function OrganizationsReport(
 
       <p className="govuk-body">Sorted by age; newest first.</p>
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header">Organisation</th>
@@ -234,6 +237,7 @@ export function OrganizationsReport(
           ))}
         </tbody>
       </table>
+      </div>
     </>
   );
 }
@@ -274,7 +278,8 @@ export function CostReport(props: ICostReportProperties): ReactElement {
         Billables by organisation for {props.date}
       </h1>
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header" scope="col">
@@ -324,10 +329,12 @@ export function CostReport(props: ICostReportProperties): ReactElement {
         </tbody>
         <tfoot />
       </table>
+      </div>
 
       <h1 className="govuk-heading-l">Billables by quota for {props.date}</h1>
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header" scope="col">
@@ -372,6 +379,7 @@ export function CostReport(props: ICostReportProperties): ReactElement {
           ))}
         </tbody>
       </table>
+      </div>
     </>
   );
 }
@@ -381,7 +389,8 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
     <>
       <h1 className="govuk-heading-l">Billables by service for {props.date}</h1>
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header" scope="col">
@@ -425,12 +434,14 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
         </tbody>
         <tfoot />
       </table>
+      </div>
 
       <h1 className="govuk-heading-l">
         Billables by organisation and service for {props.date}
       </h1>
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header" scope="col">
@@ -480,12 +491,14 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
         </tbody>
         <tfoot />
       </table>
+      </div>
 
       <h1 className="govuk-heading-l">
         Billables by organisation and space and service for {props.date}
       </h1>
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header" scope="col">
@@ -539,6 +552,7 @@ export function CostByServiceReport(props: ICostByServiceReport): ReactElement {
         </tbody>
         <tfoot />
       </table>
+      </div>
     </>
   );
 }

--- a/src/components/service-events/views.tsx
+++ b/src/components/service-events/views.tsx
@@ -110,7 +110,8 @@ export function ServiceEventsPage(
         pagination={props.pagination}
       />
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header">Date</th>
@@ -144,6 +145,7 @@ export function ServiceEventsPage(
           ))}
         </tbody>
       </table>
+      </div>
     </ServiceTab>
   );
 }

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -146,7 +146,8 @@ function Metric(props: IMetricProperties): ReactElement {
         </a>
       </div>
       <div className="govuk-grid-column-one-third-from-desktop">
-        <table className="govuk-table">
+        <div className="scrollable-table-container">
+          <table className="govuk-table">
           <caption className="govuk-table__caption govuk-visually-hidden">
             Summary
           </caption>
@@ -208,6 +209,7 @@ function Metric(props: IMetricProperties): ReactElement {
             />
           </tbody>
         </table>
+        </div>
       </div>
     </div>
   );

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -109,7 +109,8 @@ export function ServicePage(props: IServicePageProperties): ReactElement {
     <ServiceTab {...props}>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <table className="govuk-table">
+          <div className="scrollable-table-container">
+            <table className="govuk-table">
             <caption className="govuk-table__caption">Service details</caption>
             <tbody className="govuk-table__body">
               <tr className="govuk-table__row">
@@ -155,6 +156,7 @@ export function ServicePage(props: IServicePageProperties): ReactElement {
               </tr>
             </tbody>
           </table>
+          </div>
 
           <CommandLineAlternative context="for all of your services">
             cf services

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -299,8 +299,8 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
           </a>
         </div>
       </details>
-
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th
@@ -361,6 +361,7 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
           ))}
         </tbody>
       </table>
+      </div>
     </>
   );
 }
@@ -430,7 +431,8 @@ export function ApplicationsPage(
         {props.applications.length === 1 ? 'application' : 'applications'}
       </p>
       {props.applications.length > 0 ? (
-        <table className="govuk-table">
+        <div className="scrollable-table-container">
+          <table className="govuk-table">
           <thead className="govuk-table__head">
             <tr className="govuk-table__row">
               <th className="govuk-table__header name" scope="col">
@@ -508,6 +510,7 @@ export function ApplicationsPage(
             ))}
           </tbody>
         </table>
+        </div>
         ) : (
           <></>
         )
@@ -532,7 +535,8 @@ export function BackingServicePage(
       </p>
 
       {props.services.length > 0 ? (
-        <table className="govuk-table">
+        <div className="scrollable-table-container">
+          <table className="govuk-table">
           <thead className="govuk-table__head">
             <tr className="govuk-table__row">
               <th className="govuk-table__header name" scope="col">
@@ -580,6 +584,7 @@ export function BackingServicePage(
             ))}
           </tbody>
         </table>
+        </div>
         ) : (
           <></>
         )
@@ -619,7 +624,8 @@ export function EventsPage(props: IEventsPageProperties): ReactElement {
         pagination={props.pagination}
       />
 
-      <table className="govuk-table">
+      <div className="scrollable-table-container">
+        <table className="govuk-table">
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th className="govuk-table__header">Date</th>
@@ -654,6 +660,7 @@ export function EventsPage(props: IEventsPageProperties): ReactElement {
           ))}
         </tbody>
       </table>
+      </div>
 
       <Pagination
         space={props.space}

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -75,7 +75,8 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
             className="paas-statement-range"
           >
             <input type="hidden" name="_csrf" value={props.csrf} />
-            <table className="govuk-table paas-statement-filters">
+            <div className="scrollable-table-container">
+              <table className="govuk-table paas-statement-filters">
               <tbody className="govuk-table__body">
                 <tr className="govuk-table__row">
                   <th className="govuk-table__header" scope="column">
@@ -160,6 +161,7 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
                 </tr>
               </tbody>
             </table>
+            </div>
 
             <input type="hidden" name="sort" value={props.orderBy} />
             <input type="hidden" name="order" value={props.orderDirection} />
@@ -167,7 +169,8 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
         </div>
 
         <div className="govuk-grid-column-full">
-          <table className="govuk-table paas-exchange-rate">
+          <div className="scrollable-table-container">
+            <table className="govuk-table paas-exchange-rate">
             <tr className="govuk-table__row">
               <th className="govuk-table__header" scope="row">
                 Total cost for {props.currentMonth}{' '}
@@ -245,7 +248,7 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
               <td className="paas-month-price">inc VAT at 20%</td>
             </tr>
           </table>
-
+          </div>
           <p>
             <a
               href={props.linkTo('admin.statement.download', {
@@ -294,7 +297,8 @@ function Statement(props: IStatementProps): ReactElement {
         <input type="hidden" name="space" value={props.filterSpace?.guid} />
         <input type="hidden" name="service" value={props.filterService?.guid} />
 
-        <table className="govuk-table paas-table-billing-statement">
+        <div className="scrollable-table-container">
+          <table className="govuk-table paas-table-billing-statement">
           <thead className="govuk-table__head">
             <tr className="govuk-table__row">
               <th className="govuk-table__header" scope="col">
@@ -412,6 +416,7 @@ function Statement(props: IStatementProps): ReactElement {
             ))}
           </tbody>
         </table>
+        </div>
       </form>
     </>
   );

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -68,3 +68,10 @@ abbr {
 .govuk-link:not([href*="//"]) {
   @include govuk-link-style-no-visited-state;
 }
+
+.scrollable-table-container {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+}


### PR DESCRIPTION
What
----

Make tables scrollable once the content is larger than the current viewport.
Only applied to tables that are meant to be a data tables.

We are wrapping tables in a scrollable container to retain the table properties for screenreaders

_The user permissions "table" will be addressed separately._

How to review
-----
- code review for sense check **(suggest commit by commit)**
- view my admin dev pages that the tables and check on mobile


Visual changes
------
Only when the content is greater than the viewport

## Before
![non-scrolling](https://user-images.githubusercontent.com/3758555/76966402-d105ae80-691d-11ea-914c-ca505f92fe66.gif)

## After
![scrollable table](https://user-images.githubusercontent.com/3758555/76966428-db27ad00-691d-11ea-925b-2c0ddc1da68b.gif)



