### PR TITLE
Use Zendesk Requests API for ticket creation

### DIFF
--- a/src/components/support/controllers.test.tsx
+++ b/src/components/support/controllers.test.tsx
@@ -82,7 +82,7 @@ describe(controller.HandleSignupFormPost, () => {
 
   it('should create a zendesk ticket correctly', async () => {
     nockZD
-      .post('/tickets.json')
+      .post('/requests.json')
       .reply(201, {});
 
     const response = await controller.HandleSignupFormPost(ctx, {}, {
@@ -101,7 +101,7 @@ describe(controller.HandleSignupFormPost, () => {
 
   it('should create a zendesk ticket correctly when no additional users provided', async () => {
     nockZD
-      .post('/tickets.json')
+      .post('/requests.json')
       .reply(201, {});
 
     const response = await controller.HandleSignupFormPost(ctx, {}, {
@@ -153,7 +153,7 @@ describe(controller.HandleContactUsFormPost, () => {
 
   it('should create a zendesk ticket correctly', async () => {
     nockZD
-      .post('/tickets.json')
+      .post('/requests.json')
       .reply(201, {});
 
     const response = await controller.HandleContactUsFormPost(ctx, {}, {
@@ -201,7 +201,7 @@ describe(controller.HandleFindOutMoreFormPost, () => {
 
   it('should create a zendesk ticket correctly', async () => {
     nockZD
-      .post('/tickets.json')
+      .post('/requests.json')
       .reply(201, {});
 
     const response = await controller.HandleFindOutMoreFormPost(ctx, {}, {
@@ -246,7 +246,7 @@ describe(controller.HandleHelpUsingPaasFormPost, () => {
 
   it('should create a zendesk ticket correctly', async () => {
     nockZD
-      .post('/tickets.json')
+      .post('/requests.json')
       .reply(201, {});
 
     const response = await controller.HandleHelpUsingPaasFormPost(ctx, {}, {
@@ -262,7 +262,7 @@ describe(controller.HandleHelpUsingPaasFormPost, () => {
 
   it('should create a zendesk ticket correctly when no org has been provided', async () => {
     nockZD
-      .post('/tickets.json')
+      .post('/requests.json')
       .reply(201, {});
 
     const response = await controller.HandleHelpUsingPaasFormPost(ctx, {}, {
@@ -310,7 +310,7 @@ describe(controller.HandleSomethingWrongWithServiceFormPost, () => {
 
   it('should create a zendesk ticket correctly', async () => {
     nockZD
-      .post('/tickets.json')
+      .post('/requests.json')
       .reply(201, {});
 
     const response = await controller.HandleSomethingWrongWithServiceFormPost(ctx, {}, {

--- a/src/components/support/controllers.tsx
+++ b/src/components/support/controllers.tsx
@@ -416,8 +416,8 @@ export async function HandleSomethingWrongWithServiceFormPost(
 
   const client = zendesk.createClient(ctx.app.zendeskConfig);
 
-  await client.tickets.create({
-    ticket: {
+  await client.requests.create({
+    request: {
       comment: {
         body: somethingWrongWithServiceContent({
           affected_paas_organisation: body.affected_paas_organisation,
@@ -428,6 +428,10 @@ export async function HandleSomethingWrongWithServiceFormPost(
         }),
       },
       subject: `[PaaS Support] ${TODAY_DATE.toDateString()} something wrong in ${body.affected_paas_organisation} live service`,
+      requester: {
+        email: body.email,
+        name: body.name,
+      },
     },
   });
   template.title = 'We have received your message';
@@ -493,8 +497,8 @@ export async function HandleHelpUsingPaasFormPost(
 
   const client = zendesk.createClient(ctx.app.zendeskConfig);
 
-  await client.tickets.create({
-    ticket: {
+  await client.requests.create({
+    request: {
       comment: {
         body: helpUsingPaasContent({
           email: body.email,
@@ -504,6 +508,10 @@ export async function HandleHelpUsingPaasFormPost(
         }),
       },
       subject: `[PaaS Support] ${TODAY_DATE.toDateString()} request for help`,
+      requester: {
+        email: body.email,
+        name: body.name,
+      },
     },
   });
 
@@ -569,8 +577,8 @@ export async function HandleFindOutMoreFormPost (
 
   const client = zendesk.createClient(ctx.app.zendeskConfig);
 
-  await client.tickets.create({
-    ticket: {
+  await client.requests.create({
+    request: {
       comment: {
         body: findoutMoreContent({
           email: body.email,
@@ -580,6 +588,10 @@ export async function HandleFindOutMoreFormPost (
         }),
       },
       subject: `[PaaS Support] ${TODAY_DATE.toDateString()} request for information`,
+      requester: {
+        email: body.email,
+        name: body.name,
+      },
     },
   });
 
@@ -647,8 +659,8 @@ export async function HandleContactUsFormPost(
 
   const client = zendesk.createClient(ctx.app.zendeskConfig);
 
-  await client.tickets.create({
-    ticket: {
+  await client.requests.create({
+    request: {
       comment: {
         body: contactUsContent({
           department_agency: body.department_agency,
@@ -659,6 +671,10 @@ export async function HandleContactUsFormPost(
         }),
       },
       subject: `[PaaS Support] ${TODAY_DATE.toDateString()} support request from website`,
+      requester: {
+        email: body.email,
+        name: body.name,
+      },
     },
   });
 
@@ -746,8 +762,8 @@ export async function HandleSignupFormPost(
 
   const client = zendesk.createClient(ctx.app.zendeskConfig);
 
-  await client.tickets.create({
-    ticket: {
+  await client.requests.create({
+    request: {
       comment: {
         body: signUpContent({
           additional_users: body.additional_users,
@@ -760,6 +776,10 @@ export async function HandleSignupFormPost(
         }),
       },
       subject: `[PaaS Support] ${TODAY_DATE.toDateString()} Registration Request`,
+      requester: {
+        email: body.email,
+        name: body.name,
+      },
     },
   });
 


### PR DESCRIPTION
What
----

With Tickets API we couldn't set the user's email address as the requester, which meant manually updating email for each ticket.

With this change and and the addition of the requester object, tickets that are created have the user's email address and name.

Additionaly, users now get an email confirmation and email updates.

### Before

<img width="672" alt="Screenshot 2020-07-29 at 17 05 52" src="https://user-images.githubusercontent.com/3758555/88824538-619ea600-d1be-11ea-985c-52df01dd0d5c.png">
<img width="537" alt="Screenshot 2020-07-29 at 17 06 14" src="https://user-images.githubusercontent.com/3758555/88824543-62373c80-d1be-11ea-998e-aafb91dba6e2.png">


### After
<img width="617" alt="Screenshot 2020-07-29 at 17 07 37" src="https://user-images.githubusercontent.com/3758555/88824577-6d8a6800-d1be-11ea-866e-13000cdfbcaf.png">
<img width="619" alt="Screenshot 2020-07-29 at 17 07 45" src="https://user-images.githubusercontent.com/3758555/88824581-6f542b80-d1be-11ea-9174-bce4473853fe.png">

**Received email on solved**
<img width="652" alt="Screenshot 2020-07-29 at 17 13 08" src="https://user-images.githubusercontent.com/3758555/88824897-d2de5900-d1be-11ea-9177-8c453e5a4384.png">


How to review
-------------

- checkout `use-zendesk-requests-api` branch
- run `npm install`
- run locally with `ZENDESK_API_TOKEN="{token}" ZENDESK_USERNAME="{user}" npm run start:with-stub-api` with creds from the password-store (or deploy to your env)
- submit ones of the forms
- check email in Zendesk if it contains correct requester email and name
- evaluate code

Who can review
---------------

not @kr8n3r 

