### PR TITLE
Introduce quota management

### DIFF
--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -36,6 +36,17 @@ export const router = new Router([
     path: '/organisations/:organizationGUID',
   },
   {
+    action: organizations.editOrgQuota,
+    name: 'admin.organizations.quota.edit',
+    path: '/organisations/:organizationGUID/quota',
+  },
+  {
+    action: organizations.updateOrgQuota,
+    method: 'post',
+    name: 'admin.organizations.quota.update',
+    path: '/organisations/:organizationGUID/quota',
+  },
+  {
     action: spaces.listApplications,
     name: 'admin.organizations.spaces.applications.list',
     path: '/organisations/:organizationGUID/spaces/:spaceGUID/applications',

--- a/src/components/organizations/controllers.tsx
+++ b/src/components/organizations/controllers.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Template } from '../../layouts';
 import CloudFoundryClient from '../../lib/cf';
 import { IOrganization } from '../../lib/cf/types';
-import { IParameters, IResponse } from '../../lib/router';
+import { IParameters, IResponse, NotAuthorisedError } from '../../lib/router';
 import { IContext } from '../app/context';
 
 import { OrganizationsPage, EditOrganizationQuota } from './views';
@@ -58,6 +58,10 @@ export async function listOrganizations(
 }
 
 export async function editOrgQuota(ctx: IContext, params: IParameters): Promise<IResponse> {
+  if (!ctx.token.hasAdminScopes()) {
+    throw new NotAuthorisedError('Not a platform admin');
+  }
+
   const cf = new CloudFoundryClient({
     accessToken: ctx.token.accessToken,
     apiEndpoint: ctx.app.cloudFoundryAPI,
@@ -91,6 +95,10 @@ export async function editOrgQuota(ctx: IContext, params: IParameters): Promise<
 }
 
 export async function updateOrgQuota(ctx: IContext, params: IParameters, body: IUpdateOrgQuotaBody): Promise<IResponse> {
+  if (!ctx.token.hasAdminScopes()) {
+    throw new NotAuthorisedError('Not a platform admin');
+  }
+
   const cf = new CloudFoundryClient({
     accessToken: ctx.token.accessToken,
     apiEndpoint: ctx.app.cloudFoundryAPI,

--- a/src/components/organizations/controllers.tsx
+++ b/src/components/organizations/controllers.tsx
@@ -7,7 +7,12 @@ import { IOrganization } from '../../lib/cf/types';
 import { IParameters, IResponse } from '../../lib/router';
 import { IContext } from '../app/context';
 
-import { OrganizationsPage } from './views';
+import { OrganizationsPage, EditOrganizationQuota } from './views';
+import { SuccessPage } from '../shared';
+
+interface IUpdateOrgQuotaBody {
+  readonly quota: string;
+}
 
 function sortOrganizationsByName(
   organizations: ReadonlyArray<IOrganization>,
@@ -49,5 +54,70 @@ export async function listOrganizations(
         quotas={orgQuotasByGUID}
       />,
     ),
+  };
+}
+
+export async function editOrgQuota(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const [organization, quotas] = await Promise.all([
+    cf.organization(params.organizationGUID),
+    cf.organizationQuotas(),
+  ]);
+
+  const realQuotas = quotas.filter(quota => !quota.name.match(/^(CATS|ACC|BACC|SMOKE|PERF|AIVENBACC)-/));
+  const template = new Template(ctx.viewContext, `Organisation ${organization.entity.name}`);
+
+  template.breadcrumbs = [
+    { href: ctx.linkTo('admin.organizations'), text: 'Organisations' },
+    {
+      href: ctx.linkTo('admin.organizations.view', { organizationGUID: organization.metadata.guid }),
+      text: organization.entity.name,
+    },
+    { text: 'Manage Quota' },
+  ];
+
+  return {
+    body: template.render(<EditOrganizationQuota
+      organization={organization}
+      quotas={realQuotas.sort((qA, qB) => qA.apps.total_memory_in_mb - qB.apps.total_memory_in_mb)}
+      csrf={ctx.viewContext.csrf}
+    />),
+  };
+}
+
+export async function updateOrgQuota(ctx: IContext, params: IParameters, body: IUpdateOrgQuotaBody): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const organization = await cf.organization(params.organizationGUID);
+
+  await cf.applyOrganizationQuota(body.quota, params.organizationGUID);
+
+  const template = new Template(ctx.viewContext, `Quota successfully set`);
+
+  template.breadcrumbs = [
+    { href: ctx.linkTo('admin.organizations'), text: 'Organisations' },
+    {
+      href: ctx.linkTo('admin.organizations.view', { organizationGUID: organization.metadata.guid }),
+      text: organization.entity.name,
+    },
+    {
+      href: ctx.linkTo('admin.organizations.quota.edit', { organizationGUID: organization.metadata.guid }),
+      text: 'Manage Quota',
+    },
+  ];
+
+  return {
+    body: template.render(<SuccessPage
+      heading="Quota successfully set"
+    />),
   };
 }

--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { IOrganization, IOrganizationQuota } from '../../lib/cf/types';
+import { IOrganization, IOrganizationQuota, IV3OrganizationQuota } from '../../lib/cf/types';
 import { RouteLinker } from '../app';
 
 interface IOrganizationProperties {
@@ -14,6 +14,12 @@ interface IOrganizationPageProperties {
   readonly organizations: ReadonlyArray<IOrganization>;
   readonly linkTo: RouteLinker;
   readonly quotas: { readonly [guid: string]: IOrganizationQuota };
+}
+
+interface IEditOrganizationQuotaProperties {
+  readonly csrf: string;
+  readonly organization: IOrganization;
+  readonly quotas: ReadonlyArray<IV3OrganizationQuota>;
 }
 
 export function Organization(props: IOrganizationProperties): ReactElement {
@@ -244,4 +250,65 @@ export function OrganizationsPage(
       </div>
     </>
   );
+}
+
+export function EditOrganizationQuota(props: IEditOrganizationQuotaProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-full">
+      <h1 className="govuk-heading-l">
+        <span className="govuk-caption-l">Organisation</span>{' '}
+        {props.organization.entity.name}
+      </h1>
+    </div>
+
+    <div className="govuk-grid-column-one-half">
+      <form method="post">
+        <input type="hidden" name="_csrf" value={props.csrf} />
+
+        <div className="govuk-form-group">
+          <label className="govuk-label" htmlFor="quota">
+            Quota
+          </label>
+          <span id="quota-hint" className="govuk-hint">
+            The <code>default</code> quota represents a trial account for specific organisation and will not be billed
+            for.
+          </span>
+          <select className="govuk-select" id="quota" name="quota">
+            {props.quotas.map(quota => <option
+              key={quota.guid}
+              selected={props.organization.entity.quota_definition_guid === quota.guid}
+              value={quota.guid}>
+                {quota.name}
+              </option>)}
+          </select>
+        </div>
+
+        <button className="govuk-button" data-module="govuk-button" data-prevent-double-click="true">
+          Set Organisation Quota
+        </button>
+      </form>
+    </div>
+
+    <div className="govuk-grid-column-one-half">
+      <table className="govuk-table">
+        <caption className="govuk-table__caption">Existing quotas</caption>
+        <thead className="govuk-table__head">
+          <tr className="govuk-table__row">
+            <th scope="col" className="govuk-table__header">Name</th>
+            <th scope="col" className="govuk-table__header">Memory</th>
+            <th scope="col" className="govuk-table__header">Routes</th>
+            <th scope="col" className="govuk-table__header">Services</th>
+          </tr>
+        </thead>
+        <tbody className="govuk-table__body">
+          {props.quotas.map(quota => <tr className="govuk-table__row" key={quota.guid}>
+            <th scope="row" className="govuk-table__header">{quota.name}</th>
+            <td className="govuk-table__cell">{quota.apps.total_memory_in_mb}</td>
+            <td className="govuk-table__cell">{quota.routes.total_routes}</td>
+            <td className="govuk-table__cell">{quota.services.total_service_instances}</td>
+          </tr>)}
+        </tbody>
+      </table>
+    </div>
+  </div>;
 }

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './success-page';

--- a/src/components/shared/success-page.test.tsx
+++ b/src/components/shared/success-page.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SuccessPage } from './success-page';
+import { shallow } from 'enzyme';
+
+describe(SuccessPage, () => {
+  it('should parse simple SuccessPage', () => {
+    const markup = shallow(<SuccessPage heading="Success!" />);
+
+    expect(markup.find('h1').text()).toEqual('Success!');
+  });
+
+  it('should parse rich SuccessPage', () => {
+    const markup = shallow(<SuccessPage heading="Success!" text="You have passed the test.">
+      <p>Read more elsewhere!</p>
+      <a href="#">Elsewhere</a>
+    </SuccessPage>);
+
+    expect(markup.find('h1').text()).toEqual('Success!');
+    expect(markup.render().find('div.govuk-panel__body').text()).toEqual('You have passed the test.');
+    expect(markup.render().find('a').text()).toEqual('Elsewhere');
+  });
+});

--- a/src/components/shared/success-page.tsx
+++ b/src/components/shared/success-page.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement, ReactNode } from 'react';
+
+interface ISuccessPageProperties {
+  readonly heading: string;
+  readonly text?: string;
+  readonly children?: ReactNode;
+}
+
+export function SuccessPage(props: ISuccessPageProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-two-thirds">
+      <div className="govuk-panel govuk-panel--confirmation">
+        <h1 className="govuk-panel__title">{props.heading}</h1>
+        {props.text ? <div className="govuk-panel__body">{props.text}</div> : <></>}
+      </div>
+      {props.children ? <p className="govuk-body">{props.children}</p> : <></>}
+    </div>
+  </div>;
+}

--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -397,7 +397,7 @@ describe(SpacesPage, () => {
     const markup = shallow(
       <SpacesPage
         linkTo={route => `__LINKS_TO__${route}`}
-        isAdmin={false}
+        isAdmin={true}
         isManager={true}
         isBillingManager={false}
         organization={organization}
@@ -407,6 +407,7 @@ describe(SpacesPage, () => {
     );
     const $ = cheerio.load(markup.html());
     expect($('table tbody tr')).toHaveLength(1);
+    expect($('p').text()).toContain('Manage quota for this organization');
     expect($('p').text()).toContain(
       `There is 1 space in ${organization.entity.name}.`,
     );

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -202,6 +202,15 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
             .
           </p>
 
+          {props.isAdmin ? <p className="govuk-body">
+            <a
+              href={props.linkTo('admin.organizations.quota.edit', { organizationGUID: props.organization.metadata.guid })}
+              className="govuk-link"
+            >
+              Manage quota for this organization
+            </a>
+          </p> : <></>}
+
           <p className="govuk-body">
             <a
               href="https://docs.cloud.service.gov.uk/managing_apps.html#quotas"

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -261,6 +261,20 @@ export default class CloudFoundryClient {
     return response.data;
   }
 
+  public async organizationQuotas(): Promise<ReadonlyArray<cf.IV3OrganizationQuota>> {
+    const response = await this.request('get', '/v3/organization_quotas');
+
+    return await this.allV3Resources(response);
+  }
+
+  public async applyOrganizationQuota(quotaGUID: string, ...organizationGUIDs: ReadonlyArray<string>): Promise<object> {
+    const response = await this.request('post', `/v3/organization_quotas/${quotaGUID}/relationships/organizations`, {
+      data: organizationGUIDs.map(guid => ({ guid })),
+    });
+
+    return response.data;
+  }
+
   public async v3CreateSpace(spaceRequest: cf.IV3SpaceRequest): Promise<cf.IV3SpaceResource> {
     const response = await this.request(
       'post',

--- a/src/lib/cf/types.ts
+++ b/src/lib/cf/types.ts
@@ -252,6 +252,34 @@ export interface IOrganizationQuota {
   readonly metadata: IMetadata;
 }
 
+export interface IV3OrganizationQuota {
+  readonly guid: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+  readonly name: string;
+  readonly links: {
+    readonly self: IV3Link;
+  };
+  readonly apps: {
+    readonly per_process_memory_in_mb: number;
+    readonly total_memory_in_mb: number;
+    readonly total_instances: number;
+    readonly per_app_tasks: number;
+  };
+  readonly domains: {
+    readonly total_domains: number;
+  };
+  readonly routes: {
+    readonly total_routes: number;
+    readonly total_reserved_ports: number;
+  };
+  readonly services: {
+    readonly paid_services_allowed: number;
+    readonly total_service_instances: number;
+    readonly total_service_keys: number;
+  };
+}
+
 export interface IOrganizationUserRoles {
   readonly entity: {
     readonly active: boolean;


### PR DESCRIPTION
What
----

Personally I find it difficult to figure out which region does the
organisation belong to, by first logging in to possibly two pazmins, and
then the CLI, figure out what does the quota offer and set it for the
user before informing them of what has been done to their org.

This should reduce the amount of actions I need to perform each time and
help me move on with my life without distractions.

Probably useless to the rest of the team.

How to review
-------------

- Deploy to your environment (or see tlwr)
- Navigate to an organisation
- As an operator find the `Manage quota for this organization`
- Attempt to change the quota