### PR TITLE
Update calculator layout

### DIFF
--- a/src/components/calculator/calculator.scss
+++ b/src/components/calculator/calculator.scss
@@ -107,14 +107,8 @@
 }
 
 .paas-service-selection {
-  text-align: right;
-
-  .govuk-form-group {
-    display: inline-block;
-    float: left;
-    margin: 0;
-    width: 80%;
-  }
+  display: table;
+  width: 100%;
 
   select {
     @include govuk-font($size: 16);

--- a/src/components/calculator/calculator.scss
+++ b/src/components/calculator/calculator.scss
@@ -47,6 +47,7 @@
 
   .paas-service-heading {
     padding-top: 10px;
+    text-align: left;
   }
 
   .paas-admin-fee {

--- a/src/components/calculator/views.tsx
+++ b/src/components/calculator/views.tsx
@@ -148,44 +148,44 @@ function Plans(props: IPlansProperties): ReactElement {
     <>
       {values(
         mapValues(groupBy(props.plans, 'serviceName'), (plans, serviceName) => (
-          <tr key={serviceName} className="govuk-table__row">
-            <td className="govuk-table__cell">
-              {niceServiceName(props.serviceName)}
-            </td>
-            <td className="govuk-table__cell ">
+          
+            <div key={serviceName} className="govuk-summary-list__row">
               <form className="paas-service-selection" method="get">
-                <StateFields
-                  items={props.state.items}
-                  rangeStart={props.state.rangeStart}
-                  rangeStop={props.state.rangeStop}
-                />
-                {plans.length > 1 ? (
-                  <div className="govuk-form-group">
-                    <label className="govuk-label govuk-visually-hidden" htmlFor={`service-${props.serviceName}`}>
-                      Select a {props.serviceName} service plan
-                    </label>
-                    <select
-                      className="govuk-select govuk-!-width-full"
-                      id={`service-${props.serviceName}`}
-                      name={`items[${props.state.items.length}][planGUID]`}
-                    >
-                      {plans.slice().sort(orderPlans).map(plan => (
-                        <option key={plan.planGUID} value={plan.planGUID}>
-                          {niceServiceName(plan.planName)}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                ) : (
-                  <>
-                    <input
-                      type="hidden"
-                      name={`items[${props.state.items.length}][planGUID]`}
-                      value={plans[0].planGUID}
-                    />
-                    {props.serviceName === 'app' ? (
-                      <>
-                        <div style={{ width: '46%' }}>
+                <dt className="govuk-summary-list__key">
+                {niceServiceName(props.serviceName)}
+              </dt>
+                <dd className="govuk-summary-list__value">
+                  <StateFields
+                    items={props.state.items}
+                    rangeStart={props.state.rangeStart}
+                    rangeStop={props.state.rangeStop}
+                  />
+                  {plans.length > 1 ? (
+                    <div className="govuk-form-group">
+                      <label className="govuk-label govuk-visually-hidden" htmlFor={`service-${props.serviceName}`}>
+                        Select a {props.serviceName} service plan
+                      </label>
+                      <select
+                        className="govuk-select govuk-!-width-full"
+                        id={`service-${props.serviceName}`}
+                        name={`items[${props.state.items.length}][planGUID]`}
+                      >
+                        {plans.slice().sort(orderPlans).map(plan => (
+                          <option key={plan.planGUID} value={plan.planGUID}>
+                            {niceServiceName(plan.planName)}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  ) : (
+                    <>
+                      <input
+                        type="hidden"
+                        name={`items[${props.state.items.length}][planGUID]`}
+                        value={plans[0].planGUID}
+                      />
+                      {props.serviceName === 'app' ? (
+                        <>
                           <div className="govuk-form-group">
                             <label className="govuk-label govuk-visually-hidden" htmlFor={'nodes-app'}>
                               Select number of app instances
@@ -206,14 +206,6 @@ function Plans(props: IPlansProperties): ReactElement {
                               <option value="128">128 app instances</option>
                             </select>
                           </div>
-                        </div>
-                        <div
-                          style={{
-                            float: 'left',
-                            marginLeft: '14px',
-                            width: '46%',
-                          }}
-                        >
                           <div className="govuk-form-group">
                             <label className="govuk-label govuk-visually-hidden" htmlFor={'mem-app'}>
                               Select the amount of memory per instance
@@ -234,25 +226,26 @@ function Plans(props: IPlansProperties): ReactElement {
                               <option value="16384">16.0 GiB of memory</option>
                             </select>
                           </div>
-                        </div>
-                      </>
-                    ) : (
-                      <></>
-                    )}
-                  </>
-                )}
-                <button type="submit" className="paas-add-button">
-                  Add{' '}
-                  <span className="govuk-visually-hidden">
-                  {props.serviceName === 'app' ? 
-                    'compute instance with selected configuration' : 
-                    `selected ${props.serviceName} service plan`
-                  }
-                  </span>
-                </button>
+                        </>
+                      ) : (
+                        <></>
+                      )}
+                    </>
+                  )}
+                </dd>
+                <dd className="govuk-summary-list__actions">
+                  <button type="submit" className="paas-add-button">
+                    Add{' '}
+                    <span className="govuk-visually-hidden">
+                    {props.serviceName === 'app' ? 
+                      'compute instance with selected configuration' : 
+                      `selected ${props.serviceName} service plan`
+                    }
+                    </span>
+                  </button>
+                </dd>
               </form>
-            </td>
-          </tr>
+            </div>
         )),
       )}
     </>
@@ -275,13 +268,8 @@ export function CalculatorPage(props: ICalculatorPageProperties): ReactElement {
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds paas-service-list">
-          <div className="scrollable-table-container">
-            <table className="govuk-table">
-            <thead>
-              <th>Service</th>
-              <th>Select options</th>
-            </thead>
-            <tbody className="govuk-table__body">
+          <h2 className="govuk-heading-m">Select a service and options to estimate costs</h2>
+          <dl className="govuk-summary-list">
               {values(
                 mapValues(
                   groupBy(props.state.plans, 'serviceName'),
@@ -295,9 +283,7 @@ export function CalculatorPage(props: ICalculatorPageProperties): ReactElement {
                   ),
                 ),
               )}
-            </tbody>
-          </table>
-          </div>
+          </dl>
         </div>
 
         <div className="govuk-grid-column-one-third paas-summary-section">

--- a/src/components/calculator/views.tsx
+++ b/src/components/calculator/views.tsx
@@ -293,10 +293,17 @@ export function CalculatorPage(props: ICalculatorPageProperties): ReactElement {
 
           <table>
             <caption>Services added</caption>
+            <thead className="govuk-visually-hidden">
+              <tr>
+                <th scope="col">Service</th>
+                <th scope="col">Cost or action</th>
+              </tr>
+            </thead>
+            <tbody>
             {props.quote.events.map((event, index) => (
               <Fragment key={index}>
                 <tr>
-                  <td className="paas-service-heading">{niceServiceName(event.resourceType)}</td>
+                  <th scope="row" className="paas-service-heading">{niceServiceName(event.resourceType)}</th>
                   <td>
                     <form method="get">
                       <StateFields
@@ -340,9 +347,11 @@ export function CalculatorPage(props: ICalculatorPageProperties): ReactElement {
                   £{((props.quote.exVAT / 100) * 10).toFixed(2)}
                 </td>
               </tr>
+            
             ) : (
               <></>
             )}
+            </tbody>
           </table>
 
           <p className="paas-total">Estimated monthly cost</p>


### PR DESCRIPTION
What
----

Problem:

The ‘Select options’ column refers to multiple form elements in some rows which may be difficult for some users to differentiate between;
the columns header does not accurately convey the purpose of the corresponding data; the header cell spans what appears to be three columns but has not been marked-up as such.

Solution:
Alternatively, use a definition list similar to the GOV.UK Check answers Page pattern to present the content on this page.

We have used the [summary list](https://design-system.service.gov.uk/components/summary-list/ component (definition list) for the updated layout.

Update estimated cost summary table with valid markup

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174300123


How to review
-------------

- checkout branch, run locally
- go to /calculator and check it still works
- evaluate chanhes

Who can review
---------------

not @kr8n3r 

Visual changes
----

### Before

**Mobile**
<img width="405" alt="before mobile" src="https://user-images.githubusercontent.com/3758555/90758774-6c3cee80-e2d7-11ea-8f7b-78fb1888781f.png">

**Desktop**
<img width="815" alt="before desktop" src="https://user-images.githubusercontent.com/3758555/90758643-3d267d00-e2d7-11ea-8b53-44f2d7ca937e.png">


### After

**Mobile**
<img width="404" alt="after mobile" src="https://user-images.githubusercontent.com/3758555/90758834-85de3600-e2d7-11ea-97b1-d73f99444f7d.png">

**Desktop**
<img width="828" alt="after desktop" src="https://user-images.githubusercontent.com/3758555/90758476-00f31c80-e2d7-11ea-984b-771d628f4a8e.png">


