### PR TITLE
Include file type in non-html links

### DIFF
--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -120,7 +120,7 @@ export function OrganizationsPage(
               href="https://packages.cloudfoundry.org/stable?release=redhat64&source=github"
               className="govuk-link"
             >
-              Download the RedHat version
+              Download the RedHat version <span className="govuk-visually-hidden">installer [RPM] file</span>
             </a>
           </p>
           <p className="govuk-body">
@@ -128,7 +128,7 @@ export function OrganizationsPage(
               href="https://packages.cloudfoundry.org/stable?release=debian64&source=github"
               className="govuk-link"
             >
-              Download the Debian version
+              Download the Debian version <span className="govuk-visually-hidden">installer [DEB] file</span>
             </a>
           </p>
         </div>
@@ -140,7 +140,7 @@ export function OrganizationsPage(
               href="https://packages.cloudfoundry.org/stable?release=macosx64&source=github"
               className="govuk-link"
             >
-              Download the macOS version
+              Download the macOS version <span className="govuk-visually-hidden">installer [PKG] file</span>
             </a>
           </p>
         </div>
@@ -152,7 +152,7 @@ export function OrganizationsPage(
               href="https://packages.cloudfoundry.org/stable?release=windows64&source=github"
               className="govuk-link"
             >
-              Download the Windows version
+              Download the Windows version <span className="govuk-visually-hidden">installer [ZIP] file</span>
             </a>
           </p>
         </div>

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -255,9 +255,10 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
                 organizationGUID: props.organizationGUID,
                 rangeStart: props.filterMonth,
               })}
-              className="govuk-link download"
+              className="govuk-link"
+              download
             >
-              Download a spreadsheet of these items
+              Download a spreadsheet of these items <span className="govuk-visually-hidden">as a comma-separated values [CSV] file</span>
             </a>
           </p>
         </div>


### PR DESCRIPTION
What
----

Ensure that when linking to non-HTML documents that the document type is identified.

This information needs to be included in the hyperlink so that it can be read in the screen reader’s link list.
We've included it as a visually hidden text that still gets read out to screenreader users.

We unfortunately do not know the file-size to include that as well.

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174300567

How to review
-------------

- checkout branch, run locally
- visit organisation page
- check "Download X version" contain a visually hidden text with package file
- visit organisation statements page
- check "Download a spreadsheet of these items" contains a visually hidden text with a file name

Who can review
---------------

not @kr8n3r 
