### PR TITLE
Enhance Roles detail element text for screenreaders

### DIFF
--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -151,7 +151,7 @@ export function PermissionBlock(
           aria-expanded="false"
         >
           <span className="govuk-details__summary-text">
-            What can these roles do?
+            What can these <span className="govuk-visually-hidden">organisation level</span> roles do?
           </span>
         </summary>
         <div className="govuk-details__text" aria-hidden="true">
@@ -246,7 +246,7 @@ export function PermissionBlock(
       <details className="govuk-details"  data-module="govuk-details">
         <summary className="govuk-details__summary">
           <span className="govuk-details__summary-text">
-            What can these roles do?
+            What can these <span className="govuk-visually-hidden">space level</span> roles do?
           </span>
         </summary>
         <div className="govuk-details__text">
@@ -631,7 +631,7 @@ export function OrganizationUsersPage(
               <details className="govuk-details" data-module="govuk-details">
                 <summary className="govuk-details__summary">
                   <span className="govuk-details__summary-text">
-                    What can these roles do?
+                    What can these <span className="govuk-visually-hidden">organisation level</span> roles do?
                   </span>
                 </summary>
 


### PR DESCRIPTION
What
----

The multiple generic ‘What can these roles do?’ buttons are not
descriptive enough for screen reader users to distinguish between
them when navigating out of context.

Solution:
Ensure that all form elements are uniquely descriptive of their purpose
by including additional text to provide more context and help
users distinguish between the Details components.

For example, ‘What can these organisation level roles do?’ and
‘What can these space level roles do?’.

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174313818

How to review
-------------

- check out branch, run locally
- visit org page and check "What can these roles do?" element has a visually hidden added text of "organisation level"
- visit org team members page and invite new users
- visit org page and check details "What can these roles do?" elements have a visually hidden added text of "organisation level" and "space level" respectively

Who can review
---------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
