### PR TITLE
[#172361641] Enable session propagation for public pages.

### DIFF
--- a/src/components/auth/auth.test.ts
+++ b/src/components/auth/auth.test.ts
@@ -6,7 +6,7 @@ import nock from 'nock';
 import pino from 'pino';
 import request from 'supertest';
 
-import auth from '.';
+import { handleSession, requireAuthentication } from './auth';
 
 describe('auth test suite', () => {
   const app = express();
@@ -31,16 +31,16 @@ describe('auth test suite', () => {
 
   app.use(cookieSession({ keys: ['mysecret'], name: 'auth-test' }));
 
-  app.use(
-    auth({
-      authorizationURL: 'https://example.com/login/oauth/authorize',
-      clientID: 'key',
-      clientSecret: 'secret',
-      logoutURL: 'https://example.com/login/logout.do',
-      tokenURL: 'https://example.com/uaa/oauth/token',
-      uaaAPI: 'https://example.com/uaa',
-    }),
-  );
+  const sessionConfig = {
+    authorizationURL: 'https://example.com/login/oauth/authorize',
+    clientID: 'key',
+    clientSecret: 'secret',
+    logoutURL: 'https://example.com/login/logout.do',
+    tokenURL: 'https://example.com/uaa/oauth/token',
+    uaaAPI: 'https://example.com/uaa',
+  };
+  app.use(handleSession(sessionConfig));
+  app.use(requireAuthentication(sessionConfig));
 
   app.get('/test', (_req, res) => {
     res.status(200);

--- a/src/components/auth/auth.ts
+++ b/src/components/auth/auth.ts
@@ -35,7 +35,7 @@ function syncMiddleware(f: MiddlewareFunction) {
   };
 }
 
-export default function authentication(config: IConfig) {
+export function handleSession(config: IConfig) {
   const app = express();
 
   const options: StrategyOptions = {
@@ -87,6 +87,12 @@ export default function authentication(config: IConfig) {
     req.logout();
     res.redirect(config.logoutURL);
   });
+
+  return app;
+}
+
+export function requireAuthentication(config: IConfig) {
+  const app = express();
 
   app.use(
     syncMiddleware(async (req: any, res, next) => {

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,2 +1,2 @@
-export { default } from './auth';
+export * from './auth';
 export * from './has-role';


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/172361641)

What
----
In order to make the publicly accessible pages (for example: Marketplace) to be `session` aware and indicate if user is already logged in or not, we had to split the default function in `auth` component into two -  `handleSession` and `requireAuthentication`. So, now the protected links are using both functions and public pages are using `handleSession` only. 

How to review
-------------

Code Review

Build pazmin locally and deploy into your dev environment.

Steps to validate:
 1. navigate to your https://admin.<YOUR-DEV-ENV-NAME\>.dev.cloudpipeline.digital/

 2. login into your pazmin app

3. navigate to https://admin.<YOUR-DEV-ENV-NAME\>.dev.cloudpipeline.digital/marketplace - make sure that you see *Sign Out* link in the top level navigation bar.

4. logout from pazmin app and navigate to https://admin.<YOUR-DEV-ENV-NAME\>.dev.cloudpipeline.digital/marketplace again - make sure that you see *Sign In* link in the top level navigation bar.


Who can review
---------------

Not @barsutka @paroxp 
