### PR TITLE
return "metrics unavailable" page for unknown svcs

### DIFF
--- a/src/components/service-metrics/controllers.test.tsx
+++ b/src/components/service-metrics/controllers.test.tsx
@@ -319,7 +319,7 @@ describe('service metrics test suite', () => {
     ).toHaveLength(0);
   });
 
-  it('should throw an error when encountering an unknown service', async () => {
+  it('should not return metrics when encountering an unknown service', async () => {
     mockService({
       ...data.serviceObj,
       entity: {
@@ -328,17 +328,19 @@ describe('service metrics test suite', () => {
       },
     });
 
-    await expect(
-      viewServiceMetrics(ctx, {
-        organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
-        rangeStart: moment()
-          .subtract(1, 'hour')
-          .format('YYYY-MM-DD[T]HH:mm'),
-        rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
-        serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
-        spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      }),
-    ).rejects.toThrow(/Unrecognised service label unknown-service-label/);
+    const response = await viewServiceMetrics(ctx, {
+      organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
+      rangeStart: moment()
+      .subtract(1, 'hour')
+      .format('YYYY-MM-DD[T]HH:mm'),
+      rangeStop: moment().format('YYYY-MM-DD[T]HH:mm'),
+      serviceGUID: '0d632575-bb06-4ea5-bb19-a451a9644d92',
+      spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
+    });
+
+    expect(response.body).toContain(
+      'Metrics are not available for this service yet.',
+    );
   });
 
   it('should redirect if no range provided', async () => {

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -209,14 +209,6 @@ export async function viewServiceMetrics(
     spaceGUID: space.metadata.guid,
   };
 
-  if (serviceLabel === 'User Provided Service') {
-    return {
-      body: template.render(
-        <UnsupportedServiceMetricsPage {...defaultTemplateParams} />,
-      ),
-    };
-  }
-
   const downloadLink = ctx.linkTo(
     'admin.organizations.spaces.services.metrics.download',
     {
@@ -320,7 +312,11 @@ export async function viewServiceMetrics(
       );
       break;
     default:
-      throw new Error(`Unrecognised service label ${serviceLabel}`);
+      return {
+        body: template.render(
+          <UnsupportedServiceMetricsPage {...defaultTemplateParams} />,
+        ),
+      };
   }
 
   return {


### PR DESCRIPTION
the service metrics tab would result in a 500 error if it encountered a
service type that it didn't understand.

there are several ways this could occur:

* A new backing service without metrics implemented yet
* A custom service from a space-scoped broker
* A user provided service

The user-provided-service path was hard coded to display a nicer error
page, but anything else would result in a generic error.

This changes it so that ANY unknown service gets the "metrics
unavailable" page so the user doesn't loose their flow and the tabbed
interface operates as expected.
