### PR TITLE
Update Terms of Use page 'title' property

### DIFF
--- a/src/components/terms/middleware.tsx
+++ b/src/components/terms/middleware.tsx
@@ -44,7 +44,7 @@ export function termsCheckerMiddleware(
           csrf: req.csrfToken(),
           location,
         },
-        'Terms',
+        'Terms of Use for GOV.UK Platform as a Service',
       );
       res.send(
         template.render(


### PR DESCRIPTION
What
----

An internal audit noted "The page title does not match the page heading. This means that users might struggle to understand what the page is for"

This updates the `title` property to match the main heading

How to review
-------------

🤔 if title makes sense

Who can review
---------------

not @kr8n3r 
