### PR TITLE
Update calculator buttons' labels

### DIFF
--- a/src/components/calculator/calculator.scss
+++ b/src/components/calculator/calculator.scss
@@ -144,3 +144,12 @@
     min-width: 43px;
   }
 }
+
+.paas-add-button {
+  position: relative;
+  &:before {
+    position: absolute;
+    left: 4px;
+    content: "\002B" / "";
+  }
+}

--- a/src/components/calculator/views.test.tsx
+++ b/src/components/calculator/views.test.tsx
@@ -1,6 +1,7 @@
-import { render } from 'enzyme';
+import { render} from 'enzyme';
 import {
     appInstanceDescription,
+    appInstanceDescriptionText,
 } from './views';
 
 describe(appInstanceDescription, () => {
@@ -17,5 +18,16 @@ describe(appInstanceDescription, () => {
   it('should display "1 app instance with 2 GiB of memory" without a decimal point', () => {
     const instanceDescription = render(appInstanceDescription(2048,1)).text()
     expect(instanceDescription).toEqual("1 app instance with 2 GiB of memory")
+  });
+});
+
+describe(appInstanceDescriptionText, () => {
+  it('should return text "1 app instance with 64 mebibytes of memory', () => {
+    const instanceDescription = appInstanceDescriptionText(64,1).toString()
+    expect(instanceDescription).toEqual("1 app instance with 64 mebibytes of memory")
+  });
+  it('should return text "1 app instance with 1.5 gibibytes of memory', () => {
+    const instanceDescription = appInstanceDescriptionText(1536,1).toString()
+    expect(instanceDescription).toEqual("1 app instance with 1.5 gibibytes of memory")
   });
 });

--- a/src/components/calculator/views.tsx
+++ b/src/components/calculator/views.tsx
@@ -1,7 +1,7 @@
 import { groupBy, mapValues, values } from 'lodash';
 import React, { Fragment, ReactElement } from 'react';
 
-import { bytesToHuman } from '../../layouts/helpers';
+import { bytesConvert, bytesToHuman } from '../../layouts/helpers';
 import { KIBIBYTE } from '../../layouts/constants';
 
 export interface IQuote {
@@ -101,6 +101,14 @@ export function appInstanceDescription(memoryInMB: number, instances: number): R
     {' '}
     {bytesToHuman(memoryInMB * 1024 * 1024, precisionDigits)} of memory
   </>;
+}
+
+export function appInstanceDescriptionText(memoryInMB: number, instances: number) {
+  const precisionDigits = memoryInMB > KIBIBYTE && memoryInMB < KIBIBYTE * 2 ? 1 : 0;
+  const converted = bytesConvert((memoryInMB * 1024 * 1024), precisionDigits);
+  return (
+    `${instances.toFixed(0)} app instance${instances === 1 ? '' : 's'}${' '}with${' '}${converted.value} ${converted.long} of memory`
+  )
 }
 
 function StateFields(props: IStateFieldsProperties): ReactElement {
@@ -224,8 +232,14 @@ function Plans(props: IPlansProperties): ReactElement {
                     )}
                   </>
                 )}
-                <button type="submit" className="paas-link-button">
-                  + Add
+                <button type="submit" className="paas-add-button">
+                  Add{' '}
+                  <span className="govuk-visually-hidden">
+                  {props.serviceName === 'app' ? 
+                    'compute instance with selected configuration' : 
+                    `selected ${props.serviceName} service plan`
+                  }
+                  </span>
                 </button>
               </form>
             </td>
@@ -299,7 +313,11 @@ export function CalculatorPage(props: ICalculatorPageProperties): ReactElement {
                       <button
                         className="paas-remove-button"
                         type="submit"
-                        arria-label="Remove"
+                        aria-label={`Remove 
+                          ${event.resourceType === 'app'
+                          ? `compute configuration of ${appInstanceDescriptionText(event.memoryInMB, event.numberOfNodes)}`
+                          : `${event.resourceType} ${event.resourceName} service plan`}
+                        `}
                       >
                         &times;
                       </button>


### PR DESCRIPTION
What
----

Problem:
The multiple generic '+ Add' and ‘x’ buttons are not descriptive enough
for screen reader users to determine their function or purpose when
navigating out of context.

Also, the aria-label element is spelled wrong which means “Remove” is
not announced to screen reader users; however, multiple generic ‘Remove’
buttons are also not descriptive enough for screen reader users to
determine their function or purpose.

Solution:
- Update 'Add' button for each row with descriptive text to read:
  - for services: "Add selected <serviceName> service plan"
  - for app instances: "Add compute instance with selected configuration"
- Update 'Remove' button for each added row with descriptive text to
read:
  - for services: "Remove <serviceName> <servicePlan> service plan"
  - for app instances: "Remove compute configuration of <number> app
  instances with <selectedMemory> of memory"

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174313713


**Add button updated label text**
<img width="752" alt="Add button updated label text" src="https://user-images.githubusercontent.com/3758555/90637951-8cf83c00-e224-11ea-929c-6787f514e006.png">


**Remove button updated label text**
<img width="1143" alt="remove button updated label" src="https://user-images.githubusercontent.com/3758555/90637854-6fc36d80-e224-11ea-828d-936edaab4734.png">
<br />
<img width="598" alt="Screenshot 2020-08-19 at 14 46 15" src="https://user-images.githubusercontent.com/3758555/90642838-cd5ab880-e22a-11ea-910f-8beb26cdfab9.png">


How to review
-------------

- checkout branch, run locally
- go to /calculator
- check 'Add' for each row contains a distinctive text (visually hidden)
- add some instances and apps
- check 'Remove (X)' button contains a distinctive text (visually hidden) in `aria-label` attribute

Who can review
---------------

not @kr8n3r 
