### PR TITLE
Add password reset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ OAUTH_CLIENT_ID="my-client-id" \
 OAUTH_CLIENT_SECRET="my-secret" \
 ACCOUNTS_SECRET="my-accounts-secret" \
 NOTIFY_API_KEY="qwerty123456" \
+NOTIFY_PASSWORD_RESET_TEMPLATE_ID="qwerty123456" \
 NOTIFY_WELCOME_TEMPLATE_ID="qwerty123456" \
 AWS_REGION="eu-west-2" \
 npm start

--- a/src/components/app/app.test.config.ts
+++ b/src/components/app/app.test.config.ts
@@ -37,6 +37,7 @@ export const config: IAppConfig = {
   location: 'Ireland',
   logger,
   notifyAPIKey: 'test-123456-qwerty',
+  notifyPasswordResetTemplateID: 'qwerty-123456',
   notifyWelcomeTemplateID: 'qwerty-123456',
   oauthClientID: 'key',
   oauthClientSecret: 'secret',

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -152,7 +152,7 @@ describe('app test suite', () => {
     expect(response.status).toEqual(200);
   });
 
-  it('should throw error when accessing marketplace without', async () => {
+  it('should throw error when accessing marketplace without services', async () => {
     nockCF
       .get('/v3/service_offerings').reply(404);
 
@@ -189,6 +189,20 @@ describe('app test suite', () => {
     const response = await request(app).get('/marketplace/SERVICE_GUID');
 
     expect(response.status).toEqual(500);
+  });
+
+  it('should be able to access password reset request page without login', async () => {
+    const app = init(config);
+    const response = await request(app).get('/password/request');
+
+    expect(response.status).toEqual(200);
+  });
+
+  it('should be able to access password reset page without login', async () => {
+    const app = init(config);
+    const response = await request(app).get('/password/reset?code=1234567890');
+
+    expect(response.status).toEqual(200);
   });
 
   it('should return a 403 when accessing /forbidden', async () => {

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -193,14 +193,14 @@ describe('app test suite', () => {
 
   it('should be able to access password reset request page without login', async () => {
     const app = init(config);
-    const response = await request(app).get('/password/request');
+    const response = await request(app).get('/password/request-reset');
 
     expect(response.status).toEqual(200);
   });
 
   it('should be able to access password reset page without login', async () => {
     const app = init(config);
-    const response = await request(app).get('/password/reset?code=1234567890');
+    const response = await request(app).get('/password/confirm-reset?code=1234567890');
 
     expect(response.status).toEqual(200);
   });

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -30,6 +30,7 @@ export interface IAppConfig {
   readonly location: string;
   readonly logger: BaseLogger;
   readonly notifyAPIKey: string;
+  readonly notifyPasswordResetTemplateID: string | null;
   readonly notifyWelcomeTemplateID: string | null;
   readonly oauthClientID: string;
   readonly oauthClientSecret: string;

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -125,7 +125,7 @@ export default function(config: IAppConfig): express.Express {
   );
 
   /* istanbul ignore next */
-  app.get('/password/request', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  app.get('/password/request-reset', (req: express.Request, res: express.Response, next: express.NextFunction) => {
     const route = router.findByName('users.password.request.form');
     const ctx = initContext(req, router, route, config);
 
@@ -138,7 +138,7 @@ export default function(config: IAppConfig): express.Express {
   );
 
   /* istanbul ignore next */
-  app.post('/password/request', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  app.post('/password/request-reset', (req: express.Request, res: express.Response, next: express.NextFunction) => {
     const route = router.findByName('users.password.request');
     const ctx = initContext(req, router, route, config);
 
@@ -151,7 +151,7 @@ export default function(config: IAppConfig): express.Express {
   );
 
   /* istanbul ignore next */
-  app.get('/password/reset', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  app.get('/password/confirm-reset', (req: express.Request, res: express.Response, next: express.NextFunction) => {
     const route = router.findByName('users.password.reset.form');
     const ctx = initContext(req, router, route, config);
 
@@ -164,7 +164,7 @@ export default function(config: IAppConfig): express.Express {
   );
 
   /* istanbul ignore next */
-  app.post('/password/reset', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  app.post('/password/confirm-reset', (req: express.Request, res: express.Response, next: express.NextFunction) => {
     const route = router.findByName('users.password.reset');
     const ctx = initContext(req, router, route, config);
 

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -15,6 +15,7 @@ import { getCalculator } from '../calculator';
 import { internalServerErrorMiddleware } from '../errors';
 import { listServices, viewService } from '../marketplace';
 import { termsCheckerMiddleware } from '../terms';
+import { resetPassword, resetPasswordObtainToken, resetPasswordProvideNew, resetPasswordRequestToken } from '../users';
 
 import { csp } from './app.csp';
 import { initContext } from './context';
@@ -30,8 +31,8 @@ export interface IAppConfig {
   readonly location: string;
   readonly logger: BaseLogger;
   readonly notifyAPIKey: string;
-  readonly notifyPasswordResetTemplateID: string | null;
-  readonly notifyWelcomeTemplateID: string | null;
+  readonly notifyPasswordResetTemplateID?: string;
+  readonly notifyWelcomeTemplateID?: string;
   readonly oauthClientID: string;
   readonly oauthClientSecret: string;
   readonly sessionSecret: string;
@@ -120,6 +121,58 @@ export default function(config: IAppConfig): express.Express {
           res.status(response.status || 200).send(response.body);
         })
         .catch(err => internalServerErrorMiddleware(err, req, res, next));
+    },
+  );
+
+  /* istanbul ignore next */
+  app.get('/password/request', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const route = router.findByName('users.password.request.form');
+    const ctx = initContext(req, router, route, config);
+
+    resetPasswordRequestToken(ctx, { ...req.query, ...req.params, ...route.parser.match(req.path) })
+      .then((response: IResponse) => {
+        res.status(response.status || 200).send(response.body);
+      })
+      .catch(err => internalServerErrorMiddleware(err, req, res, next));
+    },
+  );
+
+  /* istanbul ignore next */
+  app.post('/password/request', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const route = router.findByName('users.password.request');
+    const ctx = initContext(req, router, route, config);
+
+    resetPasswordObtainToken(ctx, { ...req.query, ...req.params, ...route.parser.match(req.path) }, req.body)
+      .then((response: IResponse) => {
+        res.status(response.status || 200).send(response.body);
+      })
+      .catch(err => internalServerErrorMiddleware(err, req, res, next));
+    },
+  );
+
+  /* istanbul ignore next */
+  app.get('/password/reset', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const route = router.findByName('users.password.reset.form');
+    const ctx = initContext(req, router, route, config);
+
+    resetPasswordProvideNew(ctx, { ...req.query, ...req.params, ...route.parser.match(req.path) })
+      .then((response: IResponse) => {
+        res.status(response.status || 200).send(response.body);
+      })
+      .catch(err => internalServerErrorMiddleware(err, req, res, next));
+    },
+  );
+
+  /* istanbul ignore next */
+  app.post('/password/reset', (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const route = router.findByName('users.password.reset');
+    const ctx = initContext(req, router, route, config);
+
+    resetPassword(ctx, { ...req.query, ...req.params, ...route.parser.match(req.path) }, req.body)
+      .then((response: IResponse) => {
+        res.status(response.status || 200).send(response.body);
+      })
+      .catch(err => internalServerErrorMiddleware(err, req, res, next));
     },
   );
 

--- a/src/components/app/context.ts
+++ b/src/components/app/context.ts
@@ -14,6 +14,7 @@ export interface IRawToken {
 }
 
 export interface IViewContext {
+  readonly authenticated: boolean;
   readonly csrf: string;
   readonly location: string;
   readonly origin?: string;
@@ -56,6 +57,7 @@ export function initContext(
     session: req.session,
     token: req.token,
     viewContext: {
+      authenticated: !!req.user,
       csrf: req.csrfToken(),
       isPlatformAdmin,
       location: config.location,

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -271,6 +271,28 @@ export const router = new Router([
     name: 'marketplace.service',
     path: '/marketplace/:serviceGUID',
   },
+  {
+    action: users.resetPasswordRequestToken,
+    name: 'users.password.request.form',
+    path: '/password/request',
+  },
+  {
+    action: users.resetPasswordObtainToken,
+    method: 'post',
+    name: 'users.password.request',
+    path: '/password/request',
+  },
+  {
+    action: users.resetPasswordProvideNew,
+    name: 'users.password.reset.form',
+    path: '/password/reset',
+  },
+  {
+    action: users.resetPassword,
+    method: 'post',
+    name: 'users.password.reset',
+    path: '/password/reset',
+  },
 ]);
 
 export default router;

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -274,24 +274,24 @@ export const router = new Router([
   {
     action: users.resetPasswordRequestToken,
     name: 'users.password.request.form',
-    path: '/password/request',
+    path: '/password/request-reset',
   },
   {
     action: users.resetPasswordObtainToken,
     method: 'post',
     name: 'users.password.request',
-    path: '/password/request',
+    path: '/password/request-reset',
   },
   {
     action: users.resetPasswordProvideNew,
     name: 'users.password.reset.form',
-    path: '/password/reset',
+    path: '/password/confirm-reset',
   },
   {
     action: users.resetPassword,
     method: 'post',
     name: 'users.password.reset',
-    path: '/password/reset',
+    path: '/password/confirm-reset',
   },
 ]);
 

--- a/src/components/users/controllers.test.tsx
+++ b/src/components/users/controllers.test.tsx
@@ -504,7 +504,7 @@ describe(users.resetPassword, () => {
     })).rejects.toThrowError(/Invalid password reset token/);
   });
 
-  it('should throw an error if passwords missmatch', async () => {
+  it('should throw an error if passwords mismatch', async () => {
     const response = await users.resetPassword(ctx, {}, {
       code: '1234567890',
       password: 'poiuytrewq',

--- a/src/components/users/controllers.tsx
+++ b/src/components/users/controllers.tsx
@@ -193,7 +193,7 @@ export async function resetPasswordObtainToken(
   const resetCode = await uaa.obtainPasswordResetCode(uaaUser.userName);
 
   const url = new URL(ctx.app.domainName);
-  url.pathname = '/password/reset';
+  url.pathname = '/password/confirm-reset';
   url.searchParams.set('code', resetCode);
 
   await notify.sendPasswordReminder(email, url.toString());

--- a/src/components/users/controllers.tsx
+++ b/src/components/users/controllers.tsx
@@ -234,7 +234,7 @@ export async function resetPassword(ctx: IContext, _params: IParameters, body: I
       body: template.render(<PasswordResetSetPasswordForm
         csrf={ctx.viewContext.csrf}
         code={body.code}
-        passwordMissmatch={true}
+        passwordMismatch={true}
       />),
       status: 400,
     };

--- a/src/components/users/controllers.tsx
+++ b/src/components/users/controllers.tsx
@@ -153,7 +153,7 @@ export async function resetPasswordObtainToken(
     template.title = 'Error: User not found';
 
     return {
-      body: template.render(<PasswordResetRequest csrf={ctx.viewContext.csrf} invalidEmail={true} />),
+      body: template.render(<PasswordResetRequest csrf={ctx.viewContext.csrf} userNotFound={true} />),
       status: 404,
     };
   }
@@ -166,7 +166,7 @@ export async function resetPasswordObtainToken(
     template.title = 'Error: User not found';
 
     return {
-      body: template.render(<PasswordResetRequest csrf={ctx.viewContext.csrf} invalidEmail={true} />),
+      body: template.render(<PasswordResetRequest csrf={ctx.viewContext.csrf} userNotFound={true} />),
       status: 404,
     };
   }
@@ -179,11 +179,7 @@ export async function resetPasswordObtainToken(
     template.title = `Error: You have enabled ${idpNice} single sign-on`;
 
     return {
-      body: template.render(
-        <PasswordResetRequest
-          csrf={ctx.viewContext.csrf}
-          invalidEmail={true} />,
-      ),
+      body: template.render(<PasswordResetRequest csrf={ctx.viewContext.csrf} userEnabledSSO={true} />),
     };
   }
 

--- a/src/components/users/controllers.tsx
+++ b/src/components/users/controllers.tsx
@@ -85,6 +85,9 @@ export async function getUser(ctx: IContext, params: IParameters): Promise<IResp
   });
 
   const uaaUser = await uaa.getUser(accountsUser.uuid);
+  if (!uaaUser) {
+    throw new NotFoundError('User not found');
+  }
   const origin = uaaUser.origin;
 
   const template = new Template(ctx.viewContext, 'User');

--- a/src/components/users/controllers.tsx
+++ b/src/components/users/controllers.tsx
@@ -115,7 +115,7 @@ export async function resetPasswordRequestToken(ctx: IContext, _params: IParamet
 export async function resetPasswordObtainToken(
   ctx: IContext, params: IParameters, body: IPasswordResetBody,
 ): Promise<IResponse> {
-  const VALID_EMAIL = /[^.]@[^.]/;
+  const VALID_EMAIL = /^[^@]*@[^@]*$/;
   const email = (/* istanbul ignore next */ body.email || '').toLowerCase();
   const template = new Template(ctx.viewContext, 'Request password reset');
 

--- a/src/components/users/controllers.tsx
+++ b/src/components/users/controllers.tsx
@@ -179,7 +179,7 @@ export async function resetPasswordObtainToken(
     template.title = `Error: You have enabled ${idpNice} single sign-on`;
 
     return {
-      body: template.render(<PasswordResetRequest csrf={ctx.viewContext.csrf} userEnabledSSO={true} />),
+      body: template.render(<PasswordResetRequest csrf={ctx.viewContext.csrf} userEnabledSSO={true} idpNice={idpNice}/>),
     };
   }
 

--- a/src/components/users/views.test.tsx
+++ b/src/components/users/views.test.tsx
@@ -117,11 +117,11 @@ describe(PasswordResetSetPasswordForm, () => {
     expect(markup.text()).not.toContain('You need to type in the same password twice');
   });
 
-  it('should correctly throw an error when passwordMissmatch flag on', () => {
+  it('should correctly throw an error when passwordMismatch flag on', () => {
     const markup = shallow(<PasswordResetSetPasswordForm
       code="PASSWORD_RESET_CODE"
       csrf="CSRF_TOKEN"
-      passwordMissmatch={true}
+      passwordMismatch={true}
     />);
     expect(markup.render().find('input[name=_csrf]').val()).toEqual('CSRF_TOKEN');
     expect(markup.render().find('input[name=code]').val()).toEqual('PASSWORD_RESET_CODE');

--- a/src/components/users/views.test.tsx
+++ b/src/components/users/views.test.tsx
@@ -7,7 +7,7 @@ import { DATE_TIME } from '../../layouts';
 import { IUserSummaryOrganization } from '../../lib/cf/types';
 import { IUaaGroup } from '../../lib/uaa';
 
-import { UserPage } from './views';
+import { PasswordResetRequest, PasswordResetSetPasswordForm, PasswordResetSuccess, UserPage } from './views';
 
 function linker(_route: string, params: any): string {
   return params?.organizationGUID
@@ -70,5 +70,61 @@ describe(UserPage, () => {
     const $ = cheerio.load(markup.html());
     expect($('p').text()).toContain('This user is a member of 1 org.');
     expect($('p').text()).toContain('This user manages 2 orgs.');
+  });
+});
+
+describe(PasswordResetRequest, () => {
+  it('should correctly produce the syntax', () => {
+    const markup = shallow(<PasswordResetRequest csrf="CSRF_TOKEN" />);
+    expect(markup.render().find('input[name=_csrf]').val()).toEqual('CSRF_TOKEN');
+    expect(markup.text()).not.toContain('Enter an email address in the correct format, like name@example.com');
+  });
+
+  it('should correctly throw an error when invalidEmail flag on', () => {
+    const markup = shallow(<PasswordResetRequest
+      csrf="CSRF_TOKEN"
+      invalidEmail={true}
+      values={{ email: 'jeff@example.com' }}
+    />);
+    expect(markup.render().find('input[name=_csrf]').val()).toEqual('CSRF_TOKEN');
+    expect(markup.render().find('input[name=email]').val()).toEqual('jeff@example.com');
+    expect(markup.text()).toContain('Enter an email address in the correct format, like name@example.com');
+  });
+
+  it('should correctly throw an error when invalidEmail flag on and no values passed back', () => {
+    const markup = shallow(<PasswordResetRequest
+      csrf="CSRF_TOKEN"
+      invalidEmail={true}
+    />);
+    expect(markup.render().find('input[name=_csrf]').val()).toEqual('CSRF_TOKEN');
+    expect(markup.render().find('input[name=email]').val()).toBeUndefined();
+    expect(markup.text()).toContain('Enter an email address in the correct format, like name@example.com');
+  });
+});
+
+describe(PasswordResetSuccess, () => {
+  it('should correctly produce the syntax', () => {
+    const markup = shallow(<PasswordResetSuccess title="Success" />);
+    expect(markup.find('h1').text()).toEqual('Success');
+  });
+});
+
+describe(PasswordResetSetPasswordForm, () => {
+  it('should correctly produce the syntax', () => {
+    const markup = shallow(<PasswordResetSetPasswordForm csrf="CSRF_TOKEN" code="PASSWORD_RESET_CODE" />);
+    expect(markup.render().find('input[name=_csrf]').val()).toEqual('CSRF_TOKEN');
+    expect(markup.render().find('input[name=code]').val()).toEqual('PASSWORD_RESET_CODE');
+    expect(markup.text()).not.toContain('You need to type in the same password twice');
+  });
+
+  it('should correctly throw an error when passwordMissmatch flag on', () => {
+    const markup = shallow(<PasswordResetSetPasswordForm
+      code="PASSWORD_RESET_CODE"
+      csrf="CSRF_TOKEN"
+      passwordMissmatch={true}
+    />);
+    expect(markup.render().find('input[name=_csrf]').val()).toEqual('CSRF_TOKEN');
+    expect(markup.render().find('input[name=code]').val()).toEqual('PASSWORD_RESET_CODE');
+    expect(markup.text()).toContain('You need to type in the same password twice');
   });
 });

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -20,6 +20,8 @@ interface IUserPageProps {
 interface IPasswordResetFormProperties {
   readonly csrf: string;
   readonly invalidEmail?: boolean;
+  readonly userEnabledSSO?: boolean;
+  readonly userNotFound?: boolean;
   readonly values?: {
     readonly email: string;
   };
@@ -125,7 +127,7 @@ export function UserPage(props: IUserPageProps): ReactElement {
 export function PasswordResetRequest(props: IPasswordResetFormProperties): ReactElement {
   return <div className="govuk-grid-row">
     <div className="govuk-grid-column-two-thirds">
-      {props.invalidEmail ? <div
+      {props.invalidEmail || props.userEnabledSSO || props.userNotFound ? <div
         className="govuk-error-summary"
         aria-labelledby="error-summary-title"
         role="alert"
@@ -136,21 +138,34 @@ export function PasswordResetRequest(props: IPasswordResetFormProperties): React
           There is a problem
         </h2>
 
-        <div className="govuk-error-summary__body">
+        {props.invalidEmail ?  <div className="govuk-error-summary__body">
           <ul className="govuk-list govuk-error-summary__list">
             <li>
               <a href="#email">Enter an email address in the correct format, like name@example.com</a>
             </li>
           </ul>
-        </div>
+          </div> : <></>}
+
+        {props.userEnabledSSO ?  <div className="govuk-error-summary__body">
+          <ul className="govuk-list govuk-error-summary__list">
+            <li>
+              <a href="#email">You have enabled single sign-on</a>
+            </li>
+          </ul>
+        </div> : <></>}
+
+        {props.userNotFound ?  <div className="govuk-error-summary__body">
+          <ul className="govuk-list govuk-error-summary__list">
+            <li>
+              <a href="#email">User not found</a>
+            </li>
+          </ul>
+        </div> : <></>}
       </div> : <></>}
 
       <h1 className="govuk-heading-l">Request password reset</h1>
       <p className="govuk-body">
-        We will send you an activation link via email. If you do not receive an
-        email in the next 24 hours, your account may not exist in the system or
-        you could have setup authentication with Google or Microsoft Single
-        Sign-on.
+        We will send you an activation link via email.
       </p>
 
       <form method="post" className="govuk-!-mt-r6">

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -17,6 +17,26 @@ interface IUserPageProps {
   readonly user: IAccountsUser;
 }
 
+interface IPasswordResetFormProperties {
+  readonly csrf: string;
+  readonly invalidEmail?: boolean;
+  readonly values?: {
+    readonly email: string;
+  };
+}
+
+interface IPasswordResetSetPasswordFormProperties {
+  readonly code: string;
+  readonly csrf: string;
+  readonly passwordMissmatch?: boolean;
+}
+
+interface IPasswordResetSuccessProperties {
+  readonly footnote?: string;
+  readonly message?: string;
+  readonly title: string;
+}
+
 export function UserPage(props: IUserPageProps): ReactElement {
   const listOrgs = (orgs: ReadonlyArray<IUserSummaryOrganization>) =>
     orgs.map(org => (
@@ -100,4 +120,169 @@ export function UserPage(props: IUserPageProps): ReactElement {
       </ul>
     </>
   );
+}
+
+export function PasswordResetRequest(props: IPasswordResetFormProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-two-thirds">
+      {props.invalidEmail ? <div
+        className="govuk-error-summary"
+        aria-labelledby="error-summary-title"
+        role="alert"
+        tabIndex={-1}
+        data-module="govuk-error-summary"
+      >
+        <h2 className="govuk-error-summary__title" id="error-summary-title">
+          There is a problem
+        </h2>
+
+        <div className="govuk-error-summary__body">
+          <ul className="govuk-list govuk-error-summary__list">
+            <li>
+              <a href="#email">Enter an email address in the correct format, like name@example.com</a>
+            </li>
+          </ul>
+        </div>
+      </div> : <></>}
+
+      <h1 className="govuk-heading-l">Request password reset</h1>
+      <p className="govuk-body">
+        We will send you an activation link via email. If you do not receive an
+        email in the next 24 hours, your account may not exist in the system or
+        you could have setup authentication with Google or Microsoft Single
+        Sign-on.
+      </p>
+
+      <form method="post" className="govuk-!-mt-r6">
+        <input type="hidden" name="_csrf" value={props.csrf} />
+
+        <div className={`govuk-form-group ${props.invalidEmail ? 'govuk-form-group--error' : ''}`}>
+          <label className="govuk-label" htmlFor="email">
+            Email address
+          </label>
+
+          {props.invalidEmail ? <span id="email-error" className="govuk-error-message">
+            <span className="govuk-visually-hidden">Error:</span>{' '}
+            Enter an email address in the correct format, like name@example.com
+          </span> : <></>}
+
+          <input
+            className={`govuk-input ${props.invalidEmail ? 'govuk-input--error' : ''}`}
+            id="email"
+            name="email"
+            type="text"
+            defaultValue={props.values?.email}
+            aria-describedby={props.invalidEmail ? 'email-error' : ''}
+          />
+        </div>
+
+        <button
+          className="govuk-button"
+          data-module="govuk-button"
+          data-prevent-double-click="true"
+        >
+          Request password reset
+        </button>
+      </form>
+    </div>
+  </div>;
+}
+
+export function PasswordResetSuccess(props: IPasswordResetSuccessProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-two-thirds">
+      <div className="govuk-panel govuk-panel--confirmation">
+        <h1 className="govuk-panel__title">{props.title}</h1>
+        <div className="govuk-panel__body">{props.message}</div>
+      </div>
+
+      <p className="govuk-body">
+        {props.footnote}
+      </p>
+    </div>
+  </div>;
+}
+
+export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFormProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-two-thirds">
+      {props.passwordMissmatch ? <div
+        className="govuk-error-summary"
+        aria-labelledby="error-summary-title"
+        role="alert"
+        tabIndex={-1}
+        data-module="govuk-error-summary"
+      >
+        <h2 className="govuk-error-summary__title" id="error-summary-title">
+          There is a problem
+        </h2>
+
+        <div className="govuk-error-summary__body">
+          <ul className="govuk-list govuk-error-summary__list">
+            <li>
+              <a href="#password">You need to type in the same password twice</a>
+            </li>
+          </ul>
+        </div>
+      </div> : <></>}
+
+      <h1 className="govuk-heading-l">Password reset</h1>
+      <p className="govuk-body">
+        We will send you an activation link via email. If you do not receive an
+        email in the next 24 hours, your account may not exist in the system or
+        you could have setup authentication with Google or Microsoft Single
+        Sign-on.
+      </p>
+
+      <form method="post" className="govuk-!-mt-r6">
+        <input type="hidden" name="_csrf" value={props.csrf} />
+
+        <div className={`govuk-form-group ${props.passwordMissmatch ? 'govuk-form-group--error' : ''}`}>
+          <input type="hidden" name="code" value={props.code} />
+
+          <label className="govuk-label" htmlFor="password">
+            New Password
+          </label>
+
+          {props.passwordMissmatch ? <span id="password-error" className="govuk-error-message">
+            <span className="govuk-visually-hidden">Error:</span>{' '}
+            You need to type in the same password twice
+          </span> : <></>}
+
+          <input
+            className={`govuk-input ${props.passwordMissmatch ? 'govuk-input--error' : ''}`}
+            id="password"
+            name="password"
+            type="password"
+            aria-describedby={props.passwordMissmatch ? 'password-error' : ''}
+          />
+
+          <label className="govuk-label" htmlFor="password-confirmation">
+            Confirm your new password
+          </label>
+
+          {props.passwordMissmatch ? <span id="password-confirmation-error" className="govuk-error-message">
+            <span className="govuk-visually-hidden">Error:</span>{' '}
+            You need to type in the same password twice
+          </span> : <></>}
+
+          <input
+            className={`govuk-input ${props.passwordMissmatch ? 'govuk-input--error' : ''}`}
+            id="password-confirmation"
+            name="passwordConfirmation"
+            type="password"
+            aria-describedby={props.passwordMissmatch ? 'password-error' : ''}
+          />
+        </div>
+
+        <button
+          className="govuk-button"
+          data-module="govuk-button"
+          data-prevent-double-click="true"
+        >
+          Reset password
+        </button>
+      </form>
+    </div>
+  </div>;
 }

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -31,7 +31,7 @@ interface IPasswordResetFormProperties {
 interface IPasswordResetSetPasswordFormProperties {
   readonly code: string;
   readonly csrf: string;
-  readonly passwordMissmatch?: boolean;
+  readonly passwordMismatch?: boolean;
 }
 
 interface IPasswordResetSuccessProperties {
@@ -222,7 +222,7 @@ export function PasswordResetSuccess(props: IPasswordResetSuccessProperties): Re
 export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFormProperties): ReactElement {
   return <div className="govuk-grid-row">
     <div className="govuk-grid-column-two-thirds">
-      {props.passwordMissmatch ? <div
+      {props.passwordMismatch ? <div
         className="govuk-error-summary"
         aria-labelledby="error-summary-title"
         role="alert"
@@ -253,41 +253,41 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
       <form method="post" className="govuk-!-mt-r6">
         <input type="hidden" name="_csrf" value={props.csrf} />
 
-        <div className={`govuk-form-group ${props.passwordMissmatch ? 'govuk-form-group--error' : ''}`}>
+        <div className={`govuk-form-group ${props.passwordMismatch ? 'govuk-form-group--error' : ''}`}>
           <input type="hidden" name="code" value={props.code} />
 
           <label className="govuk-label" htmlFor="password">
             New Password
           </label>
 
-          {props.passwordMissmatch ? <span id="password-error" className="govuk-error-message">
+          {props.passwordMismatch ? <span id="password-error" className="govuk-error-message">
             <span className="govuk-visually-hidden">Error:</span>{' '}
             You need to type in the same password twice
           </span> : <></>}
 
           <input
-            className={`govuk-input ${props.passwordMissmatch ? 'govuk-input--error' : ''}`}
+            className={`govuk-input ${props.passwordMismatch ? 'govuk-input--error' : ''}`}
             id="password"
             name="password"
             type="password"
-            aria-describedby={props.passwordMissmatch ? 'password-error' : ''}
+            aria-describedby={props.passwordMismatch ? 'password-error' : ''}
           />
 
           <label className="govuk-label" htmlFor="password-confirmation">
             Confirm your new password
           </label>
 
-          {props.passwordMissmatch ? <span id="password-confirmation-error" className="govuk-error-message">
+          {props.passwordMismatch ? <span id="password-confirmation-error" className="govuk-error-message">
             <span className="govuk-visually-hidden">Error:</span>{' '}
             You need to type in the same password twice
           </span> : <></>}
 
           <input
-            className={`govuk-input ${props.passwordMissmatch ? 'govuk-input--error' : ''}`}
+            className={`govuk-input ${props.passwordMismatch ? 'govuk-input--error' : ''}`}
             id="password-confirmation"
             name="passwordConfirmation"
             type="password"
-            aria-describedby={props.passwordMissmatch ? 'password-error' : ''}
+            aria-describedby={props.passwordMismatch ? 'password-error' : ''}
           />
         </div>
 

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -21,6 +21,7 @@ interface IPasswordResetFormProperties {
   readonly csrf: string;
   readonly invalidEmail?: boolean;
   readonly userEnabledSSO?: boolean;
+  readonly idpNice?: string;
   readonly userNotFound?: boolean;
   readonly values?: {
     readonly email: string;
@@ -149,7 +150,7 @@ export function PasswordResetRequest(props: IPasswordResetFormProperties): React
         {props.userEnabledSSO ?  <div className="govuk-error-summary__body">
           <ul className="govuk-list govuk-error-summary__list">
             <li>
-              <a href="#email">You have enabled single sign-on</a>
+              <a href="#email">You have enabled single sign-on, please sign in using {props.idpNice!}</a>
             </li>
           </ul>
         </div> : <></>}

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -263,9 +263,9 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
 
       <form method="post" className="govuk-!-mt-r6">
         <input type="hidden" name="_csrf" value={props.csrf} />
+        <input type="hidden" name="code" value={props.code} />
 
-        <div className={`govuk-form-group ${props.passwordMismatch ? 'govuk-form-group--error' : ''}`}>
-          <input type="hidden" name="code" value={props.code} />
+        <div className={`govuk-form-group ${props.passwordMismatch || props.passwordDoesNotMeetPolicy ? 'govuk-form-group--error' : ''}`}>
 
           <label className="govuk-label" htmlFor="password">
             New Password
@@ -282,12 +282,14 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
           </span> : <></>}
 
           <input
-            className={`govuk-input ${props.passwordMismatch ? 'govuk-input--error' : ''}`}
+            className={`govuk-input ${props.passwordMismatch || props.passwordDoesNotMeetPolicy ? 'govuk-input--error' : ''}`}
             id="password"
             name="password"
             type="password"
             aria-describedby={props.passwordMismatch || props.passwordDoesNotMeetPolicy ? 'password-error' : ''}
           />
+        </div>
+        <div className={`govuk-form-group ${props.passwordMismatch ? 'govuk-form-group--error' : ''}`}>
 
           <label className="govuk-label" htmlFor="password-confirmation">
             Confirm your new password
@@ -303,7 +305,7 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
             id="password-confirmation"
             name="passwordConfirmation"
             type="password"
-            aria-describedby={props.passwordMismatch || props.passwordDoesNotMeetPolicy ? 'password-error' : ''}
+            aria-describedby={props.passwordMismatch ? 'password-error' : ''}
           />
         </div>
 

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -32,6 +32,8 @@ interface IPasswordResetSetPasswordFormProperties {
   readonly code: string;
   readonly csrf: string;
   readonly passwordMismatch?: boolean;
+  readonly passwordDoesNotMeetPolicy?: boolean;
+  readonly passwordDoesNotMeetPolicyMessage?: string;
 }
 
 interface IPasswordResetSuccessProperties {
@@ -222,7 +224,7 @@ export function PasswordResetSuccess(props: IPasswordResetSuccessProperties): Re
 export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFormProperties): ReactElement {
   return <div className="govuk-grid-row">
     <div className="govuk-grid-column-two-thirds">
-      {props.passwordMismatch ? <div
+      {props.passwordMismatch || props.passwordDoesNotMeetPolicy ? <div
         className="govuk-error-summary"
         aria-labelledby="error-summary-title"
         role="alert"
@@ -235,20 +237,29 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
 
         <div className="govuk-error-summary__body">
           <ul className="govuk-list govuk-error-summary__list">
-            <li>
-              <a href="#password">You need to type in the same password twice</a>
-            </li>
+            {props.passwordMismatch
+              ?  <li><a href="#password">You need to type in the same password twice</a></li>
+              : <></>
+            }
+            {props.passwordDoesNotMeetPolicy
+              ?  <li><a href="#password">Your password should meet our password policy</a></li>
+              : <></>
+            }
           </ul>
         </div>
       </div> : <></>}
 
       <h1 className="govuk-heading-l">Password reset</h1>
-      <p className="govuk-body">
-        We will send you an activation link via email. If you do not receive an
-        email in the next 24 hours, your account may not exist in the system or
-        you could have setup authentication with Google or Microsoft Single
-        Sign-on.
-      </p>
+      <p className="govuk-body">You should set a secure password which:</p>
+      <ul className="govuk-list govuk-list--bullet">
+        <li>is at least 12 characters long</li>
+        <li>includes both an uppercase and lowercase character</li>
+        <li>includes a number</li>
+        <li>
+          includes one of <code>-_+:;&lt;&gt;[]()#@£$%^&amp;!</code>
+        </li>
+        <li>you do not use anywhere else (eg for another website)</li>
+      </ul>
 
       <form method="post" className="govuk-!-mt-r6">
         <input type="hidden" name="_csrf" value={props.csrf} />
@@ -263,6 +274,11 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
           {props.passwordMismatch ? <span id="password-error" className="govuk-error-message">
             <span className="govuk-visually-hidden">Error:</span>{' '}
             You need to type in the same password twice
+            </span> : <></>}
+
+          {props.passwordDoesNotMeetPolicy ? <span id="password-error" className="govuk-error-message">
+            <span className="govuk-visually-hidden">Error:</span>{' '}
+            {props.passwordDoesNotMeetPolicyMessage!}
           </span> : <></>}
 
           <input
@@ -270,7 +286,7 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
             id="password"
             name="password"
             type="password"
-            aria-describedby={props.passwordMismatch ? 'password-error' : ''}
+            aria-describedby={props.passwordMismatch || props.passwordDoesNotMeetPolicy ? 'password-error' : ''}
           />
 
           <label className="govuk-label" htmlFor="password-confirmation">
@@ -287,7 +303,7 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
             id="password-confirmation"
             name="passwordConfirmation"
             type="password"
-            aria-describedby={props.passwordMismatch ? 'password-error' : ''}
+            aria-describedby={props.passwordMismatch || props.passwordDoesNotMeetPolicy ? 'password-error' : ''}
           />
         </div>
 

--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, ReactElement, ReactNode } from 'react';
 
 interface IHeaderProperties {
+  readonly authenticated?: boolean;
   readonly assetPath?: string;
   readonly location: string;
   readonly isPlatformAdmin: boolean;
@@ -39,7 +40,7 @@ interface ICommandLineAlternativeProperties {
   readonly context?: string;
 }
 
-export function Header(params: IHeaderProperties): ReactElement {
+export function Header(props: IHeaderProperties): ReactElement {
   const platformLink = (
     <li className="govuk-header__navigation-item admin">
       <a className="govuk-header__link" href="/platform-admin">
@@ -48,7 +49,7 @@ export function Header(params: IHeaderProperties): ReactElement {
     </li>
   );
 
-  const assetPath = params.assetPath || '/assets';
+  const assetPath = props.assetPath || '/assets';
 
   return (
     <header className="govuk-header" role="banner" data-module="govuk-header">
@@ -106,11 +107,11 @@ export function Header(params: IHeaderProperties): ReactElement {
                   Marketplace
                 </a>
               </li>
-                <li className="govuk-header__navigation-item">
-                  <a className="govuk-header__link" href="/">
-                    Organisations
-                  </a>
-                </li>
+              {props.authenticated ? <li className="govuk-header__navigation-item">
+                <a className="govuk-header__link" href="/">
+                  Organisations
+                </a>
+              </li> : undefined}
               <li className="govuk-header__navigation-item">
                 <a
                   className="govuk-header__link"
@@ -119,20 +120,26 @@ export function Header(params: IHeaderProperties): ReactElement {
                   Documentation
                 </a>
               </li>
-              {params.isPlatformAdmin ? platformLink : undefined}
-              <li className="govuk-header__navigation-item">
-                <a className="govuk-header__link" href="/auth/logout">
-                  Sign out
-                </a>
-              </li>
+              {props.isPlatformAdmin ? platformLink : undefined}
+              {props.authenticated
+                ? <li className="govuk-header__navigation-item">
+                    <a className="govuk-header__link" href="/auth/logout">
+                      Sign out
+                    </a>
+                  </li>
+                : <li className="govuk-header__navigation-item">
+                    <a className="govuk-header__link" href="/">
+                      Sign In
+                    </a>
+                  </li>}
               <li className="govuk-header__navigation-item">
                 <a
                   href="https://www.cloud.service.gov.uk/sign-in"
                   title="Switch to a different region"
-                  className={`govuk-header__link govuk-tag app-region-tag app-region-tag--${params.location.toLowerCase()}`}
-                  aria-label={`Current region: ${params.location.toLowerCase()}. Switch to a different region.`}
+                  className={`govuk-header__link govuk-tag app-region-tag app-region-tag--${props.location.toLowerCase()}`}
+                  aria-label={`Current region: ${props.location.toLowerCase()}. Switch to a different region.`}
                 >
-                  <span className="app-region-tag__text">Region:</span> {params.location}
+                  <span className="app-region-tag__text">Region:</span> {props.location}
                 </a>
               </li>
             </ul>

--- a/src/layouts/template.tsx
+++ b/src/layouts/template.tsx
@@ -90,7 +90,11 @@ export class Template {
             </a>
 
             ${renderToStaticMarkup(<>
-              <Header location={this.ctx.location} isPlatformAdmin={!!this.ctx.isPlatformAdmin} />
+              <Header
+                location={this.ctx.location}
+                isPlatformAdmin={!!this.ctx.isPlatformAdmin}
+                authenticated={this.ctx.authenticated}
+              />
 
               <div className="govuk-width-container">
                 <PhaseBanner tag={{ text: 'beta' }}>

--- a/src/lib/accounts/accounts.test.ts
+++ b/src/lib/accounts/accounts.test.ts
@@ -103,6 +103,17 @@ describe('lib/accounts test suite', () => {
     }]
   }`,
       )
+      .get('/users?email=url%2bencoded@user.in.database')
+      .reply(
+        200,
+        `{
+    "users": [{
+      "user_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "user_email": "url+encoded@user.in.database",
+      "username": "url+encoded@user.in.database"
+    }]
+  }`,
+      )
       .get('/users?email=no@user.in.database')
       .reply(
         200,
@@ -273,6 +284,15 @@ describe('lib/accounts test suite', () => {
     expect(user).not.toBeUndefined();
     expect(user!.email).toEqual('one@user.in.database');
     expect(user!.username).toEqual('one@user.in.database');
+  });
+
+  it('should get a user by email when the email includes a plus', async () => {
+    // the mock only expects a URL encoded email address
+    const ac = new AccountsClient(cfg);
+    const user = await ac.getUserByEmail('url+encoded@user.in.database');
+    expect(user).not.toBeUndefined();
+    expect(user!.email).toEqual('url+encoded@user.in.database');
+    expect(user!.username).toEqual('url+encoded@user.in.database');
   });
 
   it('should return undefined for a user which does not exist', async () => {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -271,7 +271,8 @@ export class AccountsClient {
   ): Promise<IAccountsUser | undefined> {
     const response = await this.request({
       method: 'get',
-      url: `/users?email=${email}`,
+      url: '/users',
+      params: { email },
     });
 
     const parsedResponse: IAccountsUsersResponse = response.data;

--- a/src/lib/notify/notify.client.test.ts
+++ b/src/lib/notify/notify.client.test.ts
@@ -20,11 +20,12 @@ describe('lib/notify test suite', () => {
   it('notify middleware should include NotifyClient on req', async () => {
     nockNotify
       .post('/v2/notifications/email')
+      .times(2)
       .reply(200, { content: { body: 'FAKE_NOTIFY_RESPONSE' } });
 
     const notify = new NotificationClient({
       apiKey: 'test-key-1234',
-      templates: { welcome: 'WELCOME_ID' },
+      templates: { passwordReset:'PASSWORD_RESET_ID', welcome: 'WELCOME_ID' },
     });
 
     const personalisation = {
@@ -33,11 +34,17 @@ describe('lib/notify test suite', () => {
       url: 'https://default.url',
     };
 
-    const notifyResponse = await notify.sendWelcomeEmail(
+    const notifyWelcomeResponse = await notify.sendWelcomeEmail(
       'jeff@jeff.com',
       personalisation,
     );
 
-    expect(notifyResponse.body.content.body).toContain('FAKE_NOTIFY_RESPONSE');
+    const notifyPasswordResetResponse = await notify.sendPasswordReminder(
+      'jeff@jeff.com',
+      'https://example.com/reset?code=1234567890',
+    );
+
+    expect(notifyWelcomeResponse.body.content.body).toContain('FAKE_NOTIFY_RESPONSE');
+    expect(notifyPasswordResetResponse.body.content.body).toContain('FAKE_NOTIFY_RESPONSE');
   });
 });

--- a/src/lib/notify/notify.client.ts
+++ b/src/lib/notify/notify.client.ts
@@ -1,4 +1,4 @@
-import { NotifyClient } from 'notifications-node-client';
+import { IResponse, NotifyClient } from 'notifications-node-client';
 
 interface ITemplates {
   readonly welcome?: string;
@@ -26,10 +26,7 @@ export default class NotificationClient {
     this.templates = config.templates || {};
   }
 
-  public async sendWelcomeEmail(
-    emailAddress: string,
-    personalisation: IWelcomeEmailParameters,
-  ) {
+  public async sendWelcomeEmail(emailAddress: string, personalisation: IWelcomeEmailParameters): Promise<IResponse> {
     /* istanbul ignore next */
     if (!this.templates.welcome) {
       throw new Error('NotifyClient: templates.welcome: id is required');
@@ -39,6 +36,17 @@ export default class NotificationClient {
 
     return await this.client.sendEmail(templateID, emailAddress, {
       personalisation,
+    });
+  }
+
+  public async sendPasswordReminder(emailAddress: string, url: string): Promise<IResponse> {
+    /* istanbul ignore next */
+    if (!this.templates.passwordReset) {
+      throw new Error('NotifyClient: templates.passwordReset: id is required');
+    }
+
+    return await this.client.sendEmail(this.templates.passwordReset, emailAddress, {
+      personalisation: { url },
     });
   }
 }

--- a/src/lib/notify/notify.client.ts
+++ b/src/lib/notify/notify.client.ts
@@ -1,7 +1,8 @@
 import { NotifyClient } from 'notifications-node-client';
 
 interface ITemplates {
-  readonly [name: string]: string | null;
+  readonly welcome?: string;
+  readonly passwordReset?: string;
 }
 
 interface IConfig {

--- a/src/lib/uaa/uaa.test.ts
+++ b/src/lib/uaa/uaa.test.ts
@@ -233,4 +233,32 @@ describe('lib/uaa test suite', () => {
     const updatedUser = await client.setUserOrigin(data.userId, 'google');
     expect(updatedUser.id).toEqual(data.userId);
   });
+
+  it('should successfully call /password_resets', async () => {
+    nockUAA
+      .post('/oauth/token')
+      .query((x: any) => x.grant_type === 'client_credentials')
+      .reply(200, { access_token: 'FAKE_ACCESS_TOKEN' })
+
+      .post('/password_resets')
+      .reply(201, { code: 'FAKE_PASSWORD_RESET_CODE' });
+
+    const client = new UAAClient(config);
+    const code = await client.obtainPasswordResetCode('jeff');
+    expect(code).toEqual('FAKE_PASSWORD_RESET_CODE');
+  });
+
+  it('should successfully call /password_change', async () => {
+    nockUAA
+      .post('/oauth/token')
+      .query((x: any) => x.grant_type === 'client_credentials')
+      .reply(200, { access_token: 'FAKE_ACCESS_TOKEN' })
+
+      .post('/password_change')
+      .reply(200, { id: 'FAKE_USER_GUID' });
+
+    const client = new UAAClient(config);
+    const user = await client.resetPassword('FAKE_PASSWORD_RESET_CODE', 'myNewPassword123!');
+    expect(user.id).toEqual('FAKE_USER_GUID');
+  });
 });

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -227,7 +227,7 @@ export default class UAAClient {
   }
 
   public async findUser(email: string): Promise<types.IUaaUser> {
-    const params = { filter: `email eq ${JSON.stringify(email)}` };
+    const params = { filter: `email eq "${email}"` };
     const response = await this.request('get', '/Users', { params });
 
     return response.data.resources[0] as types.IUaaUser;

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -308,4 +308,16 @@ export default class UAAClient {
 
     return response.data as types.IUaaUser;
   }
+
+  public async obtainPasswordResetCode(username: string): Promise<string> {
+    const response = await this.request('post', '/password_resets', { data: username });
+
+    return response.data.code;
+  }
+
+  public async resetPassword(code: string, password: string): Promise<types.IUaaUser> {
+    const response = await this.request('post', '/password_change', { data: { code, new_password: password } });
+
+    return response.data;
+  }
 }

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -310,7 +310,13 @@ export default class UAAClient {
   }
 
   public async obtainPasswordResetCode(username: string): Promise<string> {
-    const response = await this.request('post', '/password_resets', { data: username });
+    const response = await this.request('post', '/password_resets', {
+      data: username,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+    });
 
     return response.data.code;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,6 +98,7 @@ async function main() {
     location,
     logger,
     notifyAPIKey: expectEnvVariable('NOTIFY_API_KEY'),
+    notifyPasswordResetTemplateID: process.env.NOTIFY_PASSWORD_RESET_TEMPLATE_ID || null,
     notifyWelcomeTemplateID: process.env.NOTIFY_WELCOME_TEMPLATE_ID || null,
     oauthClientID: expectEnvVariable('OAUTH_CLIENT_ID'),
     oauthClientSecret: expectEnvVariable('OAUTH_CLIENT_SECRET'),


### PR DESCRIPTION
What
----

We'll be sending out password reset email to our tenants. Notify
requires us to point out a template to be used for email sending
functionality.

We have a wrapper around notify's SDK, which is limited to our needs.
We're adding a new function that will specifically target the password
reset email.

We're able to use UAA headlessly via the API to perform some actions.
These include the password reset flow. We're simply adding functions
calling for these specific endpoints, with some additional data.

It seems that using both JSON.stringify and axios, messes up with the
attribute enough, for the UAA API to return bad request response.

This deserves testing the user invitation functionality...

As a bonus, I've had a look into the navigation component.

We're adding more and more pages which do not require authentication.
This makes it unreasonable, to ignore the navigation always say things
like `Sign out`. Instead, we're adding a flag, which will trigger
different menu items depending on the state of the session.

How to review
-------------

- Deploy alphagov/paas-cf#2328 to your dev env - or manually setup your env
- Deploy pazmin from this branch to your environment
- Attempt to run through entire forgotten password flow
- Check wording please - I made it all up...

⚠️ This needs to be merged before the alphagov/paas-cf#2328 ⚠️ 
-------------------------------------------------------------------