### PR TITLE
Reduce number of columns on mobile

### DIFF
--- a/src/components/marketplace/_marketplace.scss
+++ b/src/components/marketplace/_marketplace.scss
@@ -18,8 +18,12 @@
 
 .marketplace-list {
   display: grid;
-  grid-template-columns: auto auto auto;
+  grid-template-columns: repeat(2, auto);
   grid-gap: .5rem;
+
+  @include govuk-media-query($from: tablet) {
+    grid-template-columns: repeat(3, auto);
+  }
 
   li {
     box-sizing: border-box;


### PR DESCRIPTION
## What

The mobile view is somewhat compact with the three services per row. We
can reduce the number of columns to two and leave without change on
desktop for better user experience.

### Before

<img width="383" alt="Screenshot 2020-04-09 at 10 33 04" src="https://user-images.githubusercontent.com/2418945/78880602-8cb58c00-7a4d-11ea-8354-d49b4ab74480.png">

### After

<img width="377" alt="Screenshot 2020-04-09 at 10 28 53" src="https://user-images.githubusercontent.com/2418945/78880439-4fe99500-7a4d-11ea-8400-920d26bf00c7.png">

## How to review

- Sanity check