### PR TITLE
Update Org/Space/App/Service/Event titles & headings

### DIFF
--- a/src/components/application-events/controllers.test.tsx
+++ b/src/components/application-events/controllers.test.tsx
@@ -60,7 +60,7 @@ describe('application event', () => {
     });
 
     expect(response.body).toContain(
-      `${defaultApp().entity.name} - Application Event`,
+      `Application ${defaultApp().entity.name} Event details`,
     );
 
     expect(response.body).toContain(
@@ -94,7 +94,7 @@ describe('application event', () => {
     });
 
     expect(response.body).toContain(
-      `${defaultApp().entity.name} - Application Event`,
+      `Application ${defaultApp().entity.name} Event`,
     );
 
     expect(response.body).toContain(
@@ -124,7 +124,7 @@ describe('application event', () => {
     });
 
     expect(response.body).toContain(
-      `${defaultApp().entity.name} - Application Event`,
+      `Application ${defaultApp().entity.name} Event details`,
     );
 
     expect(response.body).toContain(
@@ -185,7 +185,7 @@ describe('application events', () => {
       });
 
       expect(response.body).toContain(
-        `${defaultApp().entity.name} - Application Events`,
+        `Application ${defaultApp().entity.name} Events`,
       );
       expect(response.body).toContain('0 total events');
     });
@@ -258,7 +258,7 @@ describe('application events', () => {
       });
 
       expect(response.body).toContain(
-        `${defaultApp().entity.name} - Application Events`,
+        `Application ${defaultApp().entity.name} Events`,
       );
 
       expect(response.body).toContain('Displaying page 1 of 2702');

--- a/src/components/application-events/controllers.tsx
+++ b/src/components/application-events/controllers.tsx
@@ -44,7 +44,7 @@ export async function viewApplicationEvent(
 
   const template = new Template(
     ctx.viewContext,
-    `${application.entity.name} - Application Event`,
+    `Application ${application.entity.name} Event details`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
@@ -128,7 +128,7 @@ export async function viewApplicationEvents(
 
   const template = new Template(
     ctx.viewContext,
-    `${application.entity.name} - Application Events`,
+    `Application ${application.entity.name} Events`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {

--- a/src/components/application-events/views.tsx
+++ b/src/components/application-events/views.tsx
@@ -99,8 +99,11 @@ export function ApplicationEventDetailPage(
   return (
     <>
       <h1 className="govuk-heading-l">
-        <span className="govuk-caption-l">Application Event</span>{' '}
-        {props.application.entity.name}
+        <span className="govuk-caption-l">
+          <span className="govuk-visually-hidden">Application</span>{' '}
+          {props.application.entity.name}
+        </span>{' '}
+        Event details
       </h1>
 
       <Event event={props.event} actor={props.actor} />
@@ -118,6 +121,7 @@ export function ApplicationEventsPage(
       spaceGUID={props.spaceGUID}
       linkTo={props.linkTo}
       routePartOf={props.routePartOf}
+      pageTitle="Events"
     >
       <Totals
         results={props.pagination.total_results}

--- a/src/components/applications/controllers.test.tsx
+++ b/src/components/applications/controllers.test.tsx
@@ -62,7 +62,7 @@ describe('applications test suite', () => {
       spaceGUID,
     });
 
-    expect(response.body).toMatch(new RegExp(`${name} - Application Overview`));
+    expect(response.body).toMatch(new RegExp(`Application ${name} Overview`));
   });
 
   it('should say the name of the stack being used', async () => {

--- a/src/components/applications/controllers.tsx
+++ b/src/components/applications/controllers.tsx
@@ -62,7 +62,7 @@ export async function viewApplication(
 
   const template = new Template(
     ctx.viewContext,
-    `${application.entity.name} - Application Overview`,
+    `Application ${application.entity.name} Overview`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {

--- a/src/components/applications/views.tsx
+++ b/src/components/applications/views.tsx
@@ -9,6 +9,7 @@ interface IApplicationTabProperties {
   readonly application: IApplication;
   readonly children: ReactNode;
   readonly linkTo: RouteLinker;
+  readonly pageTitle?: string;
   readonly organizationGUID: string;
   readonly routePartOf: RouteActiveChecker;
   readonly spaceGUID: string;
@@ -54,8 +55,11 @@ export function ApplicationTab(props: IApplicationTabProperties): ReactElement {
   return (
     <>
       <h1 className="govuk-heading-l">
-        <span className="govuk-caption-l">Application</span>{' '}
-        {props.application.entity.name}
+        <span className="govuk-caption-l">
+          <span className="govuk-visually-hidden">Application</span>{' '}
+          {props.application.entity.name}
+        </span>{' '}
+        {props.pageTitle}
       </h1>
 
       <div className="govuk-tabs">
@@ -129,14 +133,10 @@ export function ApplicationPage(
       routePartOf={props.routePartOf}
       organizationGUID={props.organizationGUID}
       spaceGUID={props.spaceGUID}
+      pageTitle="Overview"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <h1 className="govuk-heading-l">
-            <span className="govuk-caption-l">Application</span>{' '}
-            {props.application.entity.name}
-          </h1>
-
           <div className="scrollable-table-container">
             <table className="govuk-table">
             <caption className="govuk-table__caption">

--- a/src/components/service-events/controllers.test.tsx
+++ b/src/components/service-events/controllers.test.tsx
@@ -70,7 +70,7 @@ describe('service event', () => {
       spaceGUID,
     });
 
-    expect(response.body).toContain('name-1508 - Service Event');
+    expect(response.body).toContain('Service name-1508 Event details');
 
     expect(response.body).toContain(
       /* DateTime    */ moment(event.updated_at).format(DATE_TIME),
@@ -111,7 +111,7 @@ describe('service event', () => {
       spaceGUID,
     });
 
-    expect(response.body).toContain('name-1508 - Service Event');
+    expect(response.body).toContain('Service name-1508 Event details');
 
     expect(response.body).toContain(
       /* DateTime    */ moment(event.updated_at).format(DATE_TIME),
@@ -150,7 +150,7 @@ describe('service event', () => {
       spaceGUID,
     });
 
-    expect(response.body).toContain('name-1508 - Service Event');
+    expect(response.body).toContain('Service name-1508 Event details');
 
     expect(response.body).toContain(
       /* DateTime    */ moment(event.updated_at).format(DATE_TIME),
@@ -221,7 +221,7 @@ describe('service events', () => {
         spaceGUID,
       });
 
-      expect(response.body).toContain('name-1508 - Service Events');
+      expect(response.body).toContain('Service name-1508 Events');
       expect(response.body).toContain('0 total events');
       expect(
         spacesMissingAroundInlineElements(response.body as string),
@@ -305,7 +305,7 @@ describe('service events', () => {
         spaceGUID,
       });
 
-      expect(response.body).toContain('name-1508 - Service Events');
+      expect(response.body).toContain('Service name-1508 Events');
 
       expect(response.body).toContain('Displaying page 1 of 2702');
       expect(response.body).toContain('1337 total events');
@@ -379,7 +379,7 @@ describe('service event - CUPS', () => {
         spaceGUID,
       });
 
-      expect(response.body).toContain('name-1508 - Service Events');
+      expect(response.body).toContain('Service name-1508 Events');
       expect(response.body).not.toContain('Displaying page 1 of 1');
       expect(response.body).toContain('0 total events');
       expect(
@@ -401,7 +401,7 @@ describe('service event - CUPS', () => {
       spaceGUID,
     });
 
-    expect(response.body).toContain('name-1508 - Service Event');
+    expect(response.body).toContain('Service name-1508 Event details');
 
     expect(response.body).toContain(
       /* DateTime    */ moment(event.updated_at).format(DATE_TIME),

--- a/src/components/service-events/controllers.tsx
+++ b/src/components/service-events/controllers.tsx
@@ -62,7 +62,7 @@ export async function viewServiceEvent(
 
   const template = new Template(
     ctx.viewContext,
-    `${service.entity.name} - Service Event`,
+    `Service ${service.entity.name} Event details`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
@@ -164,7 +164,7 @@ export async function viewServiceEvents(
 
   const template = new Template(
     ctx.viewContext,
-    `${service.entity.name} - Service Events`,
+    `Service ${service.entity.name} Events`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {

--- a/src/components/service-events/views.tsx
+++ b/src/components/service-events/views.tsx
@@ -84,8 +84,11 @@ export function ServiceEventDetailPage(
   return (
     <>
       <h1 className="govuk-heading-l">
-        <span className="govuk-caption-l">Service Event</span>{' '}
-        {props.service.entity.name}
+        <span className="govuk-caption-l">
+          <span className="govuk-visually-hidden">Service</span>{' '}
+          {props.service.entity.name}
+        </span>{' '}
+        Event details
       </h1>
 
       <Event event={props.event} actor={props.actor} />
@@ -97,7 +100,7 @@ export function ServiceEventsPage(
   props: IServiceEventsPageProperties,
 ): ReactElement {
   return (
-    <ServiceTab {...props}>
+    <ServiceTab {...props} pageTitle="Events">
       <Totals
         results={props.pagination.total_results}
         page={props.pagination.page}

--- a/src/components/service-metrics/controllers.test.tsx
+++ b/src/components/service-metrics/controllers.test.tsx
@@ -104,7 +104,7 @@ describe('service metrics test suite', () => {
     });
 
     expect(response.status).not.toEqual(302);
-    expect(response.body).toContain('name-1508 - Service Metrics');
+    expect(response.body).toContain('Service name-1508 Metrics');
 
     expect(
       spacesMissingAroundInlineElements(response.body as string),
@@ -136,7 +136,7 @@ describe('service metrics test suite', () => {
     });
 
     expect(response.status).not.toEqual(302);
-    expect(response.body).toContain('name-1508 - Service Metrics');
+    expect(response.body).toContain('Service name-1508 Metrics');
 
     expect(
       spacesMissingAroundInlineElements(response.body as string),

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -196,7 +196,7 @@ export async function viewServiceMetrics(
 
   const template = new Template(
     ctx.viewContext,
-    `${service.entity.name} - Service Metrics`,
+    `Service ${service.entity.name} Metrics`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -380,7 +380,7 @@ export function UnsupportedServiceMetricsPage(
   props: IPageProperties,
 ): ReactElement {
   return (
-    <ServiceTab {...props}>
+    <ServiceTab {...props} pageTitle="Metrics">
       <ExperimentalWarning />
 
       <p>Metrics are not available for this service yet.</p>
@@ -390,7 +390,7 @@ export function UnsupportedServiceMetricsPage(
 
 export function MetricPage(props: IMetricPageProperties): ReactElement {
   return (
-    <ServiceTab {...props}>
+    <ServiceTab {...props} pageTitle="Metrics">
       <ExperimentalWarning />
 
       <div className="govuk-width-container">

--- a/src/components/services/controllers.mocked.test.tsx
+++ b/src/components/services/controllers.mocked.test.tsx
@@ -71,7 +71,7 @@ describe(listServiceLogs, () => {
       organizationGUID: 'ORG_GUID', serviceGUID: 'SERVICE_INSTANCE_GUID', spaceGUID: 'SPACE_GUID',
     });
 
-    expect(response.body).toContain('mydb - Service Logs');
+    expect(response.body).toContain('Service mydb Logs');
     expect(response.body).toContain('file-one');
   });
 
@@ -93,7 +93,7 @@ describe(listServiceLogs, () => {
       organizationGUID: 'ORG_GUID', serviceGUID: 'SERVICE_INSTANCE_GUID', spaceGUID: 'SPACE_GUID',
     });
 
-    expect(response.body).toContain('mydb - Service Logs');
+    expect(response.body).toContain('Service mydb Logs');
     expect(response.body).toContain('There are no log files available at this time.');
   });
 });

--- a/src/components/services/controllers.test.tsx
+++ b/src/components/services/controllers.test.tsx
@@ -48,7 +48,7 @@ describe('services test suite', () => {
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
     });
 
-    expect(response.body).toContain('name-1508 - Service Overview');
+    expect(response.body).toContain('Service name-1508 Overview');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -61,7 +61,7 @@ describe('services test suite', () => {
       spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
     });
 
-    expect(response.body).toContain('name-1700 - Service Overview');
+    expect(response.body).toContain('Service name-1700 Overview');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);

--- a/src/components/services/controllers.tsx
+++ b/src/components/services/controllers.tsx
@@ -52,7 +52,7 @@ export async function viewService(
 
   const template = new Template(
     ctx.viewContext,
-    `${service.entity.name} - Service Overview`,
+    `Service ${service.entity.name} Overview`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
@@ -73,6 +73,7 @@ export async function viewService(
         service={summarisedService}
         organizationGUID={organization.metadata.guid}
         spaceGUID={space.metadata.guid}
+        pageTitle="Overview"
       />,
     ),
   };
@@ -123,7 +124,7 @@ export async function listServiceLogs(ctx: IContext, params: IParameters): Promi
 
   const template = new Template(
     ctx.viewContext,
-    `${serviceInstance.entity.name} - Service Logs`,
+    `Service ${serviceInstance.entity.name} Logs`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
@@ -159,6 +160,7 @@ export async function listServiceLogs(ctx: IContext, params: IParameters): Promi
       routePartOf={ctx.routePartOf}
       service={summarisedService}
       spaceGUID={space.metadata.guid}
+      pageTitle="Logs"
     />),
   };
 }

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -16,6 +16,7 @@ interface IEnchancedServiceInstance extends IServiceInstance {
 interface IServicePageProperties {
   readonly service: IEnchancedServiceInstance;
   readonly linkTo: RouteLinker;
+  readonly pageTitle: string;
   readonly organizationGUID: string;
   readonly routePartOf: RouteActiveChecker;
   readonly spaceGUID: string;
@@ -69,8 +70,11 @@ export function ServiceTab(props: IServiceTabProperties): ReactElement {
   return (
     <>
       <h1 className="govuk-heading-l">
-        <span className="govuk-caption-l">Service</span>{' '}
-        {props.service.entity.name}
+        <span className="govuk-caption-l">
+          <span className="govuk-visually-hidden">Service</span>{' '}
+          {props.service.entity.name}
+        </span>{' '}
+        {props.pageTitle}
       </h1>
 
       <div className="govuk-tabs" data-module="govuk-tabs">

--- a/src/components/spaces/controllers.test.tsx
+++ b/src/components/spaces/controllers.test.tsx
@@ -59,7 +59,7 @@ describe('space event', () => {
       eventGUID: event.guid,
     });
 
-    expect(response.body).toContain('name-2064 - Space Event');
+    expect(response.body).toContain('Space name-2064 Event details');
 
     expect(response.body).toContain(
       /* DateTime    */ moment(event.updated_at).format(DATE_TIME),
@@ -93,7 +93,7 @@ describe('space event', () => {
       eventGUID: event.guid,
     });
 
-    expect(response.body).toContain('name-2064 - Space Event');
+    expect(response.body).toContain('Space name-2064 Event details');
 
     expect(response.body).toContain(
       /* DateTime    */ moment(event.updated_at).format(DATE_TIME),
@@ -123,7 +123,7 @@ describe('space event', () => {
       eventGUID: event.guid,
     });
 
-    expect(response.body).toContain('name-2064 - Space Event');
+    expect(response.body).toContain('Space name-2064 Event details');
 
     expect(response.body).toContain(
       /* DateTime    */ moment(event.updated_at).format(DATE_TIME),
@@ -252,7 +252,7 @@ describe('spaces test suite', () => {
       spaceGUID,
     });
 
-    expect(response.body).toContain(`${appName} - Overview`);
+    expect(response.body).toContain(`Space ${appName} Applications`);
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -280,7 +280,7 @@ describe('spaces test suite', () => {
       spaceGUID,
     });
 
-    expect(response.body).toContain('name-2064 - Overview');
+    expect(response.body).toContain('Space name-2064 Backing services');
     expect(response.body).toContain('name-2104');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
@@ -311,7 +311,7 @@ describe('spaces test suite', () => {
           spaceGUID,
         });
 
-        expect(response.body).toContain('name-2064 - Space Events');
+        expect(response.body).toContain('Space name-2064 Events');
         expect(response.body).toContain('0 total events');
         expect(
           spacesMissingAroundInlineElements(response.body as string),
@@ -398,7 +398,7 @@ describe('spaces test suite', () => {
           page: 1,
         });
 
-        expect(response.body).toContain('name-2064 - Space Events');
+        expect(response.body).toContain('Space name-2064 Events');
         expect(response.body).toContain('1337 total events');
         expect(response.body).toContain('<span>Previous page</span>');
         expect(response.body).not.toContain('<span>Next page</span>');

--- a/src/components/spaces/controllers.tsx
+++ b/src/components/spaces/controllers.tsx
@@ -102,7 +102,7 @@ export async function viewSpaceEvent(
 
   const template = new Template(
     ctx.viewContext,
-    `${space.entity.name} - Space Event`,
+    ` Space ${space.entity.name} Event details`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
@@ -182,7 +182,7 @@ export async function viewSpaceEvents(
 
   const template = new Template(
     ctx.viewContext,
-    `${space.entity.name} - Space Events`,
+    `Space ${space.entity.name} Events`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     { text: space.entity.name },
@@ -234,7 +234,7 @@ export async function listApplications(
 
   const template = new Template(
     ctx.viewContext,
-    `${space.entity.name} - Overview`,
+    `Space ${space.entity.name} Applications`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     { text: space.entity.name },
@@ -288,7 +288,7 @@ export async function listBackingServices(
 
   const template = new Template(
     ctx.viewContext,
-    `${space.entity.name} - Overview`,
+    `Space ${space.entity.name} Backing services`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     { text: space.entity.name },
@@ -402,7 +402,7 @@ export async function listSpaces(
 
   const template = new Template(
     ctx.viewContext,
-    `${summarisedOrganization.entity.name} – Spaces`,
+    `Organisation ${summarisedOrganization.entity.name} Overview`,
   );
   template.breadcrumbs = [
     { href: ctx.linkTo('admin.organizations'), text: 'Organisations' },

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -66,6 +66,7 @@ interface ISpaceTabProperties {
   readonly children: ReactNode;
   readonly linkTo: RouteLinker;
   readonly organizationGUID: string;
+  readonly pageTitle?: string;
   readonly routePartOf: RouteActiveChecker;
   readonly space: ISpace;
 }
@@ -175,8 +176,10 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
   return (
     <>
       <h1 className="govuk-heading-l">
-        <span className="govuk-caption-l">Organisation</span>{' '}
-        {props.organization.entity.name}
+        <span className="govuk-caption-l">
+          <span className="govuk-visually-hidden">Organisation</span>{' '}
+          {props.organization.entity.name}</span>{' '}
+          Overview
       </h1>
 
       <div className="govuk-grid-row">
@@ -379,7 +382,11 @@ export function SpaceTab(props: ISpaceTabProperties): ReactElement {
   return (
     <>
       <h1 className="govuk-heading-l">
-        <span className="govuk-caption-l">Space</span> {props.space.entity.name}
+        <span className="govuk-caption-l">
+          <span className="govuk-visually-hidden">Space</span>{' '}
+          {props.space.entity.name}
+        </span>{' '}
+        {props.pageTitle}
       </h1>
 
       <div className="govuk-tabs">
@@ -432,6 +439,7 @@ export function ApplicationsPage(
     <SpaceTab
       linkTo={props.linkTo}
       organizationGUID={props.organizationGUID}
+      pageTitle="Applications"
       routePartOf={props.routePartOf}
       space={props.space}
     >
@@ -535,6 +543,7 @@ export function BackingServicePage(
     <SpaceTab
       linkTo={props.linkTo}
       organizationGUID={props.organizationGUID}
+      pageTitle="Backing services"
       routePartOf={props.routePartOf}
       space={props.space}
     >
@@ -606,8 +615,11 @@ export function EventPage(props: IEventPageProperties): ReactElement {
   return (
     <>
       <h1 className="govuk-heading-l">
-        <span className="govuk-caption-l">Space Event</span>{' '}
-        {props.space.entity.name}
+        <span className="govuk-caption-l">
+          <span className="govuk-visually-hidden">Space</span>{' '}
+          {props.space.entity.name}
+        </span>{' '}
+        Event details
       </h1>
 
       <TargetedEvent actor={props.actor} event={props.event} />
@@ -617,7 +629,7 @@ export function EventPage(props: IEventPageProperties): ReactElement {
 
 export function EventsPage(props: IEventsPageProperties): ReactElement {
   return (
-    <SpaceTab {...props}>
+    <SpaceTab {...props} pageTitle="Events">
       <Totals
         results={props.pagination.total_results}
         page={props.pagination.page}


### PR DESCRIPTION
What
----

Problem:

When users select a "tab" such as ‘Backing services’ the page refreshes and users’ focus is returned to the top of the page. 

As the page title and main heading do not update to reflect the updated page content, some users may be unaware that the page content has changed.

While the [rest of the issue](https://www.pivotaltracker.com/n/projects/1275640/stories/174313243) talks about tabs markup not functioning like tabs in terms of keyboard navigation - they're not tabs, just look like one - for now we'll hold off from redesigning that navigational element, and have auditors test again.

This PR updates the Org/Space/App/Service/Event page titles & headings so they're unique and match when navigating pages.

We've moved the words "Organisation", "Space", "Application", "Service" from the visual text to visually-hidden text that's still part of the heading for screenreader users.

In its place we moved the Org/Space/App/Service name and below added the page title, like "Overview", "Metrics", "Applications" which matches the tab selection made and content on the page.

Visual changes
---

### Before
<img width="1275" alt="Screenshot 2020-08-20 at 08 07 41" src="https://user-images.githubusercontent.com/3758555/90729563-afd72e80-e2be-11ea-8313-5e74167f8ac1.png">
<img width="1082" alt="Screenshot 2020-08-20 at 08 07 33" src="https://user-images.githubusercontent.com/3758555/90729578-b6fe3c80-e2be-11ea-88ae-025ee2fa0e25.png">


### After 

<img width="1238" alt="Screenshot 2020-08-20 at 08 03 15" src="https://user-images.githubusercontent.com/3758555/90729605-c2516800-e2be-11ea-9629-ed505e499281.png">
<img width="1049" alt="Screenshot 2020-08-20 at 08 04 22" src="https://user-images.githubusercontent.com/3758555/90729619-c7aeb280-e2be-11ea-9c9d-c66e3d49c83c.png">

**heading also contains visually hidden text "Space" and "Application"**

<img width="1156" alt="Screenshot 2020-08-20 at 08 30 49" src="https://user-images.githubusercontent.com/3758555/90730144-88cd2c80-e2bf-11ea-9847-1069c581e0aa.png">


How to review
-------------

Describe the steps required to test the changes.

Who can review
---------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
