### PR TITLE
Fix SVG graph accessibility

### DIFF
--- a/src/components/charts/line-graph.test.ts
+++ b/src/components/charts/line-graph.test.ts
@@ -12,6 +12,24 @@ describe('line graphs', () => {
     expect(result.nodeName).toBe('svg');
   });
 
+  it('should render an a title id attribute whose value matches a spaceless defaultTitle', () => {
+    const result = drawLineGraph(defaultTitle, defaultUnits, defaultFormat, []);
+    const titleID = result.querySelector('title')?.getAttribute('id');
+    expect(titleID).toBe('sometitle');
+  });
+
+  it('should render an aria-labelledby attribute whose value that matches spaceless defaultTitle', () => {
+    const result = drawLineGraph(defaultTitle, defaultUnits, defaultFormat, []);
+    const ariaAttr = result.getAttribute('aria-labelledby');
+    expect(ariaAttr).toBe('sometitle');
+  });
+
+  it('should an SVG with a role of img', () => {
+    const result = drawLineGraph(defaultTitle, defaultUnits, defaultFormat, []);
+    const ariaAttr = result.getAttribute('role');
+    expect(ariaAttr).toBe('img');
+  });
+
   it('should render a single series as a path and not show a legend', () => {
     const series = [
       { date: new Date(2019, 1, 1), value: 58 },

--- a/src/components/charts/line-graph.ts
+++ b/src/components/charts/line-graph.ts
@@ -34,6 +34,7 @@ export function drawLineGraph(
   const { document } = window;
   const { body } = document;
 
+  const itemID = title.replace(/\s/g, '');
   const svg = select(body)
     .append('svg')
     .attr('class', 'govuk-paas-line-graph')
@@ -42,8 +43,8 @@ export function drawLineGraph(
       `${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`,
     )
     .attr('preserveAspectRatio', 'xMinYMin meet')
-    .attr('role', 'figure')
-    .attr('aria-labelledby', 'title');
+    .attr('role', 'img')
+    .attr('aria-labelledby', itemID);
 
   const xAxisExtent = extent(
     flatMap(series, s => s.metrics),
@@ -56,6 +57,7 @@ export function drawLineGraph(
 
   svg
     .append('title')
+    .attr('id', itemID)
     .text(
       `Line graph showing ${title} from ${start.format(
         dateFormat,


### PR DESCRIPTION
What
----

Ensure that the <title> relevant to the chart has an ID that is unique and that the aria-labelledby attribute refers to this ID. All IDs must be unique. 
Use the role of ‘img’ on the SVG to ensure that assistive technologies recognise the chart as an image.

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174333729

How to review
-------------

- checkout branch, run locally
- go to a service that has metrics
- pick a graph
- check that title id and aria-labelledby match 
- check another graph and make sure these values are different from the previous graph

Who can review
---------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
