### PR TITLE
Implement Service Logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1948,6 +1948,15 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/aws-sdk": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/aws-sdk/-/aws-sdk-2.7.0.tgz",
+      "integrity": "sha1-g1iLPRTr3KHUzl4CM4dXdWjOgvM=",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
@@ -3574,6 +3583,63 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
+    "aws-sdk": {
+      "version": "2.654.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.654.0.tgz",
+      "integrity": "sha512-RAx/SJ74zAqBW1wyRxiHNflmrv50i35pu8kPxfMIJ418TJzIMt+LKgn55rTJgyUdUzKi+MC9XMY4n7IDtwj3HA==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -10870,8 +10936,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -13457,6 +13522,11 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "jose": {
       "version": "1.25.0",
@@ -17330,8 +17400,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -18843,8 +18912,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "5.0.0",
@@ -21748,6 +21816,20 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "devDependencies": {
     "@intervolga/optimize-cssnano-plugin": "^1.0.6",
+    "@types/aws-sdk": "^2.7.0",
     "@types/body-parser": "^1.19.0",
     "@types/cheerio": "^0.22.17",
     "@types/compression": "^1.7.0",
@@ -107,6 +108,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-node": "^0.1.0-preview.2",
     "@aws-sdk/client-resource-groups-tagging-api-node": "0.1.0-preview.2",
+    "aws-sdk": "^2.654.0",
     "axios": "^0.19.2",
     "base32-encode": "^1.1.1",
     "compression": "^1.7.4",

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -75,8 +75,7 @@ export const router = new Router([
   {
     action: services.viewService,
     name: 'admin.organizations.spaces.services.view',
-    path:
-      '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID',
+    path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID',
   },
   {
     action: serviceMetrics.viewServiceMetrics,

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -108,6 +108,16 @@ export const router = new Router([
       '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/events/:eventGUID',
   },
   {
+    action: services.listServiceLogs,
+    name: 'admin.organizations.spaces.services.logs.view',
+    path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/logs',
+  },
+  {
+    action: services.downloadServiceLogs,
+    name: 'admin.organizations.spaces.services.logs.download',
+    path: '/organisations/:organizationGUID/spaces/:spaceGUID/services/:serviceGUID/logs/download',
+  },
+  {
     action: orgUsers.listUsers,
     name: 'admin.organizations.users',
     path: '/organisations/:organizationGUID/users',

--- a/src/components/services/controllers.mocked.test.tsx
+++ b/src/components/services/controllers.mocked.test.tsx
@@ -1,0 +1,177 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+import { RDS } from 'aws-sdk';
+
+import CloudFoundryClient from '../../lib/cf';
+import { createTestContext } from '../app/app.test-helpers';
+import { IContext } from '../app/context';
+
+import { downloadServiceLogs, listServiceLogs } from './controllers';
+
+jest.mock('aws-sdk');
+jest.mock('../../lib/cf');
+
+const mockCustomService = { metadata: { guid: 'CUSTOM_SERVICE' } };
+const mockServiceInstance = { entity: { name: 'mydb' }, metadata: { guid: 'SERVICE_INSTANCE_GUID' } };
+const mockServiceRedis = { entity: { label: 'redis' } };
+const mockServicePostgres = { entity: { label: 'postgres' } };
+const mockOrganization = { entity: { name: 'org-name' }, metadata: { guid: 'ORG_GUID' } };
+const mockSpace = { entity: { name: 'space-name' }, metadata: { guid: 'SPACE_GUID' } };
+
+const ctx: IContext = createTestContext();
+const CFClient = CloudFoundryClient as jest.Mock;
+
+describe(listServiceLogs, () => {
+  beforeEach(() => {
+    CFClient.mockClear();
+    // @ts-ignore
+    RDS.mockClear();
+  });
+
+
+  it('should throw an error if service is custom user service', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+
+    await expect(
+      listServiceLogs(ctx, { organizationGUID: 'ORG_GUID', serviceGUID: 'CUSTOM_SERVICE', spaceGUID: 'SPACE_GUID' }),
+    ).rejects.toThrowError(/Service Logs are only available for Postgres and MySQL instances/);
+  });
+
+
+  it('should throw an error if service is not supporting logs', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+    CFClient.prototype.space.mockReturnValueOnce(Promise.resolve(mockSpace));
+    CFClient.prototype.organization.mockReturnValueOnce(Promise.resolve(mockOrganization));
+    CFClient.prototype.serviceInstance.mockReturnValueOnce(Promise.resolve(mockServiceInstance));
+    CFClient.prototype.service.mockReturnValueOnce(Promise.resolve(mockServiceRedis));
+
+    await expect(
+      listServiceLogs(ctx, {
+        organizationGUID: 'ORG_GUID', serviceGUID: 'SERVICE_INSTANCE_GUID', spaceGUID: 'SPACE_GUID',
+      }),
+    ).rejects.toThrowError(/Service Logs are only available for Postgres and MySQL instances/);
+  });
+
+  it('should successfully list out all the files', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+    CFClient.prototype.space.mockReturnValueOnce(Promise.resolve(mockSpace));
+    CFClient.prototype.organization.mockReturnValueOnce(Promise.resolve(mockOrganization));
+    CFClient.prototype.serviceInstance.mockReturnValueOnce(Promise.resolve(mockServiceInstance));
+    CFClient.prototype.service.mockReturnValueOnce(Promise.resolve(mockServicePostgres));
+    // @ts-ignore
+    RDS.mockReturnValueOnce({
+      describeDBLogFiles: () => ({
+        promise: async () => await Promise.resolve({
+          DescribeDBLogFiles: [ { LastWritten: 1578837540000, LogFileName: 'file-one', Size: 73728 } ],
+        }),
+      }),
+    });
+
+    const response = await listServiceLogs(ctx, {
+      organizationGUID: 'ORG_GUID', serviceGUID: 'SERVICE_INSTANCE_GUID', spaceGUID: 'SPACE_GUID',
+    });
+
+    expect(response.body).toContain('mydb - Service Logs');
+    expect(response.body).toContain('file-one');
+  });
+});
+
+describe(downloadServiceLogs, () => {
+  beforeEach(() => {
+    CFClient.mockClear();
+    // @ts-ignore
+    RDS.mockClear();
+  });
+
+  it('should throw an error if filename is not defined', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+
+    await expect(
+      downloadServiceLogs(ctx, {}),
+    ).rejects.toThrowError(/The `filename` parameter needs to be provided/);
+  });
+
+  it('should throw an error if service is custom user service', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+
+    await expect(
+      downloadServiceLogs(ctx, {
+        filename: 'error/test',
+        organizationGUID: 'ORG_GUID',
+        serviceGUID: 'CUSTOM_SERVICE',
+        spaceGUID: 'SPACE_GUID',
+      }),
+    ).rejects.toThrowError(/Service Logs are only available for Postgres and MySQL instances/);
+  });
+
+
+  it('should throw an error if service is not supporting logs', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+    CFClient.prototype.space.mockReturnValueOnce(Promise.resolve(mockSpace));
+    CFClient.prototype.organization.mockReturnValueOnce(Promise.resolve(mockOrganization));
+    CFClient.prototype.serviceInstance.mockReturnValueOnce(Promise.resolve(mockServiceInstance));
+    CFClient.prototype.service.mockReturnValueOnce(Promise.resolve(mockServiceRedis));
+
+    await expect(
+      downloadServiceLogs(ctx, {
+        filename: 'error/test',
+        organizationGUID: 'ORG_GUID',
+        serviceGUID: 'SERVICE_INSTANCE_GUID',
+        spaceGUID: 'SPACE_GUID',
+      }),
+    ).rejects.toThrowError(/Service Logs are only available for Postgres and MySQL instances/);
+  });
+
+  it('should successfully download file', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+    CFClient.prototype.space.mockReturnValueOnce(Promise.resolve(mockSpace));
+    CFClient.prototype.organization.mockReturnValueOnce(Promise.resolve(mockOrganization));
+    CFClient.prototype.serviceInstance.mockReturnValueOnce(Promise.resolve(mockServiceInstance));
+    CFClient.prototype.service.mockReturnValueOnce(Promise.resolve(mockServicePostgres));
+    // @ts-ignore
+    RDS.mockReturnValueOnce({
+      downloadDBLogFilePortion: () => ({
+        promise: async () => await Promise.resolve({
+          LogFileData: '[TIMESTAMP] INFO: Log line\n[TIMESTAMP] ERROR: Another log line',
+        }),
+      }),
+    });
+
+    const response = await downloadServiceLogs(ctx, {
+      filename: 'error/test',
+      organizationGUID: 'ORG_GUID',
+      serviceGUID: 'SERVICE_INSTANCE_GUID',
+      spaceGUID: 'SPACE_GUID',
+    });
+
+    expect(response.download).toBeDefined();
+    expect(response.download!.data).toContain('[TIMESTAMP] ERROR: Another log line');
+    expect(response.download!.name).toEqual('db-SERVICE_INSTANCE_GUID-error-test.log');
+    expect(response.mimeType).toEqual('text/plain');
+  });
+
+  it('should successfully download an empty file if AWS returns undefined', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+    CFClient.prototype.space.mockReturnValueOnce(Promise.resolve(mockSpace));
+    CFClient.prototype.organization.mockReturnValueOnce(Promise.resolve(mockOrganization));
+    CFClient.prototype.serviceInstance.mockReturnValueOnce(Promise.resolve(mockServiceInstance));
+    CFClient.prototype.service.mockReturnValueOnce(Promise.resolve(mockServicePostgres));
+    // @ts-ignore
+    RDS.mockReturnValueOnce({
+      downloadDBLogFilePortion: () => ({
+        promise: async () => await Promise.resolve({}),
+      }),
+    });
+
+    const response = await downloadServiceLogs(ctx, {
+      filename: 'error/test',
+      organizationGUID: 'ORG_GUID',
+      serviceGUID: 'SERVICE_INSTANCE_GUID',
+      spaceGUID: 'SPACE_GUID',
+    });
+
+    expect(response.download).toBeDefined();
+    expect(response.download!.data).toEqual('\n');
+    expect(response.download!.name).toEqual('db-SERVICE_INSTANCE_GUID-error-test.log');
+    expect(response.mimeType).toEqual('text/plain');
+  });
+});

