### PR TITLE
Revert "temporarily remove the support link"

### DIFF
--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -103,6 +103,11 @@ export function Header(props: IHeaderProperties): ReactElement {
               aria-label="Top Level Navigation"
             >
               <li className="govuk-header__navigation-item">
+                <a className="govuk-header__link" href="/support">
+                  Support
+                </a>
+              </li>
+              <li className="govuk-header__navigation-item">
                 <a className="govuk-header__link" href="/marketplace">
                   Marketplace
                 </a>


### PR DESCRIPTION
Reverts alphagov/paas-admin#959 as support forms are working now.
<img width="173" alt="Screenshot 2020-07-27 at 13 42 02" src="https://user-images.githubusercontent.com/3758555/88542829-fb275580-d00e-11ea-87c4-b08d2e3b5be0.png">
