### PR TITLE
Conditionally show events table and content

### DIFF
--- a/src/components/application-events/controllers.test.tsx
+++ b/src/components/application-events/controllers.test.tsx
@@ -187,7 +187,6 @@ describe('application events', () => {
       expect(response.body).toContain(
         `${defaultApp().entity.name} - Application Events`,
       );
-      expect(response.body).toContain('Displaying page 1 of 1');
       expect(response.body).toContain('0 total events');
     });
   });

--- a/src/components/application-events/views.test.tsx
+++ b/src/components/application-events/views.test.tsx
@@ -65,4 +65,83 @@ describe(ApplicationEventsPage, () => {
     expect($('table tbody').text()).toContain('tester.testing');
     expect($('table tbody').text()).toContain('ACCOUNTS_USER_GUID_3');
   });
+
+  it('should not show the application events table if there are no events', () => {
+    const markup = shallow(
+      <ApplicationEventsPage
+        actorEmails={actorEmails}
+        application={application}
+        events={[]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.applications.events.view'
+        }
+        organizationGUID="ORG_GUID"
+        spaceGUID="SPACE_GUID"
+        pagination={{ total_results: 0, total_pages: 1, page: 1 }}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('table')).toHaveLength(0);
+  });
+
+  it('should not show the timestamp text if there are no events', () => {
+    const markup = shallow(
+      <ApplicationEventsPage
+        actorEmails={actorEmails}
+        application={application}
+        events={[]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.applications.events.view'
+        }
+        organizationGUID="ORG_GUID"
+        spaceGUID="SPACE_GUID"
+        pagination={{ total_results: 0, total_pages: 1, page: 1 }}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-tabs__panel').text()).not.toContain('Event timestamps are in UTC format');
+  });
+
+  it('should not show pagination text/links if there is only 1 page of events', () => {
+    const markup = shallow(
+      <ApplicationEventsPage
+        actorEmails={actorEmails}
+        application={application}
+        events={[
+          event,
+          {
+            ...event,
+            type: 'tester.testing',
+            actor: {
+              ...event.actor,
+              guid: 'ACCOUNTS_USER_GUID_2',
+              name: 'Charlie Chaplin',
+            },
+          },
+          {
+            ...event,
+            type: 'tester.testing',
+            actor: {
+              ...event.actor,
+              guid: 'ACCOUNTS_USER_GUID_3',
+              name: undefined,
+            },
+          },
+        ]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.applications.events.view'
+        }
+        organizationGUID="ORG_GUID"
+        spaceGUID="SPACE_GUID"
+        pagination={{ total_results: 5, total_pages: 1, page: 1 }}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-tabs__panel').text()).not.toContain('Previous page');
+    expect($('.govuk-tabs__panel').text()).not.toContain('Next page');
+  });
+
 });