--- a/src/components/services/controllers.mocked.test.tsx
+++ b/src/components/services/controllers.mocked.test.tsx
@@ -73,6 +73,27 @@ describe(listServiceLogs, () => {
     expect(response.body).toContain('mydb - Service Logs');
     expect(response.body).toContain('file-one');
   });
+
+  it('should display info about lack of logs', async () => {
+    CFClient.prototype.userServices.mockReturnValueOnce(Promise.resolve([ mockCustomService ]));
+    CFClient.prototype.space.mockReturnValueOnce(Promise.resolve(mockSpace));
+    CFClient.prototype.organization.mockReturnValueOnce(Promise.resolve(mockOrganization));
+    CFClient.prototype.serviceInstance.mockReturnValueOnce(Promise.resolve(mockServiceInstance));
+    CFClient.prototype.service.mockReturnValueOnce(Promise.resolve(mockServicePostgres));
+    // @ts-ignore
+    RDS.mockReturnValueOnce({
+      describeDBLogFiles: () => ({
+        promise: async () => await Promise.resolve({}),
+      }),
+    });
+
+    const response = await listServiceLogs(ctx, {
+      organizationGUID: 'ORG_GUID', serviceGUID: 'SERVICE_INSTANCE_GUID', spaceGUID: 'SPACE_GUID',
+    });
+
+    expect(response.body).toContain('mydb - Service Logs');
+    expect(response.body).toContain('There are no log files available at this time.');
+  });
 });
 
 describe(downloadServiceLogs, () => {

--- a/src/components/services/controllers.tsx
+++ b/src/components/services/controllers.tsx
@@ -39,10 +39,10 @@ export async function viewService(
   const summarisedService = {
     entity: service.entity,
     metadata: service.metadata,
-    service_plan: servicePlan,
     service: servicePlan
       ? await cf.service(servicePlan.entity.service_guid)
       : undefined,
+    service_plan: servicePlan,
   };
 
   const template = new Template(
@@ -51,11 +51,11 @@ export async function viewService(
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
-      text: space.entity.name,
       href: ctx.linkTo('admin.organizations.spaces.services.list', {
         organizationGUID: organization.metadata.guid,
         spaceGUID: space.metadata.guid,
       }),
+      text: space.entity.name,
     },
     { text: summarisedService.entity.name },
   ]);

--- a/src/components/services/controllers.tsx
+++ b/src/components/services/controllers.tsx
@@ -1,12 +1,16 @@
+import { RDS } from 'aws-sdk';
 import React from 'react';
 
 import { Template } from '../../layouts';
 import CloudFoundryClient from '../../lib/cf';
-import { IParameters, IResponse } from '../../lib/router';
+import { IParameters, IResponse, NotFoundError } from '../../lib/router';
 import { IContext } from '../app/context';
 import { fromOrg } from '../breadcrumbs';
+import { UserFriendlyError } from '../errors';
 
-import { ServicePage } from './views';
+import { IServiceLogItem, ServiceLogsPage, ServicePage } from './views';
+
+const UNSUPPORTED_SERVICE_LOGS_REQUEST = 'Service Logs are only available for Postgres and MySQL instances.';
 
 export async function viewService(
   ctx: IContext,
@@ -70,5 +74,117 @@ export async function viewService(
         spaceGUID={space.metadata.guid}
       />,
     ),
+  };
+}
+
+export async function listServiceLogs(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const [userProvidedServices, space, organization] = await Promise.all([
+    cf.userServices(params.spaceGUID),
+    cf.space(params.spaceGUID),
+    cf.organization(params.organizationGUID),
+  ]);
+
+  const isUserProvidedService = userProvidedServices.some(
+    s => s.metadata.guid === params.serviceGUID,
+  );
+
+  if (isUserProvidedService) {
+    throw new UserFriendlyError(UNSUPPORTED_SERVICE_LOGS_REQUEST);
+  }
+
+  const serviceInstance = await cf.serviceInstance(params.serviceGUID);
+  const service = await cf.service(serviceInstance.entity.service_guid);
+
+  if (!['postgres', 'mysql'].includes(service.entity.label)) {
+    throw new UserFriendlyError(UNSUPPORTED_SERVICE_LOGS_REQUEST);
+  }
+
+  const rds = new RDS();
+  const fileList = await rds.describeDBLogFiles({
+    DBInstanceIdentifier: `rdsbroker-${serviceInstance.metadata.guid}`,
+    MaxRecords: 72,
+  }).promise();
+
+  const template = new Template(
+    ctx.viewContext,
+    `${serviceInstance.entity.name} - Service Logs`,
+  );
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.spaces.services.list', {
+        organizationGUID: organization.metadata.guid,
+        spaceGUID: space.metadata.guid,
+      }),
+      text: space.entity.name,
+    },
+    {
+      href: ctx.linkTo('admin.organizations.spaces.services.view', {
+        organizationGUID: organization.metadata.guid,
+        serviceGUID: serviceInstance.metadata.guid,
+        spaceGUID: space.metadata.guid,
+      }),
+      text: serviceInstance.entity.name,
+    },
+    { text: 'Logs' },
+  ]);
+
+  return {
+    body: template.render(<ServiceLogsPage
+      files={fileList.DescribeDBLogFiles as ReadonlyArray<IServiceLogItem>}
+      linkTo={ctx.linkTo}
+      organizationGUID={organization.metadata.guid}
+      routePartOf={ctx.routePartOf}
+      service={serviceInstance}
+      spaceGUID={space.metadata.guid}
+    />),
+  };
+}
+
+export async function downloadServiceLogs(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  if (!params.filename) {
+    throw new NotFoundError('The `filename` parameter needs to be provided.');
+  }
+
+  const userProvidedServices = await cf.userServices(params.spaceGUID);
+
+  const isUserProvidedService = userProvidedServices.some(
+    s => s.metadata.guid === params.serviceGUID,
+  );
+
+  if (isUserProvidedService) {
+    throw new UserFriendlyError(UNSUPPORTED_SERVICE_LOGS_REQUEST);
+  }
+
+  const serviceInstance = await cf.serviceInstance(params.serviceGUID);
+  const service = await cf.service(serviceInstance.entity.service_guid);
+
+  if (!['postgres', 'mysql'].includes(service.entity.label)) {
+    throw new UserFriendlyError(UNSUPPORTED_SERVICE_LOGS_REQUEST);
+  }
+
+  const rds = new RDS();
+  const file = await rds.downloadDBLogFilePortion({
+    DBInstanceIdentifier: `rdsbroker-${serviceInstance.metadata.guid}`,
+    LogFileName: params.filename,
+  }).promise();
+
+  return {
+    download: {
+      data: file.LogFileData || '\n',
+      name: `db-${serviceInstance.metadata.guid}-${params.filename.replace('/', '-')}.log`,
+    },
+    mimeType: 'text/plain',
   };
 }

