### PR TITLE
cdn-metrics: cdn metrics work for ACM

### DIFF
--- a/src/lib/metric-data-getters/cloudfront.test.ts
+++ b/src/lib/metric-data-getters/cloudfront.test.ts
@@ -35,6 +35,7 @@ describe('Cloudfront', () => {
               Values: ['a-service-guid'],
             },
           ],
+          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
 
@@ -63,6 +64,7 @@ describe('Cloudfront', () => {
               Values: ['a-service-guid'],
             },
           ],
+          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
     });
@@ -89,6 +91,7 @@ describe('Cloudfront', () => {
               Values: ['a-service-guid'],
             },
           ],
+          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
     });
@@ -115,6 +118,7 @@ describe('Cloudfront', () => {
               Values: ['a-service-guid'],
             },
           ],
+          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
     });
@@ -149,6 +153,7 @@ describe('Cloudfront', () => {
               Values: ['a-service-guid'],
             },
           ],
+          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
     });

--- a/src/lib/metric-data-getters/cloudfront.ts
+++ b/src/lib/metric-data-getters/cloudfront.ts
@@ -63,6 +63,9 @@ export class CloudFrontMetricDataGetter extends CloudWatchMetricDataGetter
               Values: [serviceGUID],
             },
           ],
+          ResourceTypeFilters: [
+            'cloudfront:distribution',
+          ],
         }),
       )
       .then((d: rg.GetResourcesOutput) => {


### PR DESCRIPTION
What
----

We have to look up CDN distribution using the tags API

We did this naively because the broker only created one resource (the distribution)

We now create multiple resources (ACM cert and distribution)

When we look up the distribution we should specify the resource type in the filter

The problem
---

In prod, run:

```
aws resourcegroupstaggingapi get-resources --tag-filters Key=ServiceInstance,Values=ccf23248-d69c-4411-99f2-977f1c52891f --region us-east-1
```

it will return two resources

then add:

```
--resource-type-filters cloudfront:distribution
```

and you will get one resource, which is what we want to proceed with the metrics query

How to review
-------------

Code review

Go to [this page](https://admin.cloud.service.gov.uk/organisations/a27b3e36-e041-464d-85a9-c9bef5201c97/spaces/a13048ea-5ac1-4ff1-8aa3-d6a2e2e8be22/services/ccf23248-d69c-4411-99f2-977f1c52891f/metrics?rangeStart=2020-07-22T12%3A24&rangeStop=2020-07-23T12%3A24) and see that it is erroring
