### PR TITLE
Update calculator buttons' focus states

### DIFF
--- a/src/components/calculator/calculator.scss
+++ b/src/components/calculator/calculator.scss
@@ -142,5 +142,15 @@
     padding: 0;
     padding-left: 10px;
     min-width: 43px;
+    
+    &:focus {
+      @include govuk-focused-text;
+    }
+  }
+}
+
+.paas-remove-button {
+  &:focus {
+    @include govuk-focused-text;
   }
 }


### PR DESCRIPTION
What
----

The ‘+ Add’ buttons are highlighted by the browser default focus indicator which does not conform with GOV.UK Design System recommendations. This issue also applies to the ‘x’ (remove) buttons displayed under ‘Estimated cost’.

This PR adds GOV.UK Design system focus states
Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174315318

How to review
-------------

- checkout branch, run locally
- got to /calculator page
- use keyboard to tab to Add button and remove button
- check focus state is a 🐝  colour

Who can review
---------------

not @kr8n3r 

Visual change
---------------

**Before**
<img width="496" alt="before" src="https://user-images.githubusercontent.com/3758555/90633606-3daf0d00-e21e-11ea-98d8-2599ea8a92a7.png">

**After**
<img width="493" alt="Screenshot 2020-08-19 at 13 12 11" src="https://user-images.githubusercontent.com/3758555/90633633-4bfd2900-e21e-11ea-81c8-1d0c23518e7f.png">
