### PR TITLE
[#172078978] Adding a message about metrics & events timestamps being in UTC

### DIFF
--- a/src/components/application-events/views.tsx
+++ b/src/components/application-events/views.tsx
@@ -5,7 +5,7 @@ import { eventTypeDescriptions } from '../../lib/cf';
 import { IApplication, IAuditEvent } from '../../lib/cf/types';
 import { RouteActiveChecker, RouteLinker } from '../app/context';
 import { ApplicationTab } from '../applications/views';
-import { Details, Event, EventListItem, Totals } from '../events';
+import { Details, Event, EventListItem, Totals, EventTimestamps } from '../events';
 
 interface IApplicationEventDetailPageProperties {
   readonly actor?: IAccountsUser;
@@ -120,6 +120,8 @@ export function ApplicationEventsPage(
         page={props.pagination.page}
         pages={props.pagination.total_pages}
       />
+
+      <EventTimestamps />
 
       <Details />
 

--- a/src/components/events/views.test.tsx
+++ b/src/components/events/views.test.tsx
@@ -8,7 +8,7 @@ import { spacesMissingAroundInlineElements } from '../../layouts/react-spacing.t
 import { IAccountsUser } from '../../lib/accounts';
 import { IAuditEvent, IAuditEventActorTarget } from '../../lib/cf/types';
 
-import { Details, Event, TargetedEvent, Totals } from './views';
+import { Details, Event, TargetedEvent, Totals, EventTimestamps } from './views';
 
 describe(Details, () => {
   it('should display details element', () => {
@@ -149,3 +149,15 @@ describe(Totals, () => {
     expect(spacesMissingAroundInlineElements($.html())).toHaveLength(0);
   });
 });
+
+describe(EventTimestamps, () => {
+  it('should display EventTimestamp element', () => {
+    const markup = shallow(<EventTimestamps />);
+    const $ = cheerio.load(markup.html());
+    expect($('p').text()).toContain(
+      'Event timestamps are in UTC format.',
+    );
+    expect(spacesMissingAroundInlineElements($.html())).toHaveLength(0);
+  });
+});
+

--- a/src/components/events/views.tsx
+++ b/src/components/events/views.tsx
@@ -177,3 +177,11 @@ export function Totals(props: ITotalsProperties): ReactElement {
     </p>
   );
 }
+
+export function EventTimestamps(): ReactElement {
+  return (
+    <p className="govuk-body">
+      Event timestamps are in UTC format.
+    </p>
+  );
+}

--- a/src/components/service-events/views.tsx
+++ b/src/components/service-events/views.tsx
@@ -4,7 +4,7 @@ import { IAccountsUser } from '../../lib/accounts';
 import { eventTypeDescriptions } from '../../lib/cf';
 import { IAuditEvent, IServiceInstance } from '../../lib/cf/types';
 import { RouteActiveChecker, RouteLinker } from '../app';
-import { Details, Event, EventListItem, Totals } from '../events';
+import { Details, Event, EventListItem, Totals, EventTimestamps } from '../events';
 import { ServiceTab } from '../services/views';
 
 interface ILinkProperties {
@@ -99,6 +99,8 @@ export function ServiceEventsPage(
         page={props.pagination.page}
         pages={props.pagination.total_pages}
       />
+
+      <EventTimestamps />
 
       <Details />
 

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -237,6 +237,10 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
       </p>
 
       <p className="govuk-body">
+        Metrics timestamps are in UTC format.
+      </p>
+
+      <p className="govuk-body">
         Each point on a graph is aggregated over
         {' '}
         <strong className="non-breaking">{props.period.humanize()}</strong>

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -24,6 +24,7 @@ import {
   TargetedEvent,
   TargetedEventListItem,
   Totals,
+  EventTimestamps,
 } from '../events';
 
 export interface IEnchancedApplication extends IApplication {
@@ -614,6 +615,8 @@ export function EventsPage(props: IEventsPageProperties): ReactElement {
         page={props.pagination.page}
         pages={props.pagination.total_pages}
       />
+
+      <EventTimestamps />
 
       <Details />
 


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/172078978)

What
----
Backing services metrics pages the times are in UTC, but there is no indication of it anywhere.
The same is true for all the **Events** pages (e.g.: space, service and application).

Our users got confused with the timestamps in pazmin, since we are
showing these in UTC, but the CF CLI is converting it to the client
machine timezone.

How to review
-------------

Code review

CI

Deploy the new pazmin to your environment and see that we have the new message informing users that timestamps are in UTC.

Who can review
---------------

Not @barsutka 