--- a/src/components/application-events/views.tsx
+++ b/src/components/application-events/views.tsx
@@ -56,36 +56,40 @@ function Link(props: ILinkProperties): ReactElement {
 
 function Pagination(props: IPaginationProperties): ReactElement {
   return (
-    <p className="govuk-body">
-      <Link
-        href={props.linkTo(
-          'admin.organizations.spaces.applications.events.view',
-          {
-            applicationGUID: props.application.metadata.guid,
-            organizationGUID: props.organizationGUID,
-            page: props.pagination.page - 1,
-            spaceGUID: props.spaceGUID,
-          },
-        )}
-        disabled={props.pagination.page <= 1}
-      >
-        Previous page
-      </Link>{' '}
-      <Link
-        href={props.linkTo(
-          'admin.organizations.spaces.applications.events.view',
-          {
-            applicationGUID: props.application.metadata.guid,
-            organizationGUID: props.organizationGUID,
-            page: props.pagination.page + 1,
-            spaceGUID: props.spaceGUID,
-          },
-        )}
-        disabled={props.pagination.page >= props.pagination.total_pages}
-      >
-        Next page
-      </Link>
-    </p>
+    <>
+    {props.pagination.total_pages > 1 ?
+      <p className="govuk-body">
+        <Link
+          href={props.linkTo(
+            'admin.organizations.spaces.applications.events.view',
+            {
+              applicationGUID: props.application.metadata.guid,
+              organizationGUID: props.organizationGUID,
+              page: props.pagination.page - 1,
+              spaceGUID: props.spaceGUID,
+            },
+          )}
+          disabled={props.pagination.page <= 1}
+        >
+          Previous page
+        </Link>{' '}
+        <Link
+          href={props.linkTo(
+            'admin.organizations.spaces.applications.events.view',
+            {
+              applicationGUID: props.application.metadata.guid,
+              organizationGUID: props.organizationGUID,
+              page: props.pagination.page + 1,
+              spaceGUID: props.spaceGUID,
+            },
+          )}
+          disabled={props.pagination.page >= props.pagination.total_pages}
+        >
+          Next page
+        </Link>
+      </p>
+    : <></> }
+    </>
   );
 }
 
@@ -120,8 +124,11 @@ export function ApplicationEventsPage(
         page={props.pagination.page}
         pages={props.pagination.total_pages}
       />
-
-      <EventTimestamps />
+      
+      {props.pagination.total_results > 0 ? 
+        <EventTimestamps /> : 
+        <></>
+      }
 
       <Details />
 
@@ -132,42 +139,45 @@ export function ApplicationEventsPage(
         spaceGUID={props.spaceGUID}
         pagination={props.pagination}
       />
-      <div className="scrollable-table-container">
-        <table className="govuk-table">
-          <thead className="govuk-table__head">
-            <tr className="govuk-table__row">
-              <th className="govuk-table__header">Date</th>
-              <th className="govuk-table__header">Actor</th>
-              <th className="govuk-table__header">Event</th>
-              <th className="govuk-table__header">Details</th>
-            </tr>
-          </thead>
-          <tbody className="govuk-table__body">
-            {props.events.map(event => (
-              <EventListItem
-                key={event.guid}
-                actor={
-                  props.actorEmails[event.actor.guid] ||
-                  event.actor.name || <code>{event.actor.guid}</code>
-                }
-                date={event.updated_at}
-                href={props.linkTo(
-                  'admin.organizations.spaces.applications.event.view',
-                  {
-                    applicationGUID: props.application.metadata.guid,
-                    eventGUID: event.guid,
-                    organizationGUID: props.organizationGUID,
-                    spaceGUID: props.spaceGUID,
-                  },
-                )}
-                type={
-                  eventTypeDescriptions[event.type] || <code>{event.type}</code>
-                }
-              />
-            ))}
-          </tbody>
-        </table>
-      </div>
+      {props.events.length > 0 ?
+        <div className="scrollable-table-container">
+          <table className="govuk-table">
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th className="govuk-table__header">Date</th>
+                <th className="govuk-table__header">Actor</th>
+                <th className="govuk-table__header">Event</th>
+                <th className="govuk-table__header">Details</th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {props.events.map(event => (
+                <EventListItem
+                  key={event.guid}
+                  actor={
+                    props.actorEmails[event.actor.guid] ||
+                    event.actor.name || <code>{event.actor.guid}</code>
+                  }
+                  date={event.updated_at}
+                  href={props.linkTo(
+                    'admin.organizations.spaces.applications.event.view',
+                    {
+                      applicationGUID: props.application.metadata.guid,
+                      eventGUID: event.guid,
+                      organizationGUID: props.organizationGUID,
+                      spaceGUID: props.spaceGUID,
+                    },
+                  )}
+                  type={
+                    eventTypeDescriptions[event.type] || <code>{event.type}</code>
+                  }
+                />
+              ))}
+            </tbody>
+          </table>
+        </div> 
+        : <></> 
+      }
 
       <Pagination
         application={props.application}

--- a/src/components/events/views.test.tsx
+++ b/src/components/events/views.test.tsx
@@ -141,10 +141,19 @@ describe(TargetedEvent, () => {
 
 describe(Totals, () => {
   it('should display totals element', () => {
-    const markup = shallow(<Totals results={5} page={1} pages={1} />);
+    const markup = shallow(<Totals results={5} page={1} pages={2} />);
     const $ = cheerio.load(markup.html());
     expect($('p').text()).toContain(
-      'There are 5 total events. Displaying page 1 of 1.',
+      'There are 5 total events. Displaying page 1 of 2.',
+    );
+    expect(spacesMissingAroundInlineElements($.html())).toHaveLength(0);
+  });
+
+  it('should not display "Displaying page 1 of 1" totals text if there is only 1 page', () => {
+    const markup = shallow(<Totals results={5} page={1} pages={1} />);
+    const $ = cheerio.load(markup.html());
+    expect($('p').text()).not.toContain(
+      'Displaying page 1 of 1.',
     );
     expect(spacesMissingAroundInlineElements($.html())).toHaveLength(0);
   });

--- a/src/components/events/views.tsx
+++ b/src/components/events/views.tsx
@@ -172,8 +172,11 @@ export function TargetedEventListItem(
 export function Totals(props: ITotalsProperties): ReactElement {
   return (
     <p className="govuk-body">
-      There are {props.results} total events. Displaying page {props.page} of{' '}
-      {props.pages}.
+      There are {props.results} total events. 
+      {props.pages > 1 ? 
+        `${' '}Displaying page ${props.page} of${' '}${props.pages}.`
+        : <></> 
+      }
     </p>
   );
 }

--- a/src/components/service-events/controllers.test.tsx
+++ b/src/components/service-events/controllers.test.tsx
@@ -190,7 +190,6 @@ describe('service events', () => {
       });
 
       expect(response.body).toContain('name-1508 - Service Events');
-      expect(response.body).toContain('Displaying page 1 of 1');
       expect(response.body).toContain('0 total events');
       expect(
         spacesMissingAroundInlineElements(response.body as string),

--- a/src/components/service-events/views.test.tsx
+++ b/src/components/service-events/views.test.tsx
@@ -67,4 +67,83 @@ describe(ServiceEventsPage, () => {
     expect($('table tbody').text()).toContain('ACCOUNTS_USER_GUID_3');
     expect(spacesMissingAroundInlineElements(markup.html())).toHaveLength(0);
   });
+
+  it('should not show the service events table if there are no events', () => {
+    const markup = shallow(
+      <ServiceEventsPage
+        actorEmails={actorEmails}
+        service={service}
+        events={[]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.services.view'
+        }
+        organizationGUID="ORG_GUID"
+        spaceGUID="SPACE_GUID"
+        pagination={{ total_results: 0, total_pages: 1, page: 1 }}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('table')).toHaveLength(0);
+  });
+
+  it('should not show the timestamp text if there are no events', () => {
+    const markup = shallow(
+      <ServiceEventsPage
+        actorEmails={actorEmails}
+        service={service}
+        events={[]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.services.view'
+        }
+        organizationGUID="ORG_GUID"
+        spaceGUID="SPACE_GUID"
+        pagination={{ total_results: 0, total_pages: 1, page: 1 }}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-tabs__panel').text()).not.toContain('Event timestamps are in UTC format');
+  });
+
+  it('should not show pagination text/links if there is only 1 page of events', () => {
+    const markup = shallow(
+      <ServiceEventsPage
+        actorEmails={actorEmails}
+        service={service}
+        events={[
+          event,
+          {
+            ...event,
+            type: 'tester.testing',
+            actor: {
+              ...event.actor,
+              guid: 'ACCOUNTS_USER_GUID_2',
+              name: 'Charlie Chaplin',
+            },
+          },
+          {
+            ...event,
+            type: 'tester.testing',
+            actor: {
+              ...event.actor,
+              guid: 'ACCOUNTS_USER_GUID_3',
+              name: undefined,
+            },
+          },
+        ]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.services.view'
+        }
+        organizationGUID="ORG_GUID"
+        spaceGUID="SPACE_GUID"
+        pagination={{ total_results: 5, total_pages: 1, page: 1 }}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-tabs__panel').text()).not.toContain('Previous page');
+    expect($('.govuk-tabs__panel').text()).not.toContain('Next page');
+  });
+
 });

--- a/src/components/service-events/views.tsx
+++ b/src/components/service-events/views.tsx
@@ -47,6 +47,8 @@ function Link(props: ILinkProperties): ReactElement {
 
 function Pagination(props: IPaginationProperties): ReactElement {
   return (
+    <>
+    {props.pagination.total_pages > 1 ?
     <p className="govuk-body">
       <Link
         href={props.linkTo('admin.organizations.spaces.services.events.view', {
@@ -71,6 +73,8 @@ function Pagination(props: IPaginationProperties): ReactElement {
         Next page
       </Link>
     </p>
+    : <></> }
+    </>
   );
 }
 
@@ -100,7 +104,10 @@ export function ServiceEventsPage(
         pages={props.pagination.total_pages}
       />
 
-      <EventTimestamps />
+      {props.pagination.total_results > 0 ? 
+        <EventTimestamps /> : 
+        <></>
+      }
 
       <Details />
 
@@ -112,42 +119,45 @@ export function ServiceEventsPage(
         pagination={props.pagination}
       />
 
-      <div className="scrollable-table-container">
-        <table className="govuk-table">
-        <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
-            <th className="govuk-table__header">Date</th>
-            <th className="govuk-table__header">Actor</th>
-            <th className="govuk-table__header">Event</th>
-            <th className="govuk-table__header">Details</th>
-          </tr>
-        </thead>
-        <tbody className="govuk-table__body">
-          {props.events.map(event => (
-            <EventListItem
-              key={event.guid}
-              actor={
-                props.actorEmails[event.actor.guid] ||
-                event.actor.name || <code>{event.actor.guid}</code>
-              }
-              date={event.updated_at}
-              href={props.linkTo(
-                'admin.organizations.spaces.services.event.view',
-                {
-                  eventGUID: event.guid,
-                  organizationGUID: props.organizationGUID,
-                  serviceGUID: props.service.metadata.guid,
-                  spaceGUID: props.spaceGUID,
-                },
-              )}
-              type={
-                eventTypeDescriptions[event.type] || <code>{event.type}</code>
-              }
-            />
-          ))}
-        </tbody>
-      </table>
-      </div>
+      {props.events.length > 0 ?
+        <div className="scrollable-table-container">
+          <table className="govuk-table">
+          <thead className="govuk-table__head">
+            <tr className="govuk-table__row">
+              <th className="govuk-table__header">Date</th>
+              <th className="govuk-table__header">Actor</th>
+              <th className="govuk-table__header">Event</th>
+              <th className="govuk-table__header">Details</th>
+            </tr>
+          </thead>
+          <tbody className="govuk-table__body">
+            {props.events.map(event => (
+              <EventListItem
+                key={event.guid}
+                actor={
+                  props.actorEmails[event.actor.guid] ||
+                  event.actor.name || <code>{event.actor.guid}</code>
+                }
+                date={event.updated_at}
+                href={props.linkTo(
+                  'admin.organizations.spaces.services.event.view',
+                  {
+                    eventGUID: event.guid,
+                    organizationGUID: props.organizationGUID,
+                    serviceGUID: props.service.metadata.guid,
+                    spaceGUID: props.spaceGUID,
+                  },
+                )}
+                type={
+                  eventTypeDescriptions[event.type] || <code>{event.type}</code>
+                }
+              />
+            ))}
+          </tbody>
+        </table>
+        </div>
+        : <></> 
+      }
     </ServiceTab>
   );
 }

--- a/src/components/spaces/controllers.test.tsx
+++ b/src/components/spaces/controllers.test.tsx
@@ -312,7 +312,6 @@ describe('spaces test suite', () => {
         });
 
         expect(response.body).toContain('name-2064 - Space Events');
-        expect(response.body).toContain('Displaying page 1 of 1');
         expect(response.body).toContain('0 total events');
         expect(
           spacesMissingAroundInlineElements(response.body as string),

--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -104,6 +104,91 @@ describe(EventsPage, () => {
       actorEmails.ACCOUNTS_USER_GUID_1,
     );
   });
+
+  it('should not show the spaces events table if there are no events', () => {
+    const markup = shallow(
+      <EventsPage
+        actorEmails={actorEmails}
+        events={[]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.applications.events.view'
+        }
+        organizationGUID="ORG_GUID"
+        space={space}
+        pagination={{ total_results: 0, total_pages: 1, page: 1 }}
+      />,
+    );
+
+    const $ = cheerio.load(markup.html());
+    expect($('table')).toHaveLength(0);
+  });
+
+  it('should not show the spaces events table if there are no events', () => {
+    const markup = shallow(
+      <EventsPage
+        actorEmails={actorEmails}
+        events={[]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.applications.events.view'
+        }
+        organizationGUID="ORG_GUID"
+        space={space}
+        pagination={{ total_results: 0, total_pages: 1, page: 1 }}
+      />,
+    );
+
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-tabs__panel').text()).not.toContain('Event timestamps are in UTC format');
+  });
+
+  it('should not show pagination text/links if there is only 1 page of events', () => {
+    const markup = shallow(
+      <EventsPage
+        actorEmails={actorEmails}
+        events={[
+          event,
+          {
+            ...event,
+            type: 'tester.testing',
+            actor: {
+              ...event.actor,
+              guid: 'ACCOUNTS_USER_GUID_2',
+              name: 'Charlie Chaplin',
+            },
+            target: ({
+              guid: 'ACCOUNTS_USER_GUID_3',
+            } as unknown) as IAuditEventActorTarget,
+          },
+          {
+            ...event,
+            type: 'tester.testing',
+            actor: {
+              ...event.actor,
+              guid: 'ACCOUNTS_USER_GUID_3',
+              name: undefined,
+            },
+            target: ({
+              guid: 'ACCOUNTS_USER_GUID_1',
+              name: 'Jeff Jefferson',
+            } as unknown) as IAuditEventActorTarget,
+          },
+        ]}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.applications.events.view'
+        }
+        organizationGUID="ORG_GUID"
+        space={space}
+        pagination={{ total_results: 5, total_pages: 1, page: 1 }}
+      />,
+    );
+
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-tabs__panel').text()).not.toContain('Previous page');
+    expect($('.govuk-tabs__panel').text()).not.toContain('Next page');
+  });
 });
 
 describe(ApplicationsPage, () => {

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -142,28 +142,32 @@ function Link(props: ILinkProperties): ReactElement {
 
 function Pagination(props: IPaginationProperties): ReactElement {
   return (
-    <p className="govuk-body">
-      <Link
-        href={props.linkTo('admin.organizations.spaces.events.view', {
-          organizationGUID: props.organizationGUID,
-          page: props.pagination.page - 1,
-          spaceGUID: props.space.metadata.guid,
-        })}
-        disabled={props.pagination.page <= 1}
-      >
-        Previous page
-      </Link>{' '}
-      <Link
-        href={props.linkTo('admin.organizations.spaces.events.view', {
-          organizationGUID: props.organizationGUID,
-          page: props.pagination.page + 1,
-          spaceGUID: props.space.metadata.guid,
-        })}
-        disabled={props.pagination.page >= props.pagination.total_pages}
-      >
-        Next page
-      </Link>
-    </p>
+    <>
+    {props.pagination.total_pages > 1 ?
+      <p className="govuk-body">
+        <Link
+          href={props.linkTo('admin.organizations.spaces.events.view', {
+            organizationGUID: props.organizationGUID,
+            page: props.pagination.page - 1,
+            spaceGUID: props.space.metadata.guid,
+          })}
+          disabled={props.pagination.page <= 1}
+        >
+          Previous page
+        </Link>{' '}
+        <Link
+          href={props.linkTo('admin.organizations.spaces.events.view', {
+            organizationGUID: props.organizationGUID,
+            page: props.pagination.page + 1,
+            spaceGUID: props.space.metadata.guid,
+          })}
+          disabled={props.pagination.page >= props.pagination.total_pages}
+        >
+          Next page
+        </Link>
+      </p>
+    : <></> }
+    </>
   );
 }
 
@@ -616,7 +620,10 @@ export function EventsPage(props: IEventsPageProperties): ReactElement {
         pages={props.pagination.total_pages}
       />
 
-      <EventTimestamps />
+      {props.pagination.total_results > 0 ? 
+        <EventTimestamps /> : 
+        <></>
+      }
 
       <Details />
 
@@ -626,44 +633,47 @@ export function EventsPage(props: IEventsPageProperties): ReactElement {
         organizationGUID={props.organizationGUID}
         pagination={props.pagination}
       />
-
-      <div className="scrollable-table-container">
-        <table className="govuk-table">
-        <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
-            <th className="govuk-table__header">Date</th>
-            <th className="govuk-table__header">Actor</th>
-            <th className="govuk-table__header">Target</th>
-            <th className="govuk-table__header">Event</th>
-            <th className="govuk-table__header">Details</th>
-          </tr>
-        </thead>
-        <tbody className="govuk-table__body">
-          {props.events.map(event => (
-            <TargetedEventListItem
-              key={event.guid}
-              actor={
-                props.actorEmails[event.actor.guid] ||
-                event.actor.name || <code>{event.actor.guid}</code>
-              }
-              date={event.updated_at}
-              href={props.linkTo('admin.organizations.spaces.event.view', {
-                eventGUID: event.guid,
-                organizationGUID: props.organizationGUID,
-                spaceGUID: props.space.metadata.guid,
-              })}
-              target={
-                props.actorEmails[event.target.guid] ||
-                event.target.name || <code>{event.target.guid}</code>
-              }
-              type={
-                eventTypeDescriptions[event.type] || <code>{event.type}</code>
-              }
-            />
-          ))}
-        </tbody>
-      </table>
-      </div>
+      
+      {props.events.length > 0 ?
+        <div className="scrollable-table-container">
+          <table className="govuk-table">
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th className="govuk-table__header">Date</th>
+                <th className="govuk-table__header">Actor</th>
+                <th className="govuk-table__header">Target</th>
+                <th className="govuk-table__header">Event</th>
+                <th className="govuk-table__header">Details</th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {props.events.map(event => (
+                <TargetedEventListItem
+                  key={event.guid}
+                  actor={
+                    props.actorEmails[event.actor.guid] ||
+                    event.actor.name || <code>{event.actor.guid}</code>
+                  }
+                  date={event.updated_at}
+                  href={props.linkTo('admin.organizations.spaces.event.view', {
+                    eventGUID: event.guid,
+                    organizationGUID: props.organizationGUID,
+                    spaceGUID: props.space.metadata.guid,
+                  })}
+                  target={
+                    props.actorEmails[event.target.guid] ||
+                    event.target.name || <code>{event.target.guid}</code>
+                  }
+                  type={
+                    eventTypeDescriptions[event.type] || <code>{event.type}</code>
+                  }
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+        : <></> 
+      }
 
       <Pagination
         space={props.space}


### PR DESCRIPTION
What
----

Conditionally display events "tab" content for Application, Space and Service Events as follows:

- if there are 0 events or only 1 page of events, don't show "Displaying page 1 of 1." text
(for 0 events API returns 'totals_pages: 1')

- if there are 0 events, don't show "Event timestamps are in UTC format" text

- if there are 0 events, don't show an empty table

How to review
-------------

- review code commit by commit
- if running locally, adjust datat [stub-cf](https://github.com/alphagov/paas-admin/blob/master/stub-api/stub-cf.ts#L79-L88) and restart `npm run start:stub-api` . repeat.

Who can review
---------------

not @kr8n3r 

Visual changes
---------------

### Before
<img width="1110" alt="Screenshot 2020-08-03 at 20 34 10" src="https://user-images.githubusercontent.com/3758555/89219980-b54b2e00-d5c8-11ea-9966-01abc573430e.png">
<img width="1229" alt="Screenshot 2020-08-03 at 20 32 25" src="https://user-images.githubusercontent.com/3758555/89219996-baa87880-d5c8-11ea-9aeb-3f7e7479d465.png">
<img width="1235" alt="Screenshot 2020-08-03 at 20 31 39" src="https://user-images.githubusercontent.com/3758555/89220009-c1cf8680-d5c8-11ea-8eac-8c14d9accca2.png">


### After
<img width="710" alt="Screenshot 2020-08-03 at 20 23 44" src="https://user-images.githubusercontent.com/3758555/89219627-073f8400-d5c8-11ea-8544-f24578760f37.png">
<img width="1226" alt="Screenshot 2020-08-03 at 20 26 52" src="https://user-images.githubusercontent.com/3758555/89219630-0870b100-d5c8-11ea-9ca8-0235cdbabecd.png">
<img width="1220" alt="Screenshot 2020-08-03 at 20 28 34" src="https://user-images.githubusercontent.com/3758555/89219634-09a1de00-d5c8-11ea-9743-f19ee8d22a06.png">

