### PR TITLE
Fix details component implementation

### DIFF
--- a/src/components/calculator/views.tsx
+++ b/src/components/calculator/views.tsx
@@ -339,7 +339,7 @@ export function CalculatorPage(props: ICalculatorPageProperties): ReactElement {
           </p>
           <p className="paas-month">per month</p>
 
-          <details className="govuk-details" role="group">
+          <details className="govuk-details" data-module="govuk-details">
             <summary className="govuk-details__summary">
               <span className="govuk-details__summary-text">
                 Why costs may vary

--- a/src/components/events/views.tsx
+++ b/src/components/events/views.tsx
@@ -35,7 +35,7 @@ interface ITargetedEventListItemProperties extends IEventListItemProperties {
 
 export function Details(): ReactElement {
   return (
-    <details className="govuk-details" role="group">
+    <details className="govuk-details" data-module="govuk-details">
       <summary
         className="govuk-details__summary"
         role="button"

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -143,7 +143,7 @@ export function PermissionBlock(
       <h2 className="govuk-heading-m">Set organisation and space roles</h2>
       <h3 className="govuk-heading-s">Organisation level roles</h3>
 
-      <details className="govuk-details" role="group">
+      <details className="govuk-details"  data-module="govuk-details">
         <summary
           className="govuk-details__summary"
           role="button"
@@ -243,18 +243,13 @@ export function PermissionBlock(
 
       <h3 className="govuk-heading-s">Space level roles</h3>
 
-      <details className="govuk-details" role="group">
-        <summary
-          className="govuk-details__summary"
-          role="button"
-          aria-controls="details-content-0"
-          aria-expanded="false"
-        >
+      <details className="govuk-details"  data-module="govuk-details">
+        <summary className="govuk-details__summary">
           <span className="govuk-details__summary-text">
             What can these roles do?
           </span>
         </summary>
-        <div className="govuk-details__text" aria-hidden="true">
+        <div className="govuk-details__text">
           <p className="govuk-body">
             <span className="govuk-!-font-weight-bold">Space managers</span> can
             grant user roles within the space, and change properties of the
@@ -633,44 +628,39 @@ export function OrganizationUsersPage(
               )
             }
             <div className="govuk-grid-column-two-thirds">
-              <details className="govuk-details" role="group">
-            <summary
-              className="govuk-details__summary"
-              role="button"
-              aria-controls="details-content-0"
-              aria-expanded="false"
-            >
-              <span className="govuk-details__summary-text">
-                What can these roles do?
-              </span>
-            </summary>
+              <details className="govuk-details" data-module="govuk-details">
+                <summary className="govuk-details__summary">
+                  <span className="govuk-details__summary-text">
+                    What can these roles do?
+                  </span>
+                </summary>
 
-            <div className="govuk-details__text" aria-hidden="true">
-              <p className="govuk-body">
-                <span className="govuk-!-font-weight-bold">Org managers</span>{' '}
-                are users who can create and delete spaces within an org, and
-                administer user roles, both within the org and its spaces. We
-                recommend to have at least two org managers.
-              </p>
+                <div className="govuk-details__text">
+                  <p className="govuk-body">
+                    <span className="govuk-!-font-weight-bold">Org managers</span>{' '}
+                    are users who can create and delete spaces within an org, and
+                    administer user roles, both within the org and its spaces. We
+                    recommend to have at least two org managers.
+                  </p>
 
-              <p className="govuk-body">
-                <span className="govuk-!-font-weight-bold">Org auditors</span>{' '}
-                are users who can view quota allocation and user roles across
-                the org. Auditors can&apos;t change any of these configurations.
-              </p>
+                  <p className="govuk-body">
+                    <span className="govuk-!-font-weight-bold">Org auditors</span>{' '}
+                    are users who can view quota allocation and user roles across
+                    the org. Auditors can&apos;t change any of these configurations.
+                  </p>
 
-              <p className="govuk-body">
-                <span className="govuk-!-font-weight-bold">
-                  Org billing managers
-                </span>{' '}
-                are users who can see billing, costs and quota information.
-              </p>
+                  <p className="govuk-body">
+                    <span className="govuk-!-font-weight-bold">
+                      Org billing managers
+                    </span>{' '}
+                    are users who can see billing, costs and quota information.
+                  </p>
 
-              <p className="govuk-body">
-                Tasks related to spaces are associated with space-level roles.
-              </p>
-            </div>
-          </details>
+                  <p className="govuk-body">
+                    Tasks related to spaces are associated with space-level roles.
+                  </p>
+                </div>
+              </details>
             </div>
           </div>
           <h2 className="govuk-heading-m">Current team members</h2>

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -258,7 +258,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
         <></>
       )}
 
-      <details className="govuk-details" data-module="govuk-details" role="group">
+      <details className="govuk-details" data-module="govuk-details">
         <summary className="govuk-details__summary">
           <span className="govuk-details__summary-text">
             Change time period

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -288,17 +288,12 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
         {props.organization.entity.name}.
       </p>
 
-      <details className="govuk-details" role="group">
-        <summary
-          className="govuk-details__summary"
-          role="button"
-          aria-controls="details-content-0"
-          aria-expanded="false"
-        >
+      <details className="govuk-details"  data-module="govuk-details">
+        <summary className="govuk-details__summary">
           <span className="govuk-details__summary-text">What are spaces?</span>
         </summary>
 
-        <div className="govuk-details__text" aria-hidden="true">
+        <div className="govuk-details__text">
           <p>
             Each organisation contains one or more spaces, which are used to
             organise app development, deployment, and maintenance. Organisation


### PR DESCRIPTION
What
----

There were two things to fix:
- add a hook to JS so that it works in IE11
- remove hardcoded aria- attributes on some, that are only added for
IE11 with JS and are not needed to browser that support it.

This was causing an issue for screenreader users in DAC audit.

This now [follows the Design System implementation](https://design-system.service.gov.uk/components/details/)

Fixes:
- https://www.pivotaltracker.com/n/projects/1275640/stories/174315347
- https://www.pivotaltracker.com/n/projects/1275640/stories/174333654

How to review
-------------

- check out branch, run locally
- go to organisations page
- view source for "what are spaces" element
- check there are no aria attributes

Who can review
---------------

not @kr8n3r 

Changes
----

**Before**
<img width="832" alt="before" src="https://user-images.githubusercontent.com/3758555/90227023-d3f0c680-de0b-11ea-854a-5fcde6f651dd.png">

**After**
<img width="461" alt="after" src="https://user-images.githubusercontent.com/3758555/90227276-30ec7c80-de0c-11ea-84f5-19c870203195.png">

**details in IE11 is now collapsed**
<img width="1238" alt="ie11" src="https://user-images.githubusercontent.com/3758555/90227323-45c91000-de0c-11ea-864c-3103db58013a.png">
