### PR TITLE
Remove back link

### DIFF
--- a/src/components/account/account.tsx
+++ b/src/components/account/account.tsx
@@ -65,10 +65,14 @@ export async function getUseGoogleSSO(
   }
 
   const user = await fetchLoggedInUser(ctx);
-  const template = new Template(
-    ctx.viewContext,
-    'Google Single Sign On - GOV.UK PaaS',
-  );
+  const template = new Template(ctx.viewContext, 'Use Google Single Sign-On');
+  template.breadcrumbs = [
+    {
+      href: ctx.linkTo('admin.home'),
+      text: 'Organisations',
+    },
+    { text: 'Use Google Single Sign-On' },
+  ];
 
   return {
     body: template.render(
@@ -180,10 +184,14 @@ export async function getUseMicrosoftSSO(
   }
 
   const user = await fetchLoggedInUser(ctx);
-  const template = new Template(
-    ctx.viewContext,
-    'Microsoft Single Sign On - GOV.UK PaaS',
-  );
+  const template = new Template(ctx.viewContext, 'Use Microsoft Single Sign-On');
+  template.breadcrumbs = [
+    {
+      href: ctx.linkTo('admin.home'),
+      text: 'Organisations',
+    },
+    { text: 'Use Microsoft Single Sign-On' },
+  ];
 
   return {
     body: template.render(

--- a/src/components/account/views.tsx
+++ b/src/components/account/views.tsx
@@ -26,18 +26,12 @@ function Message(props: IMessageProperties): ReactElement {
         {props.children}
 
         <p className="govuk-body">
-          If you have any queries, contact{' '}
-          <a
-            className="govuk-link"
-            href="https://www.cloud.service.gov.uk/support"
-          >
+          If you have any queries, contact
+          {' '}
+          <a className="govuk-link" href="https://www.cloud.service.gov.uk/support">
             support
-          </a>
-          .
+          </a>.
         </p>
-        <a href={props.linkTo('admin.home')} className="govuk-back-link">
-          Back to account
-        </a>
       </div>
     </div>
   );
@@ -106,9 +100,6 @@ export function UnsuccessfulUpliftPage(props: IProperties): ReactElement {
 export function SSOPage(props: ISSOPageProperties): ReactElement {
   return (
     <>
-      <a href={props.linkTo('admin.home')} className="govuk-back-link">
-        Back
-      </a>
       <div className="govuk-grid-row">
         {props.user.origin === 'uaa' ? (
           <div className="govuk-grid-column-two-thirds">

--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -1,3 +1,10 @@
+// This module is just insane...
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable functional/no-let */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable functional/prefer-readonly-type */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/camelcase */
 import { isUndefined } from 'util';
 
 import lodash, { CollectionChain, mapValues, merge, values } from 'lodash';
@@ -464,6 +471,17 @@ export async function inviteUser(
     body,
   );
 
+  const template = new Template(ctx.viewContext, 'Invite a new team member');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.users', {
+        organizationGUID: organization.metadata.guid,
+      }),
+      text: 'Team members',
+    },
+    { text: 'Invite a new team member' },
+  ]);
+
   try {
     errors.push(...validateEmail(userBody), ...validatePermissions(userBody));
     if (errors.length > 0) {
@@ -547,7 +565,7 @@ export async function inviteUser(
       }
     }
 
-    const template = new Template(ctx.viewContext, 'Invited a new team member');
+    template.title = 'Invited a new team member';
 
     return {
       body: template.render(
@@ -562,20 +580,6 @@ export async function inviteUser(
   } catch (err) {
     /* istanbul ignore next */
     if (err instanceof ValidationError) {
-      const template = new Template(
-        ctx.viewContext,
-        'Invite a new team member',
-      );
-      template.breadcrumbs = fromOrg(ctx, organization, [
-        {
-          href: ctx.linkTo('admin.organizations.users', {
-            organizationGUID: organization.metadata.guid,
-          }),
-          text: 'Team members',
-        },
-        { text: 'Invite a new team member' },
-      ]);
-
       return {
         body: template.render(
           <InvitePage
@@ -681,6 +685,15 @@ export async function resendInvitation(
   });
 
   const template = new Template(ctx.viewContext, 'Invited a new team member');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.users', {
+        organizationGUID: organization.metadata.guid,
+      }),
+      text: 'Team members',
+    },
+    { text: 'Invite a new team member' },
+  ]);
 
   return {
     body: template.render(
@@ -819,7 +832,7 @@ export async function editUser(
       }),
       text: 'Team members',
     },
-    { text: accountsUser.email },
+    { text: 'Update a team member' },
   ]);
 
   /* istanbul ignore next */
@@ -920,6 +933,15 @@ export async function updateUser(
     );
 
     const template = new Template(ctx.viewContext, 'Updated a team member');
+    template.breadcrumbs = fromOrg(ctx, organization, [
+      {
+        href: ctx.linkTo('admin.organizations.users', {
+          organizationGUID: organization.metadata.guid,
+        }),
+        text: 'Team members',
+      },
+      { text: 'Update a team member' },
+    ]);
 
     return {
       body: template.render(
@@ -1024,6 +1046,15 @@ export async function confirmDeletion(
   }
 
   const template = new Template(ctx.viewContext, 'Confirm user deletion');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.users', {
+        organizationGUID: organization.metadata.guid,
+      }),
+      text: 'Team members',
+    },
+    { text: 'Delete a team member' },
+  ]);
 
   return {
     body: template.render(
@@ -1070,6 +1101,15 @@ export async function deleteUser(
   );
 
   const template = new Template(ctx.viewContext, 'Deleted a team member');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.users', {
+        organizationGUID: organization.metadata.guid,
+      }),
+      text: 'Team members',
+    },
+    { text: 'Delete a team member' },
+  ]);
 
   return {
     body: template.render(

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -364,18 +364,6 @@ export function DeleteConfirmationPage(
 ): ReactElement {
   return (
     <div className="govuk-grid-row">
-      <div className="govuk-grid-column-one-half">
-        <a
-          href={props.linkTo('admin.organizations.users.edit', {
-            organizationGUID: props.organizationGUID,
-            userGUID: props.user.metadata.guid,
-          })}
-          className="govuk-back-link"
-        >
-          See user view
-        </a>
-      </div>
-
       <div className="govuk-grid-column-two-thirds">
         <form method="post" className="govuk-!-mt-r6 paas-remove-user">
           <input type="hidden" name="_csrf" value={props.csrf} />
@@ -411,18 +399,7 @@ export function DeleteConfirmationPage(
 export function SuccessPage(props: ISuccessPageProperties): ReactElement {
   return (
     <div className="govuk-grid-row">
-      <div className="govuk-grid-column-one-half">
-        <a
-          href={props.linkTo('admin.organizations.users', {
-            organizationGUID: props.organizationGUID,
-          })}
-          className="govuk-back-link"
-        >
-          See all team members
-        </a>
-      </div>
-
-      <div className="govuk-grid-column-one-half govuk-!-pt-r1 text-right">
+      <div className="govuk-grid-column-full govuk-!-pt-r1 text-right">
         <a
           href={props.linkTo('admin.organizations.users.invite', {
             organizationGUID: props.organizationGUID,
@@ -450,15 +427,6 @@ export function EditPage(props: IEditPageProperties): ReactElement {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">
-        <a
-          href={props.linkTo('admin.organizations.users', {
-            organizationGUID: props.organization.metadata.guid,
-          })}
-          className="govuk-back-link"
-        >
-          See all team members
-        </a>
-
         <h1 className="govuk-heading-l">
           <span className="govuk-caption-l">Team member</span> {props.email}
         </h1>
@@ -561,15 +529,6 @@ export function InvitePage(props: IInvitePageProperties): ReactElement {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">
-        <a
-          href={props.linkTo('admin.organizations.users', {
-            organizationGUID: props.organization.metadata.guid,
-          })}
-          className="govuk-back-link"
-        >
-          See all team members
-        </a>
-
         <h1 className="govuk-heading-l">Invite a new team member</h1>
 
         {props.errors && props.errors.length > 0 ? (

--- a/src/layouts/template.tsx
+++ b/src/layouts/template.tsx
@@ -65,8 +65,7 @@ export class Template {
           <link rel="apple-touch-icon"
             href="${assetPath}/images/govuk-apple-touch-icon.png" />
 
-          <meta name="x-user-identity-origin" content="${this.ctx.origin ||
-            ''}" />
+          <meta name="x-user-identity-origin" content="${this.ctx.origin || ''}" />
 
           <!--[if !IE 8]><!-->
             <link href="${govukStyles}" media="screen" rel="stylesheet" />
@@ -83,69 +82,43 @@ export class Template {
 
           <meta property="og:image" content="${assetURL}/images/govuk-opengraph-image.png" />
         </head>
-        ${renderToStaticMarkup(
-          <body className="govuk-template__body">
-            <this.EnableClientSideJavaScript />
+          <body class="govuk-template__body">
+            <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-            <a href="#main-content" className="govuk-skip-link">
+            <a href="#main-content" class="govuk-skip-link">
               Skip to main content
             </a>
 
-            <Header
-              location={this.ctx.location}
-              isPlatformAdmin={!!this.ctx.isPlatformAdmin}
-            />
+            ${renderToStaticMarkup(<>
+              <Header location={this.ctx.location} isPlatformAdmin={!!this.ctx.isPlatformAdmin} />
 
-            <div className="govuk-width-container">
-              <PhaseBanner tag={{ text: 'beta' }}>
-                <a
-                  className="govuk-link"
-                  href="https://www.cloud.service.gov.uk/support"
-                >
-                  Get support
-                </a>{' '}
-                or{' '}
-                <a
-                  className="govuk-link"
-                  href="https://www.cloud.service.gov.uk/pricing"
-                >
-                  view our pricing
-                </a>
-              </PhaseBanner>
-              {this._subnav ? (
-                <SubNavigation
-                  title={this._subnav.title}
-                  items={this._subnav.items}
-                />
-              ) : (
-                undefined
-              )}
-              {this._breadcrumbs ? (
-                <Breadcrumbs items={this._breadcrumbs} />
-              ) : (
-                undefined
-              )}
-              <Main>{page}</Main>
-            </div>
+              <div className="govuk-width-container">
+                <PhaseBanner tag={{ text: 'beta' }}>
+                  <a className="govuk-link" href="https://www.cloud.service.gov.uk/support">
+                    Get support
+                  </a>
+                  {' '}or{' '}
+                  <a className="govuk-link" href="https://www.cloud.service.gov.uk/pricing">
+                    view our pricing
+                  </a>
+                </PhaseBanner>
 
-            <Footer />
+                {this._subnav
+                  ? <SubNavigation title={this._subnav.title} items={this._subnav.items} />
+                  : undefined}
 
-            <script src={`${assetPath}/all.js`}></script>
-            <script src={`${assetPath}/init.js`}></script>
-          </body>,
-        )}
+                {this._breadcrumbs
+                  ? <Breadcrumbs items={this._breadcrumbs} />
+                  : undefined}
+
+                <Main>{page}</Main>
+              </div>
+
+              <Footer />
+            </>)}
+          <script src="${assetPath}/all.js"></script>
+          <script src="${assetPath}/init.js"></script>
+        </body>
       </html>`;
-  }
-
-  private EnableClientSideJavaScript(): ReactElement {
-    return (
-      <script
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{
-          __html:
-            'document.body.className = ((document.body.className) ? document.body.className + \' js-enabled\' : \'js-enabled\');',
-        }}
-      ></script>
-    );
   }
 }


### PR DESCRIPTION
What
----

Originally, the intention was to move the back-link out of the
main-content element into the template and make it triggerable per page.

However, the back-link should not be used with breadcrumbs, which it
was. I've decided to just deprecate back-links completely, in favor of
breadcrumbs and introduce these where the back-links use to be.

As a bonus, I'm cleaning up the template file.

Some of this code is static enough and doesn't need to be managed with
TSX. We're moving it to the actual raw template, which will prevent us
from having the rightful and yet wrong danger warning about insecure
HTML.

How to review
-------------

- Sanity check
- Code review
- Deploy to your env (or see rafalp)
- Navigate around the pages that use to have back-links
- See if the breadcrumbs are there
- See if the breadcrumbs are good replacement

Context
--------

> Never use the back link component together with breadcrumbs.

Source: https://design-system.service.gov.uk/components/back-link/