--- a/src/components/services/controllers.tsx
+++ b/src/components/services/controllers.tsx
@@ -136,7 +136,7 @@ export async function listServiceLogs(ctx: IContext, params: IParameters): Promi
 
   return {
     body: template.render(<ServiceLogsPage
-      files={fileList.DescribeDBLogFiles as ReadonlyArray<IServiceLogItem>}
+      files={(fileList.DescribeDBLogFiles || []).reverse() as ReadonlyArray<IServiceLogItem>}
       linkTo={ctx.linkTo}
       organizationGUID={organization.metadata.guid}
       routePartOf={ctx.routePartOf}

--- a/src/components/services/services.scss
+++ b/src/components/services/services.scss
@@ -1,0 +1,5 @@
+.service-log-list-item__attribute {
+  &:last-child {
+    display: block;
+  }
+}

--- a/src/components/services/views.test.tsx
+++ b/src/components/services/views.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { IService, IServiceInstance, IServicePlan } from '../../lib/cf/types';
 
-import { ServicePage, ServiceTab } from './views';
+import { ServicePage, ServiceTab, ServiceLogsPage } from './views';
 
 describe(ServiceTab, () => {
   it('should produce service tab', () => {
@@ -35,7 +35,7 @@ describe(ServiceTab, () => {
       $('ul li:first-of-type').hasClass('govuk-tabs__list-item--selected'),
     ).toBe(true);
     expect($('ul li:last-of-type a').prop('href')).toEqual(
-      '__LINKS_TO__admin.organizations.spaces.services.events.view',
+      '__LINKS_TO__admin.organizations.spaces.services.logs.view',
     );
     expect(
       $('ul li:last-of-type').hasClass('govuk-tabs__list-item--selected'),
@@ -98,5 +98,42 @@ describe(ServicePage, () => {
     expect($('td.label').text()).toContain('User Provided Service');
     expect($('td.plan').text()).toContain('N/A');
     expect($('td.status').text()).toContain('N/A');
+  });
+});
+
+describe(ServiceLogsPage, () => {
+  const files = [
+    { LastWritten: 1578837540000, LogFileName: 'file-one', Size: 73728 },
+    { LastWritten: 1578841140000, LogFileName: 'file-two', Size: 1488978 },
+    { LastWritten: 1578844740000, LogFileName: 'file-three', Size: 0 },
+  ];
+  const service = ({
+    entity: { name: 'service-name' },
+    metadata: { guid: 'SERVICE_GUID' },
+  } as unknown) as IServiceInstance;
+
+  it('should print out the list of downloadable files', () => {
+    const markup = shallow(<ServiceLogsPage
+      files={files}
+      service={service}
+      linkTo={route => `__LINKS_TO__${route}`}
+      routePartOf={route => route === 'admin.organizations.spaces.services.logs.view'}
+      organizationGUID="ORG_GUID"
+      spaceGUID="SPACE_GUID"
+    />);
+
+    expect(markup.render().find('li.service-log-list-item').length).toEqual(3);
+
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('file-one');
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('72.00 KiB');
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('1:59pm, 12 January 2020');
+
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('file-two');
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('1.42 MiB');
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('2:59pm, 12 January 2020');
+
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('file-three');
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('0 B');
+    expect(markup.render().find('li.service-log-list-item').text()).toContain('3:59pm, 12 January 2020');
   });
 });

--- a/src/components/services/views.test.tsx
+++ b/src/components/services/views.test.tsx
@@ -136,4 +136,20 @@ describe(ServiceLogsPage, () => {
     expect(markup.render().find('li.service-log-list-item').text()).toContain('0 B');
     expect(markup.render().find('li.service-log-list-item').text()).toContain('3:59pm, 12 January 2020');
   });
+
+  it('should mention that there are no files available for download', () => {
+    const markup = shallow(<ServiceLogsPage
+      files={[]}
+      service={service}
+      linkTo={route => `__LINKS_TO__${route}`}
+      routePartOf={route => route === 'admin.organizations.spaces.services.logs.view'}
+      organizationGUID="ORG_GUID"
+      spaceGUID="SPACE_GUID"
+    />);
+
+    expect(markup.render().find('li.service-log-list-item').length).toEqual(0);
+
+    expect(markup.render().find('p').text())
+      .toContain('There are no log files available at this time.');
+  });
 });

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -231,20 +231,26 @@ export function ServiceLogsPage(props: IServiceLogsPageProperties): ReactElement
           <p className="govuk-body">
             Log timestamps are in UTC format.
           </p>
-          <ul className="govuk-list service-log-list">
-            {props.files.map(file => <FileListingItem
-              date={new Date(file.LastWritten)}
-              key={file.LogFileName}
-              link={props.linkTo('admin.organizations.spaces.services.logs.download', {
-                filename: file.LogFileName,
-                organizationGUID: props.organizationGUID,
-                serviceGUID: props.service.metadata.guid,
-                spaceGUID: props.spaceGUID,
-              })}
-              name={file.LogFileName}
-              size={file.Size}
-            />)}
-          </ul>
+
+          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+          {props.files.length > 0
+            ? <ul className="govuk-list service-log-list">
+                {props.files.map(file => <FileListingItem
+                  date={new Date(file.LastWritten)}
+                  key={file.LogFileName}
+                  link={props.linkTo('admin.organizations.spaces.services.logs.download', {
+                    filename: file.LogFileName,
+                    organizationGUID: props.organizationGUID,
+                    serviceGUID: props.service.metadata.guid,
+                    spaceGUID: props.spaceGUID,
+                  })}
+                  name={file.LogFileName}
+                  size={file.Size}
+                />)}
+              </ul>
+            : <p className="govuk-body">There are no log files available at this time.</p>
+          }
         </div>
       </div>
     </ServiceTab>

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -205,8 +205,11 @@ export function ServicePage(props: IServicePageProperties): ReactElement {
 
 function FileListingItem(props: IFileListingItemProperties): ReactElement {
   return <li className="service-log-list-item">
-    <a className="govuk-link" download href={props.link}>{props.name}</a>
-    <p className="govuk-body">
+    <a className="govuk-link" download href={props.link} aria-describedby={`download-${props.date.getTime()}`}>
+      {props.name}
+    </a>
+
+    <p className="govuk-body" id={`download-${props.date.getTime()}`}>
       <span className="govuk-visually-hidden">file type </span>
       <span className="service-log-list-item__attribute"><abbr title="record of events">LOG</abbr></span>,
       {' '}

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -27,7 +27,7 @@ interface ITabProperties {
   readonly children: string;
 }
 
-export function Tab(props: ITabProperties) {
+export function Tab(props: ITabProperties): ReactElement {
   const classess = ['govuk-tabs__list-item'];
   if (props.active) {
     classess.push('govuk-tabs__list-item--selected');
@@ -60,8 +60,8 @@ export function ServiceTab(props: IServiceTabProperties): ReactElement {
             )}
             href={props.linkTo('admin.organizations.spaces.services.view', {
               organizationGUID: props.organizationGUID,
-              spaceGUID: props.spaceGUID,
               serviceGUID: props.service.metadata.guid,
+              spaceGUID: props.spaceGUID,
             })}
           >
             Overview
@@ -74,8 +74,8 @@ export function ServiceTab(props: IServiceTabProperties): ReactElement {
               'admin.organizations.spaces.services.metrics.view',
               {
                 organizationGUID: props.organizationGUID,
-                spaceGUID: props.spaceGUID,
                 serviceGUID: props.service.metadata.guid,
+                spaceGUID: props.spaceGUID,
               },
             )}
           >
@@ -89,8 +89,8 @@ export function ServiceTab(props: IServiceTabProperties): ReactElement {
               'admin.organizations.spaces.services.events.view',
               {
                 organizationGUID: props.organizationGUID,
-                spaceGUID: props.spaceGUID,
                 serviceGUID: props.service.metadata.guid,
+                spaceGUID: props.spaceGUID,
               },
             )}
           >

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -16,6 +16,7 @@ $app-super-light-grey: #f8f8f8;
 @import '../components/org-users/permissions';
 
 @import '../components/statements/statements';
+@import '../components/services/services';
 @import '../components/service-metrics/service-metrics';
 @import '../components/charts/line-graph';
 

--- a/src/lib/router/route.ts
+++ b/src/lib/router/route.ts
@@ -16,7 +16,7 @@ export interface IResponse {
   readonly download?: IDownload;
   readonly redirect?: string;
   readonly status?: number;
-  readonly mimeType?: 'image/png' | 'text/csv';
+  readonly mimeType?: 'image/png' | 'text/csv' | 'text/plain';
 }
 
 export type ActionFunction = (


### PR DESCRIPTION
What
----

We'd like to allow RDS provided services, to obtain logs for the
instances in question.

Majority of the work is done for us by the AWS API and SDK.

How to review
-------------

- Code review
- Add IAM policies with accordance to alphagov/paas-aws-account-wide-terraform#214
- Deploy to your devenv
- Navigate to `admin` > `billing` > Backing Services > `billing-db` > Logs
- Use the feature

Preview
--------

![image](https://user-images.githubusercontent.com/2418945/78804935-ad7fd200-79b8-11ea-95f3-a065861234e5.png)
