### PR TITLE
Fix invite users form error handling

### DIFF
--- a/src/components/events/views.tsx
+++ b/src/components/events/views.tsx
@@ -36,16 +36,11 @@ interface ITargetedEventListItemProperties extends IEventListItemProperties {
 export function Details(): ReactElement {
   return (
     <details className="govuk-details" data-module="govuk-details">
-      <summary
-        className="govuk-details__summary"
-        role="button"
-        aria-controls="details-content-0"
-        aria-expanded="false"
-      >
+      <summary className="govuk-details__summary">
         <span className="govuk-details__summary-text">What are events?</span>
       </summary>
 
-      <div className="govuk-details__text" aria-hidden="true">
+      <div className="govuk-details__text">
         <p className="govuk-body">
           Events are a log of actions made by actors against targets.
         </p>

--- a/src/components/org-users/controllers.test.tsx
+++ b/src/components/org-users/controllers.test.tsx
@@ -265,7 +265,7 @@ describe('org-users test suite', () => {
 
     const $ = cheerio.load(response.body as string);
 
-    expect(response.body).toContain('a valid email address is required');
+    expect(response.body).toContain('Enter an email address in the correct format, like name@example.com');
     expect(
       $(
         'input[type="checkbox"][name^="org_roles[a7aff246-5f5b-4cf8-87d8-f316053e4a20][managers]"]:disabled',
@@ -316,7 +316,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('a valid email address is required');
+    expect(response.body).toContain('Enter an email address in the correct format, like name@example.com');
     expect(response.status).toEqual(400);
     expect(
       spacesMissingAroundInlineElements(response.body as string),
@@ -399,8 +399,11 @@ describe('org-users test suite', () => {
         },
       },
     );
-
-    expect(response.body).toContain('at least one role should be selected');
+    const $ = cheerio.load(response.body as string);
+    expect(response.body).toContain('At least one organisation or space level role should be selected');
+    expect($('#roles').hasClass('govuk-form-group--error')).toBeTruthy();
+    expect($('#roles').find('#roles-error').length).toBe(1);
+    expect($('#roles').attr('aria-describedby')).toBe('roles-error');
     expect(response.status).toEqual(400);
     expect(
       spacesMissingAroundInlineElements(response.body as string),
@@ -1321,7 +1324,7 @@ describe('org-users test suite', () => {
       },
     );
 
-    expect(response.body).toContain('at least one role should be selected');
+    expect(response.body).toContain('At least one organisation or space level role should be selected');
     expect(response.status).toEqual(400);
     expect(
       spacesMissingAroundInlineElements(response.body as string),

--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -218,7 +218,7 @@ function validatePermissions({
   if (!orgRolesSelected && !spaceRolesSelected) {
     errors.push({
       field: 'roles',
-      message: 'at least one role should be selected',
+      message: 'At least one organisation or space level role should be selected',
     });
   }
 
@@ -231,7 +231,7 @@ function validateEmail({ email }: IUserPostBody): ReadonlyArray<IValidationError
   if (!email || !VALID_EMAIL.test(email)) {
     errors.push({
       field: 'email',
-      message: 'a valid email address is required',
+      message: 'Enter an email address in the correct format, like name@example.com',
     });
   }
 
@@ -470,7 +470,7 @@ export async function inviteUser(
     body,
   );
 
-  const template = new Template(ctx.viewContext, 'Invite a new team member');
+  const template = new Template(ctx.viewContext, 'Error: Invite a new team member');
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
       href: ctx.linkTo('admin.organizations.users', {
@@ -503,7 +503,7 @@ export async function inviteUser(
       /* istanbul ignore next */
       if (!invitation) {
         throw new ValidationError([
-          { field: 'email', message: 'a valid email address is required' },
+          { field: 'email', message: 'Enter an email address in the correct format, like name@example.com' },
         ]);
       }
 
@@ -521,7 +521,7 @@ export async function inviteUser(
       throw new ValidationError([
         {
           field: 'email',
-          message: 'user is already a member of the organisation',
+          message: 'User is already a member of the organisation',
         },
       ]);
     }
@@ -637,7 +637,7 @@ export async function resendInvitation(
 
   /* istanbul ignore next */
   if (!VALID_EMAIL.test(user.entity.username)) {
-    throw new Error('User: a valid email address is required.');
+    throw new Error('Enter an email address in the correct format, like name@example.com');
   }
 
   const uaa = new UAAClient({
@@ -665,7 +665,7 @@ export async function resendInvitation(
   /* istanbul ignore next */
   if (!invitation) {
     throw new ValidationError([
-      { field: 'email', message: 'a valid email address is required' },
+      { field: 'email', message: 'Enter an email address in the correct format, like name@example.com' },
     ]);
   }
 

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -58,6 +58,7 @@ interface IPermissionBlockProperties {
   readonly organization: IOrganization;
   readonly spaces: ReadonlyArray<ISpace>;
   readonly values: IRoleValues;
+  readonly errors?: ReadonlyArray<IValidationError>;
 }
 
 interface IEditPageProperties extends IPermissionBlockProperties {
@@ -140,7 +141,33 @@ export function PermissionBlock(
 ): ReactElement {
   return (
     <>
+    <div 
+      id="roles"
+      className={
+        props.errors?.some(e => e.field === 'roles')
+          ? 'govuk-form-group--error'
+          : ''
+      }
+      aria-describedby={
+        props.errors?.some(e => e.field === 'roles')
+          ? 'roles-error'
+          : ''
+      }
+      >
       <h2 className="govuk-heading-m">Set organisation and space roles</h2>
+      {props.errors
+        ?.filter(error => error.field === 'roles')
+        .map((error, index) => (
+          <span
+            key={index}
+            id="roles-error"
+            className="govuk-error-message"
+          >
+            <span className="govuk-visually-hidden">Error:</span>{' '}
+            {error.message}
+          </span>
+        ))
+      }
       <h3 className="govuk-heading-s">Organisation level roles</h3>
 
       <details className="govuk-details"  data-module="govuk-details">
@@ -325,6 +352,7 @@ export function PermissionBlock(
           </fieldset>
         </div>
       ))}
+    </div>
     </>
   );
 }
@@ -472,6 +500,7 @@ export function EditPage(props: IEditPageProperties): ReactElement {
             values={props.values}
             managers={props.managers}
             billingManagers={props.billingManagers}
+            errors={props.errors}
           />
 
           <button
@@ -512,7 +541,7 @@ export function InvitePage(props: IInvitePageProperties): ReactElement {
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">
-              Error validating the update
+              There is a problem
             </h2>
 
             <div className="govuk-error-summary__body">
@@ -576,6 +605,7 @@ export function InvitePage(props: IInvitePageProperties): ReactElement {
             values={props.values}
             managers={10}
             billingManagers={10}
+            errors={props.errors}
           />
 
           <button

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -170,18 +170,13 @@ export function PermissionBlock(
       }
       <h3 className="govuk-heading-s">Organisation level roles</h3>
 
-      <details className="govuk-details"  data-module="govuk-details">
-        <summary
-          className="govuk-details__summary"
-          role="button"
-          aria-controls="details-content-0"
-          aria-expanded="false"
-        >
+      <details className="govuk-details" data-module="govuk-details">
+        <summary className="govuk-details__summary">
           <span className="govuk-details__summary-text">
             What can these <span className="govuk-visually-hidden">organisation level</span> roles do?
           </span>
         </summary>
-        <div className="govuk-details__text" aria-hidden="true">
+        <div className="govuk-details__text">
           <p className="govuk-body">
             <span className="govuk-!-font-weight-bold">Org managers</span> can
             create/delete spaces and edit user roles. The Org Managers would


### PR DESCRIPTION
What
----

Problems:

- The ‘at least one role should be selected’ Error summary skip link 
does not direct users’ focus. This appears to be because the link 
destination (href="#roles") doesn’t exist.

- ‘Error: ’ is not added to the beginning of the title attribute when 
validation errors occur

Solutions: 

- Update title and error-summary messages
- Add #roles to org wrapper, provide error message and `aria-labelledby` 
description

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174312798


How to review
-------------

- checkout branch, run locally
- go to org and invite a user
- leave empty fields and submit form
- check error summary message links to places
- evaluate roles wrapper error message
- check page title property says: Error: Invite users

Who can review
---------------

not @kr8n3r 

Visual change
----

### Before
![before](https://user-images.githubusercontent.com/3758555/90871832-9a800400-e393-11ea-817e-dfea30953669.png)


### After
![after](https://user-images.githubusercontent.com/3758555/90871973-d31fdd80-e393-11ea-93f6-59e5cf482d61.png)


