### PR TITLE
Fix CSV metrics download

### DIFF
--- a/src/components/service-metrics/controllers.test.tsx
+++ b/src/components/service-metrics/controllers.test.tsx
@@ -488,7 +488,7 @@ describe('service metrics test suite', () => {
       .split('\n')
       .filter(line => line.length > 0);
 
-    expect(lines.length).toEqual(2);
+    expect(lines.length).toBeGreaterThan(2);
 
     const [{}, first, ...{}] = lines;
     const [{}, firstDate, {}] = first.split(',');
@@ -544,7 +544,7 @@ describe('service metrics test suite', () => {
 
     const lines = response.download!.data.split('\n');
 
-    expect(lines.length).toEqual(2);
+    expect(lines.length).toBeGreaterThan(2);
 
     const [{}, first, ...{}] = lines;
     const [{}, {}, firstDate, {}] = first.split(',');
@@ -604,7 +604,7 @@ describe('service metrics test suite', () => {
 
     const lines = response.download!.data.split('\n');
 
-    expect(lines.length).toEqual(2);
+    expect(lines.length).toBeGreaterThan(2);
 
     const [{}, first, ...{}] = lines;
     const [{}, firstDate, ...{}] = first.split(',');
@@ -657,7 +657,7 @@ describe('service metrics test suite', () => {
 
     const lines = response.download!.data.split('\n');
 
-    expect(lines.length).toEqual(2);
+    expect(lines.length).toBeGreaterThan(2);
 
     const [{}, first, ...{}] = lines;
     const [{}, {}, firstDate, {}] = first.split(',');

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -506,7 +506,7 @@ export async function downloadServiceMetrics(
     throw new Error(`Did not get metric ${params.metric} for ${serviceLabel}`);
   }
 
-  const csvData = [headers, contents];
+  const csvData = [headers, ...contents];
 
   return {
     download: {

--- a/src/components/service-metrics/views.test.tsx
+++ b/src/components/service-metrics/views.test.tsx
@@ -1,0 +1,10 @@
+import { parseURL } from './views';
+
+describe(parseURL, () => {
+  it('should correctly prepare URL', () => {
+    expect(parseURL('/test', { a: 'test' })).not.toContain('//');
+    expect(parseURL('/test', { a: 'test', b: 'success' })).toEqual('/test?a=test&b=success');
+    expect(parseURL('/test?d=good&c=old', { a: 'test', b: 'success', c: 'new' }))
+      .toEqual('/test?d=good&c=new&a=test&b=success');
+  });
+});

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -141,7 +141,7 @@ function Metric(props: IMetricProperties): ReactElement {
 
         <MetricChart chart={props.chart.outerHTML} />
 
-        <a href={downloadLink.toString()} className="govuk-link">
+        <a href={downloadLink.toString()} className="govuk-link" download>
           Download &quot;{props.titleText || props.title}&quot; as a CSV
         </a>
       </div>

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -73,8 +73,8 @@ function formatValue(value: number, format?: string): ReactNode {
   }
 }
 
-function parseURL(path: string, params: object): string {
-  const u = new URL(`https://example.com/${path}`);
+export function parseURL(path: string, params: object): string {
+  const u = new URL(`https://example.com/${path.replace(/^\/+/, '')}`);
   forIn(params, (value, key) => {
     u.searchParams.set(key, value);
   });


### PR DESCRIPTION
What
----

The current approach forces the URLs to have two leading slashes, so
they're interpreted as absolute links and cause the links to not work.

The CSV files have only two lines, but a lot of entries in the second
line. This is functionality that use to work fine, before I got to it
and broke it down. Weirdly, I've also modified the tests that were
presumably correct at the time...

Applied fixes to hopefully not let that happen again.

How to review
-------------

- Code review
- Run in ACTUAL env not locally, (or see rafalp)
- Download the CSV files
  1. Navigate to `admin` organisation > `billing` space > `Backing Services` tab > `billing-db` service > `Metrics` tab
  1. Scroll down to a chart and hit `Download "xxxxxxx" as a CSV`
  1. Expect a file to be downloaded
  1. Open Finder in the location of the file
  1. Select the file
  1. Hit `Space` key
  1. See multiple rows, expect more than 2
  1. See only enough columns per heading
  1. For good measure, run the above steps on environment with broken version of pazmin