### PR TITLE
Update link text to make sense out of context

### DIFF
--- a/src/components/applications/views.tsx
+++ b/src/components/applications/views.tsx
@@ -112,7 +112,7 @@ export function AppLink(props: IAppLinkProperties): ReactElement {
   return (
     <>
       <a href={protocolOrEmpty + props.href} className="govuk-link">
-        {props.href}
+      <span className="govuk-visually-hidden">Application URL:</span>{' '} {props.href}
       </a>
       <br />
     </>

--- a/src/components/events/views.tsx
+++ b/src/components/events/views.tsx
@@ -142,7 +142,7 @@ export function EventListItem(props: IEventListItemProperties): ReactElement {
       <td className="govuk-table__cell description">{props.type}</td>
       <td className="govuk-table__cell details">
         <a className="govuk-link" href={props.href}>
-          Details
+          <span className="govuk-visually-hidden">Event</span> Details
         </a>
       </td>
     </tr>
@@ -162,7 +162,7 @@ export function TargetedEventListItem(
       <td className="govuk-table__cell description">{props.type}</td>
       <td className="govuk-table__cell details">
         <a className="govuk-link" href={props.href}>
-          Details
+          <span className="govuk-visually-hidden">Event</span> Details
         </a>
       </td>
     </tr>

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -700,7 +700,7 @@ export function OrganizationUsersPage(
                         })}
                         className="govuk-link"
                       >
-                        {props.users[guid].username}
+                        <span className="govuk-visually-hidden">user email address:</span> {props.users[guid].username}
                       </a>
                     ) : (
                       props.users[guid].username
@@ -716,7 +716,7 @@ export function OrganizationUsersPage(
                           })}
                           className="govuk-link"
                         >
-                          Password
+                          <span className="govuk-visually-hidden">Authentication method:</span> Password
                         </a>
                       ) : (
                         capitalize(props.userOriginMapping[guid])
@@ -760,7 +760,7 @@ export function OrganizationUsersPage(
                             )}
                             className="govuk-link"
                           >
-                            {space.entity.name}
+                            <span className="govuk-visually-hidden">Space assigned or can access:</span> {space.entity.name}
                           </a>
                         </li>
                       ))}

--- a/src/components/organizations/views.test.tsx
+++ b/src/components/organizations/views.test.tsx
@@ -42,7 +42,7 @@ describe(OrganizationsPage, () => {
     );
     expect($('table tbody tr')).toHaveLength(2);
 
-    expect($('table tbody tr:first-of-type th a.govuk-link').text()).toBe('A');
+    expect($('table tbody tr:first-of-type th a.govuk-link').text()).toBe('Organisation name: A');
     expect($('table tbody tr:first-of-type th a.govuk-link').prop('href')).toBe(
       '/org/a',
     );
@@ -50,7 +50,7 @@ describe(OrganizationsPage, () => {
       'Trial',
     );
 
-    expect($('table tr:last-of-type th a.govuk-link').text()).toBe('B');
+    expect($('table tr:last-of-type th a.govuk-link').text()).toBe('Organisation name: B');
     expect($('table tr:last-of-type th a.govuk-link').prop('href')).toBe('/org/b');
     expect($('table tr:last-of-type td:last-of-type').text()).toBe('Billable');
   });

--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -32,7 +32,7 @@ export function Organization(props: IOrganizationProperties): ReactElement {
           })}
           className="govuk-link"
         >
-          {props.name}
+          <span className="govuk-visually-hidden">Organisation name:</span> {props.name}
         </a>
       </th>
       <td className="govuk-table__cell">
