### PR TITLE
Show error when invite additional users is selected but no email address entered

### DIFF
--- a/src/components/support/controllers.test.tsx
+++ b/src/components/support/controllers.test.tsx
@@ -80,6 +80,23 @@ describe(controller.HandleSignupFormPost, () => {
     expect(response.body).toContain('We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, .police.uk or police.uk email addresses');
   });
 
+  it('should throw a validation error when option to add additional users was selected but no email addresses entered', async () => {
+    const response = await controller.HandleSignupFormPost(ctx, {}, {
+      name: 'Jeff',
+      email: 'jeff@example.gov.uk',
+      department_agency: 'Naming Authority',
+      service_team: 'Digital',
+      person_is_manager: 'yes',
+      invite_users: 'yes',
+      additional_users: [ { email: '' }, { email: '' }, { email: '' } ],
+    } as any);
+
+    expect(response.status).toEqual(400);
+    expect(response.body).not.toContain('We have received your request');
+    expect(response.body).toContain('Error');
+    expect(response.body).toContain('Enter at least one additional user email address');
+  });
+
   it('should create a zendesk ticket correctly', async () => {
     nockZD
       .post('/requests.json')

--- a/src/components/support/controllers.tsx
+++ b/src/components/support/controllers.tsx
@@ -309,6 +309,19 @@ function validateInviteUsers({ invite_users }: ISignupForm): ReadonlyArray<IVali
   return errors;
 }
 
+function validateAdditionalUserYesButEmpty({ invite_users, additional_users }: ISignupForm): ReadonlyArray<IValidationError> {
+  const errors = [];
+
+  if (invite_users === 'yes' && additional_users?.every(user => user.email === '')) {
+    errors.push({
+        field: 'additional_users-0',
+        message: 'Enter at least one additional user email address',
+      });
+  }
+
+  return errors;
+}
+
 function validateAdditionalUserEmail({ additional_users }: ISignupForm): ReadonlyArray<IValidationError> {
   const errors = [];
   if (additional_users) {
@@ -742,6 +755,7 @@ export async function HandleSignupFormPost(
     ...validateServiceTeam(body),
     ...validatePersonIsManager(body),
     ...validateInviteUsers(body),
+    ...validateAdditionalUserYesButEmpty(body),
     ...validateAdditionalUserEmail(body),
   );
 


### PR DESCRIPTION
What
----
Show error when invite additional users is selected but no email address entered
Users were able to select yes to invite additional users but leave the email fields empty.

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174314885

How to review
-------------

- checkout branch, run locally
- go to support form, `/support/sign-up`
- select yes to "Invite additional users" but leave their email address fields empty
- check if you see an error message
- play around with other combinations, selecting no, etc - you should see other validation messages but not this one

Who can review
---------------

not @kr8n3r 


![0 0 0 0_3000_support_sign-up](https://user-images.githubusercontent.com/3758555/90515815-13e0e200-e15b-11ea-8c5c-26f94b5beaee.png)
