### PR TITLE
Fix non-descriptive links in context

### DIFF
--- a/src/components/org-users/views.test.tsx
+++ b/src/components/org-users/views.test.tsx
@@ -335,8 +335,8 @@ describe(OrganizationUsersPage, () => {
       />,
     );
     const $ = cheerio.load(markup.html());
-    expect($('td:first-of-type').text()).toContain('user-name');
-    expect($('td:first-of-type a').length).toEqual(0);
+    expect($('tbody th:first-of-type').text()).toContain('user-name');
+    expect($('tbody th:first-of-type a').length).toEqual(0);
     expect($('td').text()).not.toContain('Origin-name');
     expect($('td').text()).not.toContain('Password');
     expect($('li').text()).toContain(space.entity.name);
@@ -355,8 +355,8 @@ describe(OrganizationUsersPage, () => {
       />,
     );
     const $ = cheerio.load(markup.html());
-    expect($('td:first-of-type').text()).toContain('user-name');
-    expect($('td:first-of-type a').length).toEqual(2);
+    expect($('tbody th:first-of-type').text()).toContain('user-name');
+    expect($('tbody th:first-of-type a').length).toEqual(2);
     expect($('td').text()).toContain('Origin-name');
     expect($('td').text()).toContain('Password');
   });

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -691,7 +691,7 @@ export function OrganizationUsersPage(
             <tbody className="govuk-table__body">
               {Object.keys(props.users).map(guid => (
                 <tr key={guid} className="govuk-table__row">
-                  <td className="govuk-table__cell">
+                  <th scope="row" className="govuk-table__header govuk-table__header--non-bold">
                     {props.privileged ? (
                       <a
                         href={props.linkTo('admin.organizations.users.edit', {
@@ -705,7 +705,7 @@ export function OrganizationUsersPage(
                     ) : (
                       props.users[guid].username
                     )}
-                  </td>
+                  </th>
                   <td className="govuk-table__cell">
                     {props.privileged ? (
                       props.userOriginMapping[guid] === 'uaa' ? (

--- a/src/components/organizations/views.test.tsx
+++ b/src/components/organizations/views.test.tsx
@@ -42,16 +42,16 @@ describe(OrganizationsPage, () => {
     );
     expect($('table tbody tr')).toHaveLength(2);
 
-    expect($('table tbody tr:first-of-type a.govuk-link').text()).toBe('A');
-    expect($('table tbody tr:first-of-type a.govuk-link').prop('href')).toBe(
+    expect($('table tbody tr:first-of-type th a.govuk-link').text()).toBe('A');
+    expect($('table tbody tr:first-of-type th a.govuk-link').prop('href')).toBe(
       '/org/a',
     );
     expect($('table tbody tr:first-of-type td:last-of-type').text()).toBe(
       'Trial',
     );
 
-    expect($('table tr:last-of-type a.govuk-link').text()).toBe('B');
-    expect($('table tr:last-of-type a.govuk-link').prop('href')).toBe('/org/b');
+    expect($('table tr:last-of-type th a.govuk-link').text()).toBe('B');
+    expect($('table tr:last-of-type th a.govuk-link').prop('href')).toBe('/org/b');
     expect($('table tr:last-of-type td:last-of-type').text()).toBe('Billable');
   });
 

--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -25,7 +25,7 @@ interface IEditOrganizationQuotaProperties {
 export function Organization(props: IOrganizationProperties): ReactElement {
   return (
     <tr className="govuk-table__row">
-      <td className="govuk-table__cell">
+      <th scope="row" className="govuk-table__header govuk-table__header--non-bold">
         <a
           href={props.linkTo('admin.organizations.view', {
             organizationGUID: props.guid,
@@ -34,7 +34,7 @@ export function Organization(props: IOrganizationProperties): ReactElement {
         >
           {props.name}
         </a>
-      </td>
+      </th>
       <td className="govuk-table__cell">
         {props.billable ? 'Billable' : 'Trial'}
       </td>

--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -290,8 +290,8 @@ describe(BackingServicePage, () => {
     const $ = cheerio.load(markup.html());
     expect($('p').text()).toContain('This space contains 2 backing services');
     expect($('table tbody tr')).toHaveLength(2);
-    expect($('table tbody .name').text()).toContain(services[0].entity.name);
-    expect($('table tbody .name').text()).toContain(services[1].entity.name);
+    expect($('table tbody th.name').text()).toContain(services[0].entity.name);
+    expect($('table tbody th.name').text()).toContain(services[1].entity.name);
     expect($('table tbody .label').text()).toContain(
       services[0].definition.entity.label,
     );

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -338,7 +338,7 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
         <tbody className="govuk-table__body">
           {props.spaces.map(space => (
             <tr key={space.metadata.guid} className="govuk-table__row">
-              <td className="govuk-table__cell">
+              <th scope="row" className="govuk-table__header govuk-table__header--non-bold">
                 <a
                   href={props.linkTo(
                     'admin.organizations.spaces.applications.list',
@@ -351,7 +351,7 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
                 >
                   {space.entity.name}
                 </a>
-              </td>
+              </th>
               <td className="govuk-table__cell">
                 {help.bytesToHuman(space.memory_allocated * MEBIBYTE)} of{' '}
                 {space.quota
@@ -467,7 +467,7 @@ export function ApplicationsPage(
           <tbody className="govuk-table__body">
             {props.applications.map(application => (
               <tr key={application.metadata.guid} className="govuk-table__row">
-                <td className="govuk-table__cell">
+                <th scope="row" className="govuk-table__header govuk-table__header--non-bold">
                   <a
                     href={props.linkTo(
                       'admin.organizations.spaces.applications.view',
@@ -481,7 +481,7 @@ export function ApplicationsPage(
                   >
                     {application.entity.name}
                   </a>
-                </td>
+                </th>
                 <td
                   className="govuk-table__cell"
                   title={`${application.summary.running_instances} running / ${application.summary.instances} desired`}
@@ -565,7 +565,7 @@ export function BackingServicePage(
           <tbody className="govuk-table__body">
             {props.services.map(service => (
               <tr key={service.metadata.guid} className="govuk-table__row">
-                <td className="govuk-table__cell name">
+                <th scope="row" className="govuk-table__header govuk-table__header--non-bold name">
                   <a
                     href={props.linkTo(
                       'admin.organizations.spaces.services.view',
@@ -579,7 +579,7 @@ export function BackingServicePage(
                   >
                     {service.entity.name}
                   </a>
-                </td>
+                </th>
                 <td className="govuk-table__cell label">
                   {service.definition?.entity.label || 'User Provided Service'}
                 </td>

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -85,3 +85,10 @@ abbr {
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
 }
+
+// tables where first cell is the row header come
+// embolden from govuk-frontend. For large, text-heavy tables
+// that's useful, but for an admin interface not necessary
+.govuk-table__header--non-bold {
+  font-weight: 400;
+}


### PR DESCRIPTION
What
----

Mark-up first cell in row as table row headings to help screen reader users determine the relationship of data within the table when navigating in context for places where cells contain links, lik users, organisations, spaces, applications...

Fixes part of https://www.pivotaltracker.com/n/projects/1275640/stories/174312848 
The other part was https://github.com/alphagov/paas-admin/pull/1007

How to review
-------------

- checkout branch, run locally
- visit org, spaces, applications and back service tables
- check that the first cell in a `th` not `td` and has a `scope="row"` attribute

Who can review
---------------

not @kr8n3r 