@@ -89,7 +89,7 @@ export function OrganizationsPage(
       <p className="govuk-body">
         To request new GOV.UK PaaS organisations,{' '}
         <a
-          href="https://www.cloud.service.gov.uk/signup"
+          href="/support/sign-up"
           className="govuk-link"
         >
           visit our signup page
@@ -165,7 +165,7 @@ export function OrganizationsPage(
           href="https://github.com/cloudfoundry/cli#downloads"
           className="govuk-link"
         >
-          visit the GitHub page
+          visit the <span className="govuk-visually-hidden">Cloud Foundry</span> GitHub page
         </a>
         .
       </p>
@@ -181,9 +181,9 @@ export function OrganizationsPage(
               href="https://docs.cloud.service.gov.uk/get_started.html#set-up-the-cloud-foundry-command-line"
               className="govuk-link"
             >
-              View our guide
+              View our guide on logging in and deploying your first app
             </a>{' '}
-            on logging in and deploying your first app to GOV.UK PaaS.
+            to GOV.UK PaaS.
           </p>
         </div>
 
@@ -195,10 +195,9 @@ export function OrganizationsPage(
               href="https://docs.cloud.service.gov.uk/orgs_spaces_users.html"
               className="govuk-link"
             >
-              Get familiar
-            </a>{' '}
-            with the basic concepts of Cloud Foundry-based platforms, and what
-            setting up environments looks like.
+              Get familiar with the basic concepts of Cloud Foundry-based platforms
+            </a>,{' '}
+            and what setting up environments looks like.
           </p>
         </div>
       </div>
@@ -214,9 +213,9 @@ export function OrganizationsPage(
               href="https://status.cloud.service.gov.uk/"
               className="govuk-link"
             >
-              Check the status
+              Check the status of GOV.UK PaaS
             </a>{' '}
-            of GOV.UK PaaS, and see the availability of live applications and
+            , and see the availability of live applications and
             database connectivity.
           </p>
 

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -228,7 +228,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
           })}
           className="govuk-link non-breaking"
         >
-          {props.service.entity.name}
+          <span className="govuk-visually-hidden">Service name:</span> {props.service.entity.name}
         </a>{' '}
         between <br />
         <strong>{moment(props.rangeStart).format(DATE_TIME)}</strong>
@@ -286,9 +286,8 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                   },
                 )}
                 className="govuk-link"
-                title={`last ${last.long}`}
               >
-                Last {last.long}
+                <span className="govuk-visually-hidden">Change time period to:</span> Last {last.long}
               </a>
             </li>
           ))}
@@ -404,7 +403,7 @@ export function MetricPage(props: IMetricPageProperties): ReactElement {
               {props.metrics.map(metric => (
                 <li key={metric.id}>
                   <a href={`#${metric.id}`} className="govuk-link">
-                    {metric.title}
+                    {metric.title} <span className="govuk-visually-hidden">metric</span>
                   </a>
                 </li>
               ))}

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -349,7 +349,7 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
                   )}
                   className="govuk-link"
                 >
-                  {space.entity.name}
+                  <span className="govuk-visually-hidden">Space name:</span> {space.entity.name}
                 </a>
               </th>
               <td className="govuk-table__cell">
@@ -479,7 +479,7 @@ export function ApplicationsPage(
                     )}
                     className="govuk-link"
                   >
-                    {application.entity.name}
+                    <span className="govuk-visually-hidden">Application name:</span> {application.entity.name}
                   </a>
                 </th>
                 <td
@@ -577,7 +577,7 @@ export function BackingServicePage(
                     )}
                     className="govuk-link"
                   >
-                    {service.entity.name}
+                    <span className="govuk-visually-hidden">Service name:</span> {service.entity.name}
                   </a>
                 </th>
                 <td className="govuk-table__cell label">


### PR DESCRIPTION
What
----

Update link text or add visually hidden text to a link

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174314435

A number of links encountered throughout the service were considered to be non-descriptive when navigating out of context. 

For example, when navigating the ‘Organisations’ page, some screen reader users were unable to determine what the ‘View our guide’, ‘Get familiar’ and ‘Check the status’ links referred to.

This issue applies to a high number of links throughout the service. I tried to update all I could find. Check linked document in the ticket.

This also fixed signup link url.

### Example of change
**Before**
<img width="408" alt="before" src="https://user-images.githubusercontent.com/3758555/90502343-8cd53f00-e145-11ea-8dea-2a3974285085.png">

**After**
<img width="453" alt="after" src="https://user-images.githubusercontent.com/3758555/90502373-9ced1e80-e145-11ea-8175-f89037b8ff5e.png">



How to review
-------------

- checkout branch, run locally
- visit pages  mentioned above or in the document and check that the link text (along with the visually hidden text) is more descriptive

Who can review
---------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
