### PR TITLE
Update pricing calculator page with form labels and matching title

### DIFF
--- a/src/components/calculator/calculator.scss
+++ b/src/components/calculator/calculator.scss
@@ -117,16 +117,9 @@
   }
 
   select {
-    @include govuk-font($size: 16);;
+    @include govuk-font($size: 16);
   }
 
-  /*Gov.Uk select macros do not allow you to exclude the label element even
-  though it should be optional and just leaves a blank label, so we are hiding
-  it with CSS.*/
-  label {
-    margin-bottom: 0;
-    visibility: hidden;
-  }
 
   button {
     @include govuk-font($size: 16);;

--- a/src/components/calculator/controllers.test.tsx
+++ b/src/components/calculator/controllers.test.tsx
@@ -94,7 +94,7 @@ describe('calculator test suite', () => {
 
     const response = await getCalculator(ctx, {});
 
-    expect(response.body).toContain('Pricing calculator');
+    expect(response.body).toContain('Estimate your monthly cost');
     expect(response.body).toMatch(/\bCompute\b/);
     expect(response.body).toMatch(/\bPostgres\b/);
     expect(response.body).toMatch(/\bMySQL\b/);
@@ -122,7 +122,7 @@ describe('calculator test suite', () => {
       items: [],
     });
 
-    expect(response.body).toContain('Pricing calculator');
+    expect(response.body).toContain('Estimate your monthly cost');
     expect(response.body).toContain('<p class="paas-price">£0.00</p>');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
@@ -412,7 +412,7 @@ describe('calculator test suite', () => {
       ],
     });
 
-    expect(response.body).toContain('Pricing calculator');
+    expect(response.body).toContain('Estimate your monthly cost');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);

--- a/src/components/calculator/controllers.tsx
+++ b/src/components/calculator/controllers.tsx
@@ -226,7 +226,7 @@ export async function getCalculator(
     quote = await getQuote(billing, state);
   }
 
-  const template = new Template(ctx.viewContext, 'Pricing calculator');
+  const template = new Template(ctx.viewContext, 'Estimate your monthly costs');
 
   return {
     body: template.render(<CalculatorPage state={state} quote={quote} />),

--- a/src/components/calculator/views.tsx
+++ b/src/components/calculator/views.tsx
@@ -153,6 +153,9 @@ function Plans(props: IPlansProperties): ReactElement {
                 />
                 {plans.length > 1 ? (
                   <div className="govuk-form-group">
+                    <label className="govuk-label govuk-visually-hidden" htmlFor={`service-${props.serviceName}`}>
+                      Select a {props.serviceName} service plan
+                    </label>
                     <select
                       className="govuk-select govuk-!-width-full"
                       id={`service-${props.serviceName}`}
@@ -176,6 +179,9 @@ function Plans(props: IPlansProperties): ReactElement {
                       <>
                         <div style={{ width: '46%' }}>
                           <div className="govuk-form-group">
+                            <label className="govuk-label govuk-visually-hidden" htmlFor={'nodes-app'}>
+                              Select number of app instances
+                            </label>
                             <select
                               className="govuk-select govuk-!-width-full"
                               id={'nodes-app'}
@@ -201,6 +207,9 @@ function Plans(props: IPlansProperties): ReactElement {
                           }}
                         >
                           <div className="govuk-form-group">
+                            <label className="govuk-label govuk-visually-hidden" htmlFor={'mem-app'}>
+                              Select the amount of memory per instance
+                            </label>
                             <select
                               className="govuk-select govuk-!-width-full"
                               id={'mem-app'}


### PR DESCRIPTION
What
----

The select fields related to the ‘Estimate your monthly costs’ table not
labelled.

This means that some users of assistive technology may not be able to
determine the form elements function or purpose.

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174299209

This PR 
- updates title property to match page heading
- adds visually hidden labels to select fields
- removes css that was making label hidden and inaccessible to
screenreaders

**Before**
<img width="789" alt="before" src="https://user-images.githubusercontent.com/3758555/90624816-7b0c9e00-e210-11ea-9bda-89440f64a42b.png">


**After**
<img width="785" alt="after" src="https://user-images.githubusercontent.com/3758555/90624740-57495800-e210-11ea-93c5-4b257443ba58.png">


How to review
-------------

- check out branch, run locally
- got to /calculator page
- check each select has a appropriately descriptive visually hidden label and that label's `for` attribute value matches the `select`'s `id`

Who can review
---------------

not @kr8n3r 