### PR TITLE
Fix calculator memory rounding

### DIFF
--- a/src/components/calculator/views.test.tsx
+++ b/src/components/calculator/views.test.tsx
@@ -1,0 +1,21 @@
+import { render } from 'enzyme';
+import {
+    appInstanceDescription,
+} from './views';
+
+describe(appInstanceDescription, () => {
+  it('should display "1 app instance with 64 MiB of memory" wihout a decimal point', () => {
+    const instanceDescription = render(appInstanceDescription(64,1)).text()
+    expect(instanceDescription).toEqual("1 app instance with 64 MiB of memory")
+  });
+
+  it('should display "1 app instance with 1.5 GiB of memory" with a decimal point', () => {
+    const instanceDescription = render(appInstanceDescription(1536,1)).text()
+    expect(instanceDescription).toEqual("1 app instance with 1.5 GiB of memory")
+  });
+
+  it('should display "1 app instance with 2 GiB of memory" without a decimal point', () => {
+    const instanceDescription = render(appInstanceDescription(2048,1)).text()
+    expect(instanceDescription).toEqual("1 app instance with 2 GiB of memory")
+  });
+});

--- a/src/components/calculator/views.tsx
+++ b/src/components/calculator/views.tsx
@@ -2,6 +2,7 @@ import { groupBy, mapValues, values } from 'lodash';
 import React, { Fragment, ReactElement } from 'react';
 
 import { bytesToHuman } from '../../layouts/helpers';
+import { KIBIBYTE } from '../../layouts/constants';
 
 export interface IQuote {
   readonly events: ReadonlyArray<IBillableEvent>;
@@ -91,13 +92,14 @@ function niceServiceName(planName: string): string {
   return niceServiceNames[planName] || planName;
 }
 
-function appInstanceDescription(memoryInMB: number, instances: number): ReactElement {
+export function appInstanceDescription(memoryInMB: number, instances: number): ReactElement {
+  const precisionDigits = memoryInMB > KIBIBYTE && memoryInMB < KIBIBYTE * 2 ? 1 : 0;
   return <>
     {instances.toFixed(0)} app instance{instances === 1 ? '' : 's'}
     {' '}
     with
     {' '}
-    {bytesToHuman(memoryInMB * 1024 * 1024, 0)} of memory
+    {bytesToHuman(memoryInMB * 1024 * 1024, precisionDigits)} of memory
   </>;
 }
 


### PR DESCRIPTION
What
----

Change toFixed precision value to 1 when the unit rounding values is between 1024 and 2048, such as 1.5GiB

**Before**
<img width="389" alt="Screenshot 2020-08-04 at 11 01 02" src="https://user-images.githubusercontent.com/3758555/89281320-d1d77c80-d641-11ea-9519-99e3121fc15f.png">


**After**
<img width="388" alt="Screenshot 2020-08-04 at 10 51 13" src="https://user-images.githubusercontent.com/3758555/89281227-b10f2700-d641-11ea-856b-aec00a442e05.png">


How to review
-------------

- checkout branch
- play with calculator, add instances with varying memory
- check that 1.5giB is not rounded to 2

Who can review
---------------

not @kr8n3r 

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174161285