### PR TITLE
Fix logical heading order on pages

### DIFF
--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -101,16 +101,16 @@ export function OrganizationsPage(
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <h1 className="govuk-heading-l">Get started with the command line</h1>
+          <h2 className="govuk-heading-l">Get started with the command line</h2>
 
           <p className="govuk-body">
             Installing the Cloud Foundry command line will let you operate
             GOV.UK PaaS from your computer terminal.
           </p>
 
-          <h2 className="govuk-heading-m">
+          <h3 className="govuk-heading-m">
             Download the Cloud Foundry command line tool
-          </h2>
+          </h3>
         </div>
 
         <div className="govuk-grid-column-one-third">
@@ -170,11 +170,11 @@ export function OrganizationsPage(
         .
       </p>
 
-      <h1 className="govuk-heading-l">Once you’ve installed the CF CLI</h1>
+      <h2 className="govuk-heading-l">Once you’ve installed the CF CLI</h2>
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-half">
-          <h2 className="govuk-heading-m">Set up and deploy your first app</h2>
+          <h3 className="govuk-heading-m">Set up and deploy your first app</h3>
 
           <p className="govuk-body">
             <a
@@ -188,7 +188,7 @@ export function OrganizationsPage(
         </div>
 
         <div className="govuk-grid-column-one-half">
-          <h2 className="govuk-heading-m">Learn more about orgs and spaces</h2>
+          <h3 className="govuk-heading-m">Learn more about orgs and spaces</h3>
 
           <p className="govuk-body">
             <a
@@ -203,11 +203,11 @@ export function OrganizationsPage(
         </div>
       </div>
 
-      <h1 className="govuk-heading-l">Stay up to date</h1>
+      <h2 className="govuk-heading-l">Stay up to date</h2>
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-half">
-          <h2 className="govuk-heading-m">Get GOV.UK PaaS status updates</h2>
+          <h3 className="govuk-heading-m">Get GOV.UK PaaS status updates</h3>
 
           <p className="govuk-body">
             <a
@@ -227,11 +227,11 @@ export function OrganizationsPage(
         </div>
       </div>
 
-      <h1 className="govuk-heading-l">Increase the security of your account</h1>
+      <h2 className="govuk-heading-l">Increase the security of your account</h2>
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-half">
-          <h2 className="govuk-heading-m">Set up Google single sign-on</h2>
+          <h3 className="govuk-heading-m">Set up Google single sign-on</h3>
 
           <p className="govuk-body">
             GOV.UK PaaS supports Google single sign-on as an authentication

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -131,9 +131,9 @@ function Metric(props: IMetricProperties): ReactElement {
   return (
     <div className="govuk-grid-row govuk-!-padding-bottom-9">
       <div className="govuk-grid-column-full">
-        <h3 className="govuk-heading-m" id={props.id}>
+        <h2 className="govuk-heading-m" id={props.id}>
           {props.title}
-        </h3>
+        </h2>
       </div>
 
       <div className="govuk-grid-column-two-thirds-from-desktop">
@@ -307,7 +307,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
         >
           <input type="hidden" name="_csrf" value={props.csrf} />
 
-          <h3 className="govuk-heading-s">Or provide custom date</h3>
+          <h2 className="govuk-heading-s">Or provide custom date <span className="govuk-visually-hidden">for showing metrics</span></h2>
           <div className="govuk-form-group">
             <label className="govuk-label" htmlFor="rangeStart">
               Start time

--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -283,7 +283,7 @@ export function SubNavigation(props: ISubNavigationProperties): ReactElement {
 export function CommandLineAlternative(props: ICommandLineAlternativeProperties): ReactElement {
   return (
     <>
-      <h4 className="govuk-heading-s">In the command line</h4>
+      <h2 className="govuk-heading-s">In the command line</h2>
 
       <p>
         You can also view this information in the Cloud Foundry command line interface by running:


### PR DESCRIPTION
What
----

- Fix heading structure on organisation page
The heading structure of the ‘Organisations’ page is not logical because multiple level-one headings are present.
This means that screen reader users may not be able to identify the structure and relation of content throughout the document.

- Change CommandLineAlternative heading to h2 …
As it stands where it appears, it should always be a H2.
Ideally we'd change this to pass the level when used on a page.

- Update heading levels on metrics page
Even though there is a visually hidden h2 on desktop viewports ("Contents on mobile tabs") but that doesn't make the order correct.
Changing h3 to h2 without changing their size fixes that problem

Fixes https://www.pivotaltracker.com/n/projects/1275640/stories/174314663

How to review
-------------

- checkout branch, run locally
- check Organisation page has logical heading structure
- check MarketPlace page has logical heading structure
- check MarketPlace service page has logical heading structure
- check Metrics page has logical heading structure


Who can review
---------------

not @kr8n3r 
