### PR TITLE
Fix pazmin request an account additional users checkbox labels

### DIFF
--- a/src/components/support/views.tsx
+++ b/src/components/support/views.tsx
@@ -1655,7 +1655,7 @@ export function SignUpPage(props: ISignupFormProperties): ReactElement {
                                     defaultChecked={props.values?.additional_users && props.values!.additional_users[0].person_is_manager === 'yes'}
                                   />
                                   <label className="govuk-label govuk-checkboxes__label" htmlFor="additional_users-0-is-manager">
-                                    <span className="govuk-visually-hidden">Assign org manager role?</span>
+                                    <span className="govuk-visually-hidden">Assign org manager role to User 1?</span>
                                   </label>
                                 </div>
                               </div>
@@ -1708,7 +1708,7 @@ export function SignUpPage(props: ISignupFormProperties): ReactElement {
                                 defaultChecked={props.values?.additional_users && props.values!.additional_users[1].person_is_manager === 'yes'}
                               />
                               <label className="govuk-label govuk-checkboxes__label" htmlFor="additional_users-1-is-manager">
-                                <span className="govuk-visually-hidden">Assign org manager role?</span>
+                                <span className="govuk-visually-hidden">Assign org manager role to User 2?</span>
                               </label>
                             </div>
                           </div>
@@ -1761,7 +1761,7 @@ export function SignUpPage(props: ISignupFormProperties): ReactElement {
                                 defaultChecked={props.values?.additional_users && props.values!.additional_users[2].person_is_manager === 'yes'}
                               />
                               <label className="govuk-label govuk-checkboxes__label" htmlFor="additional_users-2-is-manager">
-                                <span className="govuk-visually-hidden">Assign org manager role?</span>
+                                <span className="govuk-visually-hidden">Assign org manager role to User 3?</span>
                               </label>
                             </div>
                           </div>

--- a/src/components/support/views.tsx
+++ b/src/components/support/views.tsx
@@ -1648,13 +1648,13 @@ export function SignUpPage(props: ISignupFormProperties): ReactElement {
                               <div className="govuk-checkboxes">
                                 <div className="govuk-checkboxes__item">
                                   <input className="govuk-checkboxes__input"
-                                    id="additional_users-is-manager"
+                                    id="additional_users-0-is-manager"
                                     name="additional_users[0][person_is_manager]"
                                     type="checkbox"
                                     value="yes"
                                     defaultChecked={props.values?.additional_users && props.values!.additional_users[0].person_is_manager === 'yes'}
                                   />
-                                  <label className="govuk-label govuk-checkboxes__label" htmlFor="additional_users-1">
+                                  <label className="govuk-label govuk-checkboxes__label" htmlFor="additional_users-0-is-manager">
                                     <span className="govuk-visually-hidden">Assign org manager role?</span>
                                   </label>
                                 </div>


### PR DESCRIPTION
What
----

- Match label with input ID
First additional user "Org manager?" checkbox label and input were not matched, so the label wasn't read to screenreader users.

- More descriptive Org manager checkbox labels
The multiple generic ‘Assign org manager role?’ checkboxes are not descriptive enough for screen reader users to determine their function or purpose when navigating out of context.
Ensure that all form elements are uniquely descriptive of their purpose. For example, screen reader users would expect the checkbox labels to uniquely reference the email address it relates to:
**Assign org manager role to User 2?**

Fixes
- https://www.pivotaltracker.com/n/projects/1275640/stories/174299982
- https://www.pivotaltracker.com/n/projects/1275640/stories/174313772

How to review
-------------

- checkout branch, run locally
- go to support -> request an account
- check additional users Org manager checkbox labels have more descriptive label text and `for` attribute value matches the input ID value

Who can review
---------------

not @kr8n3r 
