### PR TITLE
Use /v3/roles for platform-admin user overview page

### DIFF
--- a/src/components/users/views.test.tsx
+++ b/src/components/users/views.test.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import React from 'react';
 
 import { DATE_TIME } from '../../layouts';
-import { IUserSummaryOrganization } from '../../lib/cf/types';
+import { IOrganization } from '../../lib/cf/types';
 import { IUaaGroup } from '../../lib/uaa';
 
 import { PasswordResetRequest, PasswordResetSetPasswordForm, PasswordResetSuccess, UserPage } from './views';
@@ -19,15 +19,15 @@ describe(UserPage, () => {
   const orgA = ({
     metadata: { guid: 'a' },
     entity: { name: 'A' },
-  } as unknown) as IUserSummaryOrganization;
+  } as unknown) as IOrganization;
   const orgB = ({
     metadata: { guid: 'b' },
     entity: { name: 'B' },
-  } as unknown) as IUserSummaryOrganization;
+  } as unknown) as IOrganization;
   const orgC = ({
     metadata: { guid: 'c' },
     entity: { name: 'C' },
-  } as unknown) as IUserSummaryOrganization;
+  } as unknown) as IOrganization;
   const group = ({ display: 'profile' } as unknown) as IUaaGroup;
   const user = {
     uuid: 'ACCOUNTS-USER-GUID',
@@ -40,7 +40,6 @@ describe(UserPage, () => {
     const markup = shallow(
       <UserPage
         organizations={[orgA, orgB, orgC]}
-        managedOrganizations={[orgA]}
         groups={[group]}
         lastLogon={logon}
         linkTo={linker}
@@ -51,15 +50,13 @@ describe(UserPage, () => {
     const $ = cheerio.load(markup.html());
     expect($('dd').text()).toContain(moment(logon).format(DATE_TIME));
     expect($('p').text()).toContain('This user is a member of 3 orgs.');
-    expect($('p').text()).toContain('This user manages 1 org.');
     expect($('ul:last-of-type li')).toHaveLength(1);
   });
 
   it('should display list of organizations', () => {
     const markup = shallow(
       <UserPage
-        organizations={[orgB]}
-        managedOrganizations={[orgA, orgC]}
+        organizations={[orgA, orgB, orgC]}
         groups={[group]}
         lastLogon={logon}
         linkTo={linker}
@@ -68,8 +65,7 @@ describe(UserPage, () => {
       />,
     );
     const $ = cheerio.load(markup.html());
-    expect($('p').text()).toContain('This user is a member of 1 org.');
-    expect($('p').text()).toContain('This user manages 2 orgs.');
+    expect($('p').text()).toContain('This user is a member of 3 orgs.');
   });
 });
 

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from 'react';
 
 import { DATE_TIME } from '../../layouts';
 import { IAccountsUser } from '../../lib/accounts';
-import { IUserSummaryOrganization } from '../../lib/cf/types';
+import { IOrganization } from '../../lib/cf/types';
 import { IUaaGroup } from '../../lib/uaa';
 import { RouteLinker } from '../app';
 
@@ -11,8 +11,7 @@ interface IUserPageProps {
   readonly groups: ReadonlyArray<IUaaGroup>;
   readonly lastLogon: Date;
   readonly linkTo: RouteLinker;
-  readonly managedOrganizations: ReadonlyArray<IUserSummaryOrganization>;
-  readonly organizations: ReadonlyArray<IUserSummaryOrganization>;
+  readonly organizations: ReadonlyArray<IOrganization>;
   readonly origin: string;
   readonly user: IAccountsUser;
 }
@@ -43,7 +42,7 @@ interface IPasswordResetSuccessProperties {
 }
 
 export function UserPage(props: IUserPageProps): ReactElement {
-  const listOrgs = (orgs: ReadonlyArray<IUserSummaryOrganization>) =>
+  const listOrgs = (orgs: ReadonlyArray<IOrganization>) =>
     orgs.map(org => (
       <li key={org.metadata.guid}>
         <a
@@ -103,15 +102,6 @@ export function UserPage(props: IUserPageProps): ReactElement {
       </p>
       <ul className="govuk-list govuk-list--bullet">
         {listOrgs(props.organizations)}
-      </ul>
-
-      <h3 className="govuk-heading-m">Managed Orgs</h3>
-      <p className="govuk-body">
-        This user manages {props.managedOrganizations.length}{' '}
-        {props.managedOrganizations.length === 1 ? 'org' : 'orgs'}.
-      </p>
-      <ul className="govuk-list govuk-list--bullet">
-        {listOrgs(props.managedOrganizations)}
       </ul>
 
       <h3 className="govuk-heading-m">UAA Groups</h3>

--- a/src/lib/cf/cf.test.ts
+++ b/src/lib/cf/cf.test.ts
@@ -6,6 +6,7 @@ import * as data from './cf.test.data';
 import { app as defaultApp } from './test-data/app';
 import { auditEvent as defaultAuditEvent } from './test-data/audit-event';
 import { org as defaultOrg } from './test-data/org';
+import { orgRole, spaceRole } from './test-data/roles';
 import { wrapResources, wrapV3Resources } from './test-data/wrap-resources';
 
 import CloudFoundryClient from '.';
@@ -840,5 +841,25 @@ describe('lib/cf test suite', () => {
 
     expect(space).toHaveProperty('guid');
     expect(space.guid).toEqual('SPACE_GUID');
+  });
+
+  it('should retrieve roles for a user', async () => {
+    const orgGUID = 'an-org-guid';
+    const spaceGUID = 'a-space-guid';
+    const userGUID = 'a-user-guid';
+
+    const roles = [
+      orgRole('organization_manager', orgGUID, userGUID),
+      spaceRole('space_developer', orgGUID, spaceGUID, userGUID),
+    ];
+
+    nockCF
+      .get(`/v3/roles?user_guids=${userGUID}`)
+      .reply(200, JSON.stringify(wrapV3Resources(...roles)));
+
+    const client = new CloudFoundryClient(config);
+    const actualRoles = await client.userRoles(userGUID);
+
+    expect(actualRoles).toEqual(roles)
   });
 });

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -576,4 +576,17 @@ export default class CloudFoundryClient {
 
     return resp.data;
   }
+
+  public async userRoles(userGUID: string): Promise<ReadonlyArray<cf.IRole>> {
+    const resp = await this.request(
+      'get',
+      '/v3/roles',
+      /* data */ undefined,
+      /* params */ {
+        user_guids: userGUID,
+      },
+    );
+
+    return this.allV3Resources(resp);
+  }
 }

--- a/src/lib/cf/test-data/roles.ts
+++ b/src/lib/cf/test-data/roles.ts
@@ -1,0 +1,56 @@
+import { IRole } from '../types';
+
+export function orgRole(
+  roleType: string,
+  orgGUID: string,
+  userGUID: string,
+): IRole {
+  return JSON.parse(`{
+   "type": "${roleType}",
+
+   "relationships": {
+      "user": {
+         "data": {
+            "guid": "${userGUID}"
+         }
+      },
+      "organization": {
+         "data": {
+            "guid": "${orgGUID}"
+         }
+      },
+      "space": {
+         "data": null
+      }
+   }
+}`);
+}
+
+export function spaceRole(
+  roleType: string,
+  orgGUID: string,
+  spaceGUID: string,
+  userGUID: string,
+): IRole {
+  return JSON.parse(`{
+   "type": "${roleType}",
+
+   "relationships": {
+      "user": {
+         "data": {
+            "guid": "${userGUID}"
+         }
+      },
+      "organization": {
+         "data": {
+            "guid": "${orgGUID}"
+         }
+      },
+      "space": {
+         "data": {
+            "guid": "${spaceGUID}"
+         }
+      }
+   }
+}`);
+}

--- a/src/lib/cf/types.ts
+++ b/src/lib/cf/types.ts
@@ -600,3 +600,27 @@ export interface IAuditEvent extends IV3Metadata {
 
   readonly data: any;
 }
+
+export interface IRole extends IV3Metadata {
+  readonly type: string;
+
+  readonly relationships: {
+    readonly organization: {
+      readonly data: {
+        readonly guid: string | null;
+      };
+    };
+
+    readonly space: {
+      readonly data: {
+        readonly guid: string | null;
+      };
+    };
+
+    readonly user: {
+      readonly data: {
+        readonly guid: string;
+      };
+    };
+  };
+}


### PR DESCRIPTION
What
----

- Global auditors cannot use `/v2/users/:guid/summary`
- `/v2/` is going away
- `/v3/roles` is usable by global auditors

This PR:
- adds a function to get roles for a user
- uses `/v3/roles` on the platform admin users page
- restructures the platform admin users page to just show org membership

How to review
-------------

Code review

Check out [platform admin](https://admin.tlwr.dev.cloudpipeline.digital/users/d2d6cd34-b657-4f3e-b91d-542cdfd36032) in [tlwr](https://admin.tlwr.dev.cloudpipeline.digital/) as a global auditor

Who can review
---------------

Not @tlwr
