### PR TITLE
[SUPPORT] Add`digitalaccessibilitycentre.org` to the accepted domains for audit

### DIFF
--- a/src/components/support/controllers.test.tsx
+++ b/src/components/support/controllers.test.tsx
@@ -77,7 +77,7 @@ describe(controller.HandleSignupFormPost, () => {
     expect(response.status).toEqual(400);
     expect(response.body).not.toContain('We have received your request');
     expect(response.body).toContain('Error');
-    expect(response.body).toContain('We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, .police.uk or police.uk email addresses');
+    expect(response.body).toContain('We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, .police.uk or police.uk email addresses');
   });
 
   it('should create a zendesk ticket correctly', async () => {

--- a/src/components/support/controllers.tsx
+++ b/src/components/support/controllers.tsx
@@ -258,7 +258,7 @@ function validateServiceTeam({ service_team }: ISupportFormServiceTeam): Readonl
 function validateSignupEmail({ email }: ISignupForm): ReadonlyArray<IDualValidationError> {
   const errors = [];
 
-  const allowedEmailAddresses = /(.+\.gov\.uk|.+nhs\.(net|uk)|.+mod\.uk|.+\.police\.uk|police\.uk)$/;
+  const allowedEmailAddresses = /(.+\.gov\.uk|.+nhs\.(net|uk)|.+mod\.uk|.+digitalaccessibilitycentre\.org|.+\.police\.uk|police\.uk)$/;
 
   if (!email || !VALID_EMAIL.test(email)) {
     errors.push({
@@ -270,7 +270,7 @@ function validateSignupEmail({ email }: ISignupForm): ReadonlyArray<IDualValidat
   if (email && VALID_EMAIL.test(email) && !allowedEmailAddresses.test(email)) {
     errors.push({
       field: 'email',
-      message: 'We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, .police.uk or police.uk email addresses',
+      message: 'We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, .police.uk or police.uk email addresses',
       messageExtra: `
         If you work for a government organisation or public body with a different email address, please contact us on
         <a class="govuk-link"


### PR DESCRIPTION
What
----

Add`digitalaccessibilitycentre.org` to the accepted domains for audit purposes so that all the user journeys can be tested

How to review
-------------

Code review and check the tests pass

Who can review
---------------

@AP-Hunt Has context
