### PR TITLE
Only show Logs tab on supported services

### DIFF
--- a/src/components/service-metrics/controllers.test.tsx
+++ b/src/components/service-metrics/controllers.test.tsx
@@ -63,7 +63,10 @@ describe('service metrics test suite', () => {
         '/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee',
       )
       .times(1)
-      .reply(200, data.userServiceInstance);
+      .reply(200, data.userServiceInstance)
+      .get('/v2/services/a00cacc0-0ca6-422e-91d3-6b22bcd33450')
+      .times(1)
+      .reply(200, data.serviceString);
   });
 
   function mockService(service: object) {

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -177,6 +177,19 @@ export async function viewServiceMetrics(
     ? await cf.userServiceInstance(params.serviceGUID)
     : await cf.serviceInstance(params.serviceGUID);
 
+  const servicePlan = !isUserProvidedService
+    ? await cf.servicePlan(service.entity.service_plan_guid)
+    : undefined;
+
+  const summarisedService = {
+    entity: service.entity,
+    metadata: service.metadata,
+    service: servicePlan
+      ? await cf.service(servicePlan.entity.service_guid)
+      : undefined,
+    service_plan: servicePlan,
+  };
+
   const serviceLabel = isUserProvidedService
     ? 'User Provided Service'
     : (await cf.service(service.entity.service_guid)).entity.label;
@@ -204,7 +217,7 @@ export async function viewServiceMetrics(
     rangeStart: rangeStart.toDate(),
     rangeStop: rangeStop.toDate(),
     routePartOf: ctx.routePartOf,
-    service,
+    service: summarisedService,
     serviceLabel,
     spaceGUID: space.metadata.guid,
   };

--- a/src/components/services/controllers.mocked.test.tsx
+++ b/src/components/services/controllers.mocked.test.tsx
@@ -12,6 +12,7 @@ jest.mock('../../lib/cf');
 
 const mockCustomService = { metadata: { guid: 'CUSTOM_SERVICE' } };
 const mockServiceInstance = { entity: { name: 'mydb' }, metadata: { guid: 'SERVICE_INSTANCE_GUID' } };
+const mockServicePlan = { entity: { service_guid: 'SERVICE_GUID' } };
 const mockServiceRedis = { entity: { label: 'redis' } };
 const mockServicePostgres = { entity: { label: 'postgres' } };
 const mockOrganization = { entity: { name: 'org-name' }, metadata: { guid: 'ORG_GUID' } };
@@ -57,6 +58,7 @@ describe(listServiceLogs, () => {
     CFClient.prototype.organization.mockReturnValueOnce(Promise.resolve(mockOrganization));
     CFClient.prototype.serviceInstance.mockReturnValueOnce(Promise.resolve(mockServiceInstance));
     CFClient.prototype.service.mockReturnValueOnce(Promise.resolve(mockServicePostgres));
+    CFClient.prototype.servicePlan.mockReturnValueOnce(Promise.resolve(mockServicePlan));
     // @ts-ignore
     RDS.mockReturnValueOnce({
       describeDBLogFiles: () => ({
@@ -80,6 +82,7 @@ describe(listServiceLogs, () => {
     CFClient.prototype.organization.mockReturnValueOnce(Promise.resolve(mockOrganization));
     CFClient.prototype.serviceInstance.mockReturnValueOnce(Promise.resolve(mockServiceInstance));
     CFClient.prototype.service.mockReturnValueOnce(Promise.resolve(mockServicePostgres));
+    CFClient.prototype.servicePlan.mockReturnValueOnce(Promise.resolve(mockServicePlan));
     // @ts-ignore
     RDS.mockReturnValueOnce({
       describeDBLogFiles: () => ({

--- a/src/components/services/views.test.tsx
+++ b/src/components/services/views.test.tsx
@@ -11,6 +11,7 @@ describe(ServiceTab, () => {
     const service = ({
       metadata: { guid: 'SERVICE_GUID' },
       entity: { name: 'service-name' },
+      service: { entity: { label: 'postgres' } },
     } as unknown) as IServiceInstance;
     const markup = shallow(
       <ServiceTab
@@ -40,6 +41,36 @@ describe(ServiceTab, () => {
     expect(
       $('ul li:last-of-type').hasClass('govuk-tabs__list-item--selected'),
     ).toBe(false);
+  });
+
+
+  it('should produce service tab without logs tab', () => {
+    const service = ({
+      metadata: { guid: 'SERVICE_GUID' },
+      entity: { name: 'service-name', type: 'not-approved' },
+    } as unknown) as IServiceInstance;
+
+    const markup = shallow(
+      <ServiceTab
+        service={service}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.services.view'
+        }
+        organizationGUID="ORG_GUID"
+        spaceGUID="SPACE_GUID"
+      >
+        <p>TEST</p>
+      </ServiceTab>,
+    );
+
+    const $ = cheerio.load(markup.html());
+    expect($('h1').text()).toContain('service-name');
+    expect($('section.govuk-tabs__panel').text()).toEqual('TEST');
+    expect($('ul li:first-of-type a').prop('href')).toEqual('__LINKS_TO__admin.organizations.spaces.services.view');
+    expect($('ul li:first-of-type').hasClass('govuk-tabs__list-item--selected')).toBe(true);
+    expect($('ul li:last-of-type a').prop('href')).not.toEqual('__LINKS_TO__admin.organizations.spaces.services.logs.view');
+    expect($('ul li:last-of-type').hasClass('govuk-tabs__list-item--selected')).toBe(false);
   });
 });
 

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -48,6 +48,8 @@ interface IFileListingItemProperties {
   readonly size: number;
 }
 
+export const servicesWithLogs = ['postgres', 'mysql'];
+
 export function Tab(props: ITabProperties): ReactElement {
   const classess = ['govuk-tabs__list-item'];
   if (props.active) {
@@ -117,21 +119,24 @@ export function ServiceTab(props: IServiceTabProperties): ReactElement {
           >
             Events
           </Tab>
-          <Tab
-            active={props.routePartOf(
-              'admin.organizations.spaces.services.logs.view',
-            )}
-            href={props.linkTo(
-              'admin.organizations.spaces.services.logs.view',
-              {
-                organizationGUID: props.organizationGUID,
-                serviceGUID: props.service.metadata.guid,
-                spaceGUID: props.spaceGUID,
-              },
-            )}
-          >
-            Logs
-          </Tab>
+          {servicesWithLogs.includes(props.service.service?.entity.label || 'not-supported') ?
+            <Tab
+              active={props.routePartOf(
+                'admin.organizations.spaces.services.logs.view',
+              )}
+              href={props.linkTo(
+                'admin.organizations.spaces.services.logs.view',
+                {
+                  organizationGUID: props.organizationGUID,
+                  serviceGUID: props.service.metadata.guid,
+                  spaceGUID: props.spaceGUID,
+                },
+              )}
+            >
+              Logs
+            </Tab> :
+            <></>
+          }
         </ul>
 
         <section className="govuk-tabs__panel">{props.children}</section>


### PR DESCRIPTION
What
----

At the moment, all of the services get the logs tab. If the service
doesn't support logs, the tab will simply redirect into a 404 page.

This isn't great user experience.

What we're doing here, is essentially checking if the service is one of
the supported ones, and simply attempt to not display the tab for the
user if it's not supported.

How to review
-------------

- Deploy to your devenv
- Attempt to retrieve logs for postgres/mysql service and any other service
- Expect no 404 behaviours