### PR TITLE
Database log fixups

### DIFF
--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -229,7 +229,8 @@ export function ServiceLogsPage(props: IServiceLogsPageProperties): ReactElement
             The following are hourly chunks of downloadable logs for this service.
           </p>
           <p className="govuk-body">
-            At the moment, we only provide up to 72 hours of logs. Get in touch if you need a larger range of data.
+            At the moment, we provide only the 72 most recent log files.
+            Please get in touch if you need a larger range of data.
           </p>
           <p className="govuk-body">
             Log timestamps are in UTC format.


### PR DESCRIPTION
What
----

Improve wording on database logs page

Correctly return most recent 72 log files

How to review
-------------

Code review

[Observe production](https://admin.cloud.service.gov.uk/organisations/55b1eb7d-e4c5-4359-9466-dd3ca5b0e457/spaces/80d769ff-7b01-49a4-9fa4-f87edd5328f9/services/6093d337-6918-4b97-9709-97529114eb90/logs) where it is not showing log files past April 5

[Observe dev](https://admin.tlwr.dev.cloudpipeline.digital/organisations/85a9bbf2-4d62-479c-a97b-ac3295a659cb/spaces/8e232fe4-0492-41fc-bdd6-84e027ac718b/services/488ee14f-7e58-4a03-a11c-990243cb2596/logs) where most recent log files are shown

Who can review
---------------

Not @tlwr
