### PR TITLE
[WIP] Introduce API tokens

### DIFF
--- a/src/components/api-tokens/controllers.test.tsx
+++ b/src/components/api-tokens/controllers.test.tsx
@@ -1,0 +1,242 @@
+import { spacesMissingAroundInlineElements } from '../../layouts/react-spacing.test';
+import CloudFoundryClient from '../../lib/cf';
+import UAAClient from '../../lib/uaa';
+import { IContext } from '../app';
+import { createTestContext } from '../app/app.test-helpers';
+
+import { compose, confirmRevocation, create, isTokenUser, list, revoke } from './controllers';
+import { DEFAULT_KEY_LENGTH, DEFAULT_SECRET_LENGTH } from './token';
+
+jest.mock('../../lib/cf');
+jest.mock('../../lib/uaa');
+
+const mockOrganization = { entity: { name: 'org-name' }, metadata: { guid: 'ORG_GUID' } };
+const mockUAAUser = { userName: 'jeff@jefferson.com' };
+const mockUAAUserToken = { userName: 'org-name-deployer-q1w2e3r4' };
+const mockUser = {
+  entity: { username: mockUAAUser.userName },
+  metadata: { created_at: '2020-01-01T11:00:00', guid: '__USER_GUID__' },
+};
+const mockToken = {
+  entity: { username: mockUAAUserToken.userName },
+  metadata: { created_at: '2020-01-01T12:00:00', guid: '__TOKEN_GUID__' },
+};
+
+const ctx: IContext = createTestContext();
+const MockCFClient = CloudFoundryClient as jest.Mock;
+const MockUAAClient = UAAClient as jest.Mock;
+
+describe(isTokenUser, () => {
+  it('should correctly define a token user', () => {
+    expect(isTokenUser('govuk-paas', 'govuk-paas-deploy-user-q1w2e3r4')).toBe(true);
+    expect(isTokenUser('govuk-paas', 'govuk-paas-prod-1q2w3e4r')).toBe(true);
+    expect(isTokenUser('govuk_paas', 'govuk_paas-deploy-user-q1w2e3r4')).toBe(true);
+    expect(isTokenUser('govuk_paas', 'govuk_paas-prod-1q2w3e4r')).toBe(true);
+    expect(isTokenUser('paas', 'paas-deploy-user-q1w2e3r4')).toBe(true);
+    expect(isTokenUser('paas', 'paas-prod-1q2w3e4r')).toBe(true);
+    expect(isTokenUser('testing-very-long-org-name', 'testing-very-long-org-name-deploy-user-q1w2e3r4')).toBe(true);
+    expect(isTokenUser('testing-very-long-org-name', 'testing-very-long-org-name-prod-1q2w3e4r')).toBe(true);
+
+    expect(isTokenUser('govuk-paas', 'admin')).toBe(false);
+    expect(isTokenUser('govuk-paas', 'jeff.jefferson@example.com')).toBe(false);
+    expect(isTokenUser('govuk-paas', '12345678900987654321')).toBe(false);
+  });
+});
+
+describe(list, () => {
+  beforeEach(() => {
+    MockCFClient.mockClear();
+  });
+
+  it('should throw a 404 error if user has not enough permissions', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(false);
+
+    await expect(list(ctx, {})).rejects.toThrowError(/not found/);
+  });
+
+  it('should be able to list out all tokens and no users', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+    MockCFClient.prototype.usersForOrganization.mockReturnValueOnce([ mockToken, mockUser, mockToken ]);
+
+    const response = await list(ctx, {});
+
+    expect(response.status).toBeUndefined();
+    expect(response.body).not.toContain(mockUser.entity.username);
+    expect(response.body).toContain(mockToken.entity.username);
+    expect(spacesMissingAroundInlineElements(response.body as string)).toHaveLength(0);
+  });
+});
+
+describe(confirmRevocation, () => {
+  beforeEach(() => {
+    MockCFClient.mockClear();
+    MockUAAClient.mockClear();
+  });
+
+  it('should throw a 404 error if user has not enough permissions', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(false);
+
+    await expect(confirmRevocation(ctx, {})).rejects.toThrowError(/not found/);
+  });
+
+  it('should throw a 404 error if uaa user is not found', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+    MockUAAClient.prototype.getUser.mockReturnValueOnce(null);
+
+    await expect(confirmRevocation(ctx, {})).rejects.toThrowError(/token not found/);
+  });
+
+  it('should throw a 404 error if uaa user is not a token', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+    MockUAAClient.prototype.getUser.mockReturnValueOnce(mockUAAUser);
+
+    await expect(confirmRevocation(ctx, {})).rejects.toThrowError(/token not found/);
+  });
+
+  it('should be able to print out form requiring user confirmation on revoke action', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+    MockUAAClient.prototype.getUser.mockReturnValueOnce(mockUAAUserToken);
+
+    const response = await confirmRevocation(ctx, {});
+
+    expect(response.status).toBeUndefined();
+    expect(response.body).toContain('Are you sure you\'d like to revoke the following API Token?');
+    expect(spacesMissingAroundInlineElements(response.body as string)).toHaveLength(0);
+  });
+});
+
+describe(revoke, () => {
+  beforeEach(() => {
+    MockCFClient.mockClear();
+  });
+
+  it('should throw a 404 error if user has not enough permissions', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(false);
+
+    await expect(revoke(ctx, {})).rejects.toThrowError(/not found/);
+  });
+
+  it('should throw a 404 error if uaa user is not found', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+    MockUAAClient.prototype.getUser.mockReturnValueOnce(null);
+
+    await expect(revoke(ctx, {})).rejects.toThrowError(/token not found/);
+  });
+
+  it('should throw a 404 error if uaa user is not a token', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+    MockUAAClient.prototype.getUser.mockReturnValueOnce(mockUAAUser);
+
+    await expect(revoke(ctx, {})).rejects.toThrowError(/token not found/);
+  });
+
+  it('should revoke the token after confirmation', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+    MockUAAClient.prototype.getUser.mockReturnValueOnce(mockUAAUserToken);
+    MockCFClient.prototype.setOrganizationRole.mockReturnValueOnce(null);
+
+    const response = await revoke(ctx, {});
+
+    expect(response.status).toBeUndefined();
+    expect(response.body).toContain('Successfully revoked an API Token');
+    expect(spacesMissingAroundInlineElements(response.body as string)).toHaveLength(0);
+  });
+});
+
+describe(compose, () => {
+  beforeEach(() => {
+    MockCFClient.mockClear();
+  });
+
+  it('should throw a 404 error if user has not enough permissions', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(false);
+
+    await expect(compose(ctx, {})).rejects.toThrowError(/not found/);
+  });
+
+  it('should revoke the token after confirmation', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+
+    const response = await compose(ctx, {});
+
+    expect(response.status).toBeUndefined();
+    expect(response.body).toContain('Create new API Token');
+    expect(spacesMissingAroundInlineElements(response.body as string)).toHaveLength(0);
+  });
+});
+
+describe(create, () => {
+  beforeEach(() => {
+    MockCFClient.mockClear();
+  });
+
+  it('should throw a 404 error if user has not enough permissions', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(false);
+
+    await expect(create(ctx, {}, { name: '' })).rejects.toThrowError(/not found/);
+  });
+
+  it('should throw a validation error if token name is empty', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+
+    const response = await create(ctx, {}, { name: '' });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toContain('Create new API Token');
+    expect(spacesMissingAroundInlineElements(response.body as string)).toHaveLength(0);
+  });
+
+  it('should throw a validation error if token name is not valid', async () => {
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+
+    const response = await create(ctx, {}, { name: '<script>alert("pwnd");</script>' });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toContain('Create new API Token');
+    expect(response.body).not.toContain('<script>alert("pwnd");</script>');
+    expect(spacesMissingAroundInlineElements(response.body as string)).toHaveLength(0);
+  });
+
+  it('should successfully create API Token', async () => {
+    const tokenName = 'deployer';
+
+    MockCFClient.prototype.organization.mockReturnValueOnce(mockOrganization);
+    MockCFClient.prototype.hasOrganizationRole.mockReturnValueOnce(true);
+    MockUAAClient.prototype.createUser.mockImplementation((username: string, password: string) => {
+      const numberOfHyphensBetweenName = 2;
+      const usernameLength = DEFAULT_KEY_LENGTH + numberOfHyphensBetweenName
+        + mockOrganization.entity.name.length + tokenName.length;
+
+      if (username.length !== usernameLength || password.length !== DEFAULT_SECRET_LENGTH) {
+        throw new Error(`Either Key or Secret were incorrectly generated. Got:
+        Key:    "${username}" <${username.length} / ${usernameLength}>
+        Secret: "${password}" <${password.length} / ${DEFAULT_SECRET_LENGTH}>`);
+      }
+
+      return mockUAAUserToken;
+    });
+    MockCFClient.prototype.createUser.mockReturnValueOnce(mockToken);
+    MockCFClient.prototype.assignUserToOrganization.mockReturnValueOnce(null);
+
+    const response = await create(ctx, {}, { name: tokenName });
+
+    expect(response.status).toBeUndefined();
+    expect(response.body).toContain('Successfully generted token secret');
+    expect(spacesMissingAroundInlineElements(response.body as string)).toHaveLength(0);
+  });
+});

--- a/src/components/api-tokens/controllers.tsx
+++ b/src/components/api-tokens/controllers.tsx
@@ -1,0 +1,257 @@
+import React from 'react';
+
+import { SLUG_REGEX, Template } from '../../layouts';
+import CloudFoundryClient from '../../lib/cf';
+import { IParameters, IResponse, NotFoundError } from '../../lib/router';
+import UAAClient from '../../lib/uaa';
+import { IContext } from '../app';
+import { CLOUD_CONTROLLER_ADMIN } from '../auth';
+import { fromOrg } from '../breadcrumbs';
+import { SuccessPage } from '../shared';
+
+import { generateKey, generateSecret } from './token';
+import { ConfirmAction, CreateAPIToken, ExposeSecret, ListTokens } from './views';
+
+interface ICreateUserBody {
+  readonly name: string;
+}
+
+async function checkIfAuthorised(ctx: IContext, cf: CloudFoundryClient, organizationGUID: string): Promise<void> {
+  const isAdmin = ctx.token.hasAnyScope(CLOUD_CONTROLLER_ADMIN);
+  const isManager = await cf.hasOrganizationRole(organizationGUID, ctx.token.userID, 'org_manager');
+
+  if (!isAdmin && !isManager) {
+    throw new NotFoundError('not found');
+  }
+}
+
+export function isTokenUser(organizationName: string, name: string): boolean {
+  const regex = /^.+?-[a-z0-9]{8}$/;
+
+  return name.startsWith(organizationName) && regex.test(name);
+}
+
+function tokenName(organization: string, name: string): string {
+  return name.replace(`${organization}-`, '').slice(0, -9);
+}
+
+export async function list(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const organization = await cf.organization(params.organizationGUID);
+
+  await checkIfAuthorised(ctx, cf, organization.metadata.guid);
+
+  const users = await cf.usersForOrganization(organization.metadata.guid);
+  const tokens = users.filter(user => isTokenUser(organization.entity.name, user.entity.username));
+
+  const template = new Template(ctx.viewContext, 'API Tokens');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    { text: 'API Tokens' },
+  ]);
+
+  return {
+    body: template.render(
+      <ListTokens
+        linkTo={ctx.linkTo}
+        organization={organization}
+        tokens={tokens}
+      />,
+    ),
+  };
+}
+
+export async function confirmRevocation(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const uaa = new UAAClient({
+    apiEndpoint: ctx.app.uaaAPI,
+    clientCredentials: {
+      clientID: ctx.app.oauthClientID,
+      clientSecret: ctx.app.oauthClientSecret,
+    },
+  });
+
+  const organization = await cf.organization(params.organizationGUID);
+
+  await checkIfAuthorised(ctx, cf, organization.metadata.guid);
+
+  const token = await uaa.getUser(params.tokenGUID);
+  if (!token || !isTokenUser(organization.entity.name, token.userName)) {
+    throw new NotFoundError('token not found');
+  }
+
+  const template = new Template(ctx.viewContext, 'Are you sure you\'d like to revoke the following API Token?');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.tokens.list', { organizationGUID: organization.metadata.guid }),
+      text: 'API Tokens',
+    },
+    { text: tokenName(organization.entity.name, token.userName) },
+  ]);
+
+  return {
+    body: template.render(
+      <ConfirmAction
+        action="revoke"
+        csrf={ctx.viewContext.csrf}
+        linkTo={ctx.linkTo}
+        organization={organization}
+        token={token}
+      />,
+    ),
+  };
+}
+
+export async function revoke(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const uaa = new UAAClient({
+    apiEndpoint: ctx.app.uaaAPI,
+    clientCredentials: {
+      clientID: ctx.app.oauthClientID,
+      clientSecret: ctx.app.oauthClientSecret,
+    },
+  });
+
+  const organization = await cf.organization(params.organizationGUID);
+
+  await checkIfAuthorised(ctx, cf, organization.metadata.guid);
+
+  const token = await uaa.getUser(params.tokenGUID);
+  if (!token || !isTokenUser(organization.entity.name, token.userName)) {
+    throw new NotFoundError('token not found');
+  }
+
+  await cf.setOrganizationRole(organization.metadata.guid, token.id, 'users', false);
+
+  const template = new Template(ctx.viewContext, 'Successfully revoked an API Token');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.tokens.list', { organizationGUID: organization.metadata.guid }),
+      text: 'API Tokens',
+    },
+    { text: 'Revoke API Token' },
+  ]);
+
+  return {
+    body: template.render(
+      <SuccessPage
+        heading="Successfully revoked an API Token"
+      />,
+    ),
+  };
+}
+
+export async function compose(ctx: IContext, params: IParameters): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const organization = await cf.organization(params.organizationGUID);
+
+  await checkIfAuthorised(ctx, cf, organization.metadata.guid);
+
+  const template = new Template(ctx.viewContext, 'Create new API Token');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.tokens.list', { organizationGUID: organization.metadata.guid }),
+      text: 'API Tokens',
+    },
+    { text: 'Create API Token' },
+  ]);
+
+  return {
+    body: template.render(
+      <CreateAPIToken
+        csrf={ctx.viewContext.csrf}
+        organization={organization}
+      />,
+    ),
+  };
+}
+
+export async function create(ctx: IContext, params: IParameters, body: ICreateUserBody): Promise<IResponse> {
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const uaa = new UAAClient({
+    apiEndpoint: ctx.app.uaaAPI,
+    clientCredentials: {
+      clientID: ctx.app.oauthClientID,
+      clientSecret: ctx.app.oauthClientSecret,
+    },
+  });
+
+  const organization = await cf.organization(params.organizationGUID);
+
+  await checkIfAuthorised(ctx, cf, organization.metadata.guid);
+
+  if (!body.name || !body.name.match(SLUG_REGEX)) {
+    const template = new Template(ctx.viewContext, 'Error: Create new API Token');
+    template.breadcrumbs = fromOrg(ctx, organization, [
+      {
+        href: ctx.linkTo('admin.organizations.tokens.list', { organizationGUID: organization.metadata.guid }),
+        text: 'API Tokens',
+      },
+      { text: 'Create API Token' },
+    ]);
+
+    return {
+      body: template.render(
+        <CreateAPIToken
+          csrf={ctx.viewContext.csrf}
+          error={true}
+          organization={organization}
+          values={body}
+        />,
+      ),
+      status: 400,
+    };
+  }
+
+  const tokenKey = generateKey(organization.entity.name, body.name);
+  const tokenSecret = generateSecret();
+
+  const uaaUser = await uaa.createUser(tokenKey, tokenSecret);
+  const user = await cf.createUser(uaaUser.id);
+  await cf.assignUserToOrganization(organization.metadata.guid, user.metadata.guid);
+
+  const template = new Template(ctx.viewContext, 'Successfully generted token secret');
+  template.breadcrumbs = fromOrg(ctx, organization, [
+    {
+      href: ctx.linkTo('admin.organizations.tokens.list', { organizationGUID: organization.metadata.guid }),
+      text: 'API Tokens',
+    },
+    { text: tokenName(organization.entity.name, tokenKey) },
+  ]);
+
+  return {
+    body: template.render(
+      <ExposeSecret
+        linkTo={ctx.linkTo}
+        organization={organization}
+        tokenKey={tokenKey}
+        tokenSecret={tokenSecret}
+        userGUID={user.metadata.guid}
+      />,
+    ),
+  };
+}

--- a/src/components/api-tokens/index.ts
+++ b/src/components/api-tokens/index.ts
@@ -1,0 +1,1 @@
+export * from './controllers';

--- a/src/components/api-tokens/token.test.ts
+++ b/src/components/api-tokens/token.test.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_KEY_LENGTH, DEFAULT_SECRET_LENGTH, generateKey, generateSecret } from './token';
+
+describe(generateKey, () => {
+  it('should generate a different key each time', () => {
+    const org = 'govuk-paas';
+    const key1 = generateKey(org, 'prod', DEFAULT_KEY_LENGTH);
+    const key2 = generateKey(org, 'staging', DEFAULT_KEY_LENGTH);
+    const key3 = generateKey(org, 'dev', DEFAULT_KEY_LENGTH);
+    const key4 = generateKey(org, 'dev', DEFAULT_KEY_LENGTH);
+
+    expect(key1).toMatch(/govuk-paas-prod-[a-z0-9]{8}/);
+    expect(key2).toMatch(/govuk-paas-staging-[a-z0-9]{8}/);
+    expect(key3).toMatch(/govuk-paas-dev-[a-z0-9]{8}/);
+    expect(key4).toMatch(/govuk-paas-dev-[a-z0-9]{8}/);
+    expect(key4).not.toEqual(key3);
+  });
+});
+
+describe(generateSecret, () => {
+  it('should generate a different token each time', () => {
+    const token1 = generateSecret();
+    const token2 = generateSecret();
+    const token3 = generateSecret(32);
+
+    expect(token1).not.toEqual(token2);
+    expect(token1).not.toEqual(token3);
+    expect(token2).not.toEqual(token3);
+
+    expect(token1).toHaveLength(DEFAULT_SECRET_LENGTH);
+    expect(token2).toHaveLength(DEFAULT_SECRET_LENGTH);
+    expect(token3).toHaveLength(32);
+  });
+});

--- a/src/components/api-tokens/token.ts
+++ b/src/components/api-tokens/token.ts
@@ -1,0 +1,14 @@
+import { randomBytes } from 'crypto';
+
+export const DEFAULT_KEY_LENGTH = 8;
+export const DEFAULT_SECRET_LENGTH = 64;
+
+export function generateKey(prefix: string, name: string, length = DEFAULT_KEY_LENGTH): string {
+  const key = randomBytes(length / 2).toString('hex');
+
+  return `${prefix}-${name}-${key}`;
+}
+
+export function generateSecret(length = DEFAULT_SECRET_LENGTH): string {
+  return randomBytes(length / 2).toString('hex');
+}

--- a/src/components/api-tokens/views.test.tsx
+++ b/src/components/api-tokens/views.test.tsx
@@ -1,0 +1,99 @@
+import { shallow } from 'enzyme';
+import moment from 'moment';
+import React from 'react';
+
+import { DATE_TIME } from '../../layouts';
+import { IOrganization, IOrganizationUserRoles } from '../../lib/cf/types';
+import { IParameters } from '../../lib/router';
+import { IUaaUser } from '../../lib/uaa';
+
+import { ConfirmAction, CreateAPIToken, ExposeSecret, ListTokens } from './views';
+
+const linker = (route: string, params?: IParameters): string =>
+  `__LINKS_TO_${route}_WITH_${new URLSearchParams(params)}`;
+
+const organization = {
+  entity: { name: 'org-name' },
+  metadata: { guid: '__ORG_GUID__' },
+} as IOrganization;
+
+describe(ListTokens, () => {
+  const token = {
+    entity: { username: 'token-name' },
+    metadata: { created_at: '2020-01-01T12:00:00', guid: '__TOKEN_GUID__' },
+  } as IOrganizationUserRoles;
+
+  it('should correctly parse the element', () => {
+    const markup = shallow(<ListTokens
+      linkTo={linker}
+      organization={organization}
+      tokens={[ token ]}
+    />);
+
+    expect(markup.find('a').first().text()).toEqual('Create a new API Token');
+    expect(markup.render().find('tr').last().find('th').text()).toContain(token.entity.username);
+    expect(markup.render().find('tr td').text()).toContain('Not retreivable');
+    expect(markup.render().find('tr td').text()).toContain(moment(token.metadata.created_at).format(DATE_TIME));
+    expect(markup.render().find('tr td').text()).toContain('Revoke');
+  });
+});
+
+describe(ExposeSecret, () => {
+  it('should correctly parse the element', () => {
+    const markup = shallow(<ExposeSecret
+      linkTo={linker}
+      organization={organization}
+      tokenKey="__API_TOKEN_KEY__"
+      tokenSecret="__API_TOKEN_SECRET__"
+      userGUID="__USER_GUID__"
+    />);
+
+    expect(markup.find('dl div').at(0).find('dd code').text()).toEqual('__API_TOKEN_KEY__');
+    expect(markup.find('dl div').at(0).find('dd code').text()).toEqual('__API_TOKEN_KEY__');
+    expect(markup.find('a').at(0).text()).toEqual('Manage token permissions');
+  });
+});
+
+describe(ConfirmAction, () => {
+  const token = { userName: 'token-name' } as IUaaUser;
+  it('should correctly parse the element', () => {
+    const markup = shallow(<ConfirmAction
+      action="revoke"
+      csrf="__CSRF_TOKEN__"
+      linkTo={linker}
+      organization={organization}
+      token={token}
+    />);
+
+    expect(markup.render().find('input[name=_csrf]').prop('value')).toEqual('__CSRF_TOKEN__');
+    expect(markup.find('h2').text()).toEqual('Are you sure you\'d like to revoke the following API Token?');
+    expect(markup.find('form button').text()).toEqual('Yes, revoke API Token');
+  });
+});
+
+describe(CreateAPIToken, () => {
+  it('should correctly parse the element', () => {
+    const markup = shallow(<CreateAPIToken
+      csrf="__CSRF_TOKEN__"
+      organization={organization}
+    />);
+
+    expect(markup.html()).not.toContain('error');
+    expect(markup.render().find('input[name=_csrf]').prop('value')).toEqual('__CSRF_TOKEN__');
+  });
+
+  it('should correctly parse the element when there are errors', () => {
+    const markup = shallow(<CreateAPIToken
+      csrf="__CSRF_TOKEN__"
+      error={true}
+      organization={organization}
+      values={{ name: '<script>alert("pwnd");</script>' }}
+    />);
+
+    expect(markup.html()).toContain('error');
+    expect(markup.render().find('input[name=_csrf]').prop('value')).toEqual('__CSRF_TOKEN__');
+    expect(markup.render().find('.govuk-error-message').text()).toEqual(
+      'Error: API Token name needs to be a combination of lowercase alphanumeric characters separated by hyphen.',
+    );
+  });
+});

--- a/src/components/api-tokens/views.tsx
+++ b/src/components/api-tokens/views.tsx
@@ -21,7 +21,7 @@ interface IExposeSecretProperties {
 }
 
 interface IConfirmActionProperties {
-  readonly action: 'revoke';
+  readonly action: 'rotate' | 'revoke';
   readonly csrf: string;
   readonly linkTo: RouteLinker;
   readonly organization: IOrganization;
@@ -105,7 +105,18 @@ export function ListTokens(props: IListTokensProperties): ReactElement {
                     <td className="govuk-table__cell">
                       <span className="govuk-visually-hidden">API Token:</span>
                       {' '}
-                      Not retreivable
+                      Not retreivable -
+                      {' '}
+                      <a
+                        href={props.linkTo('admin.organizations.tokens.rotate.confirm', {
+                          organizationGUID: props.organization.metadata.guid,
+                          tokenGUID: token.metadata.guid,
+                        })}
+                        title="Rotate the API Token Secret"
+                        className="govuk-link"
+                      >
+                        Rotate
+                      </a>
                     </td>
                     <td className="govuk-table__cell">
                       <span className="govuk-visually-hidden">API Token created at:</span>
@@ -145,6 +156,7 @@ export function ExposeSecret(props: IExposeSecretProperties): ReactElement {
         <h2 className="govuk-heading-m">API Token</h2>
 
         <p className="govuk-body">Please take a note of the secret as it will only be exposed once.</p>
+        <p className="govuk-body">If you happen to lose your secret, you will be able to rotate the secret later.</p>
 
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key"><span className="govuk-visually-hidden">API Token</span> Key</dt>

--- a/src/components/api-tokens/views.tsx
+++ b/src/components/api-tokens/views.tsx
@@ -1,0 +1,299 @@
+import moment from 'moment';
+import React, { ReactElement } from 'react';
+
+import { DATE_TIME, SLUG_REGEX } from '../../layouts';
+import { IOrganization, IOrganizationUserRoles } from '../../lib/cf/types';
+import { IUaaUser } from '../../lib/uaa';
+import { RouteLinker } from '../app';
+
+interface IListTokensProperties {
+  readonly linkTo: RouteLinker;
+  readonly organization: IOrganization;
+  readonly tokens: ReadonlyArray<IOrganizationUserRoles>;
+}
+
+interface IExposeSecretProperties {
+  readonly linkTo: RouteLinker;
+  readonly organization: IOrganization;
+  readonly tokenKey: string;
+  readonly tokenSecret: string;
+  readonly userGUID: string;
+}
+
+interface IConfirmActionProperties {
+  readonly action: 'revoke';
+  readonly csrf: string;
+  readonly linkTo: RouteLinker;
+  readonly organization: IOrganization;
+  readonly token: IUaaUser;
+}
+
+interface ICreateAPITokenProperties {
+  readonly csrf: string;
+  readonly error?: boolean;
+  readonly organization: IOrganization;
+  readonly values?: {
+    readonly name?: string;
+  };
+}
+
+export function ListTokens(props: IListTokensProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-full">
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <h1 className="govuk-heading-l">API Tokens</h1>
+
+          <p className="govuk-body">
+            API Tokens can be used as robot users for tooling such as Continuous Delivery. For instance, a GitHub
+            Actions pipeline capable of deploying an applciation after passing defined set of tests.
+          </p>
+          <p className="govuk-body">
+            Each API Token has it&apos;s own set of permissions much like the individual users.
+          </p>
+        </div>
+
+        <div className="govuk-grid-column-one-third text-right">
+          <a
+            href={props.linkTo('admin.organizations.tokens.create', {
+              organizationGUID: props.organization.metadata.guid,
+            })}
+            role="button"
+            draggable="false"
+            className="govuk-button"
+            data-module="govuk-button"
+          >
+            Create a new API Token
+          </a>
+        </div>
+      </div>
+
+      <h2 className="govuk-heading-m">Current API Tokens</h2>
+      {props.tokens.length > 0
+        ? <div className="scrollable-table-container">
+            <table className="govuk-table user-list-table">
+              <thead className="govuk-table__head">
+                <tr className="govuk-table__row">
+                  <th className="govuk-table__header key" scope="col">
+                    API Token Key
+                  </th>
+                  <th className="govuk-table__header secret" scope="col">
+                    API Token Secret
+                  </th>
+                  <th className="govuk-table__header created" scope="col">
+                    Created At
+                  </th>
+                  <th className="govuk-table__header revoke" scope="col">
+                    Revoke
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="govuk-table__body">
+                {props.tokens.map(token => (
+                  <tr key={token.metadata.guid} className="govuk-table__row">
+                    <th scope="row" className="govuk-table__header govuk-table__header--non-bold">
+                      <a
+                        href={props.linkTo('admin.organizations.users.edit', {
+                          organizationGUID: props.organization.metadata.guid,
+                          userGUID: token.metadata.guid,
+                        })}
+                        className="govuk-link"
+                      >
+                        <span className="govuk-visually-hidden">API Token:</span> {token.entity.username}
+                      </a>
+                    </th>
+                    <td className="govuk-table__cell">
+                      <span className="govuk-visually-hidden">API Token:</span>
+                      {' '}
+                      Not retreivable
+                    </td>
+                    <td className="govuk-table__cell">
+                      <span className="govuk-visually-hidden">API Token created at:</span>
+                      {' '}
+                      {moment(token.metadata.created_at).format(DATE_TIME)}
+                    </td>
+                    <td className="govuk-table__cell">
+                      <a
+                        href={props.linkTo('admin.organizations.tokens.revoke.confirm', {
+                          organizationGUID: props.organization.metadata.guid,
+                          tokenGUID: token.metadata.guid,
+                        })}
+                        title="Revoke the API Token"
+                        className="govuk-link"
+                      >
+                        Revoke
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        : <p className="govuk-body">There are no tokens in tour organisation.</p>}
+    </div>
+  </div>;
+}
+
+export function ExposeSecret(props: IExposeSecretProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-two-thirds">
+      <div className="govuk-panel govuk-panel--confirmation">
+        <h1 className="govuk-panel__title">Successfully generted token secret</h1>
+      </div>
+
+      <dl className="govuk-summary-list govuk-summary-list--no-border">
+        <h2 className="govuk-heading-m">API Token</h2>
+
+        <p className="govuk-body">Please take a note of the secret as it will only be exposed once.</p>
+
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key"><span className="govuk-visually-hidden">API Token</span> Key</dt>
+          <dd className="govuk-summary-list__value">
+            <code style={{ whiteSpace: 'nowrap' }}>{props.tokenKey}</code>
+          </dd>
+        </div>
+
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key"><span className="govuk-visually-hidden">API Token</span> Secret</dt>
+          <dd className="govuk-summary-list__value">
+            <code style={{ whiteSpace: 'nowrap' }}>{props.tokenSecret}</code>
+          </dd>
+        </div>
+      </dl>
+
+      <h2 className="govuk-heading-m">More actions</h2>
+      <a
+        href={props.linkTo('admin.organizations.users.edit', {
+          organizationGUID: props.organization.metadata.guid,
+          userGUID: props.userGUID,
+        })}
+        role="button"
+        draggable="false"
+        className="govuk-button"
+        data-module="govuk-button"
+      >
+        Manage token permissions
+      </a>
+    </div>
+  </div>;
+}
+
+export function ConfirmAction(props: IConfirmActionProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-two-thirds">
+      <form method="post" className="govuk-!-mt-r6 paas-remove-user">
+        <input type="hidden" name="_csrf" value={props.csrf} />
+        <h2 className="govuk-heading-l">
+          Are you sure you&apos;d like to {props.action} the following API Token?
+        </h2>
+
+        <p className="govuk-heading-m">{props.token.userName}</p>
+
+        <button
+          className="govuk-button govuk-button--warning"
+          data-module="govuk-button"
+          data-prevent-double-click={true}
+        >
+          Yes, {props.action} API Token
+        </button>
+
+        <a
+          href={props.linkTo('admin.organizations.tokens.list', {
+            organizationGUID: props.organization.metadata.guid,
+          })}
+          className="govuk-link"
+        >
+          No, go back to API Token list
+        </a>
+      </form>
+    </div>
+  </div>;
+}
+
+export function CreateAPIToken(props: ICreateAPITokenProperties): ReactElement {
+  return <div className="govuk-grid-row">
+    <div className="govuk-grid-column-full">
+      <h1 className="govuk-heading-l">
+        Create new API Token
+      </h1>
+    </div>
+
+    <div className="govuk-grid-column-one-half">
+      <form method="post" noValidate={true}>
+        {props.error
+          ? <div
+              className="govuk-error-summary"
+              aria-labelledby="error-summary-title"
+              role="alert"
+              tabIndex={-1}
+              data-module="govuk-error-summary"
+            >
+              <h2 className="govuk-error-summary__title" id="error-summary-title">
+                There is a problem
+              </h2>
+
+              <div className="govuk-error-summary__body">
+                <ul className="govuk-list govuk-error-summary__list">
+                  <li>
+                    <a href="#name">
+                      API Token name needs to be a combination of lowercase alphanumeric characters separated by hyphen.
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          : <></>}
+
+        <input type="hidden" name="_csrf" value={props.csrf} />
+
+        <div className={`govuk-form-group ${props.error ? 'govuk-form-group--error' : ''}`}>
+          <label className="govuk-label" htmlFor="name">
+            Name
+          </label>
+          <span id="name-hint" className="govuk-hint">
+            Must be a combination of lowercase alphanumeric characters separated by hyphen (<code>-</code>).
+          </span>
+          {props.error
+            ? <span id="name-error" className="govuk-error-message">
+                <span className="govuk-visually-hidden">Error:</span>{' '}
+                API Token name needs to be a combination of lowercase alphanumeric characters separated by hyphen.
+              </span>
+            : <></>}
+          <input
+            className={`govuk-input ${props.error ? 'govuk-input--error' : ''}`}
+            id="name"
+            name="name"
+            type="text"
+            spellCheck={false}
+            aria-describedby={`name-hint ${props.error ? 'name-error' : ''}`}
+            pattern={SLUG_REGEX}
+            required={true}
+            defaultValue={props.values?.name}
+          />
+        </div>
+
+        <button className="govuk-button" data-module="govuk-button" data-prevent-double-click={true}>
+          Create API Token
+        </button>
+      </form>
+    </div>
+
+    <div className="govuk-grid-column-one-half">
+      <p className="govuk-body">
+        The name for a robot user. This name will later be prefixed with the
+        organisation name and suffixed with a randomly generated 8 alphanumeric
+        string, composing end result of <code style={{ whiteSpace: 'nowrap' }}>
+          {props.organization.entity.name}-NAME-a1b2c3d4
+        </code>.
+      </p>
+
+      <p className="govuk-body">
+        After creating the API Token, you will receive a API Token Key and Secret.
+      </p>
+
+      <p className="govuk-body">
+        You should take a note of that, as the API Token Secret is not retreivable.
+      </p>
+    </div>
+  </div>;
+}

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -383,6 +383,17 @@ export const router = new Router([
     path: '/organisations/:organizationGUID/tokens/new',
   },
   {
+    action: apiTokens.confirmRotation,
+    name: 'admin.organizations.tokens.rotate.confirm',
+    path: '/organisations/:organizationGUID/tokens/:tokenGUID',
+  },
+  {
+    action: apiTokens.rotate,
+    method: 'post',
+    name: 'admin.organizations.tokens.rotate',
+    path: '/organisations/:organizationGUID/tokens/:tokenGUID',
+  },
+  {
     action: apiTokens.confirmRevocation,
     name: 'admin.organizations.tokens.revoke.confirm',
     path: '/organisations/:organizationGUID/tokens/:tokenGUID/revoke',

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -1,5 +1,6 @@
 import Router, { IParameters, IResponse } from '../../lib/router';
 import * as account from '../account';
+import * as apiTokens from '../api-tokens';
 import * as applicationEvents from '../application-events';
 import * as applications from '../applications';
 import * as marketplace from '../marketplace';
@@ -364,6 +365,33 @@ export const router = new Router([
     method: 'post',
     name: 'support.sign-up.post',
     path: '/support/sign-up',
+  },
+  {
+    action: apiTokens.list,
+    name: 'admin.organizations.tokens.list',
+    path: '/organisations/:organizationGUID/tokens',
+  },
+  {
+    action: apiTokens.compose,
+    name: 'admin.organizations.tokens.compose',
+    path: '/organisations/:organizationGUID/tokens/new',
+  },
+  {
+    action: apiTokens.create,
+    method: 'post',
+    name: 'admin.organizations.tokens.create',
+    path: '/organisations/:organizationGUID/tokens/new',
+  },
+  {
+    action: apiTokens.confirmRevocation,
+    name: 'admin.organizations.tokens.revoke.confirm',
+    path: '/organisations/:organizationGUID/tokens/:tokenGUID/revoke',
+  },
+  {
+    action: apiTokens.revoke,
+    method: 'post',
+    name: 'admin.organizations.tokens.revoke',
+    path: '/organisations/:organizationGUID/tokens/:tokenGUID/revoke',
   },
 ]);
 

--- a/src/components/org-users/controllers.test.tsx
+++ b/src/components/org-users/controllers.test.tsx
@@ -1099,7 +1099,7 @@ describe('org-users test suite', () => {
       .reply(200, JSON.stringify(defaultOrg()))
 
       .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/user_roles')
-      .times(3)
+      .times(2)
       .reply(200, cfData.userRolesForOrg);
 
     const response = await orgUsers.editUser(ctx, {
@@ -1157,7 +1157,7 @@ describe('org-users test suite', () => {
       .reply(200, JSON.stringify(defaultOrg()))
 
       .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/user_roles')
-      .times(3)
+      .times(2)
       .reply(200, cfData.userRolesForOrgWithOneManager);
 
     const response = await orgUsers.editUser(ctx, {
@@ -1197,7 +1197,7 @@ describe('org-users test suite', () => {
   it('should fail to show the user edit page due to not existing user', async () => {
     nockCF
       .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/user_roles')
-      .times(3)
+      .times(2)
       .reply(200, cfData.userRolesForOrg)
 
       .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/spaces')
@@ -1210,35 +1210,6 @@ describe('org-users test suite', () => {
       orgUsers.editUser(ctx, {
         organizationGUID: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
         userGUID: 'not-existing-user',
-      }),
-    ).rejects.toThrow(/user not found/);
-  });
-
-  it('should fail to show the user edit page due to not existing paas-accounts user', async () => {
-    nockUAA
-      .get('/Users/uaa-user-edit-123456')
-      .reply(200, uaaData.usersByEmail)
-
-      .post('/oauth/token?grant_type=client_credentials')
-      .reply(200, '{"access_token": "FAKE_ACCESS_TOKEN"}');
-
-    nockAccounts.get('/users/uaa-user-edit-123456').reply(404, '{}');
-
-    nockCF
-      .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/spaces')
-      .reply(200, cfData.spaces)
-
-      .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20')
-      .reply(200, JSON.stringify(defaultOrg()))
-
-      .get('/v2/organizations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/user_roles')
-      .times(3)
-      .reply(200, cfData.userRolesForOrg);
-
-    await expect(
-      orgUsers.editUser(ctx, {
-        organizationGUID: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-        userGUID: 'uaa-user-edit-123456',
       }),
     ).rejects.toThrow(/user not found/);
   });

--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -44,6 +44,7 @@ import {
   OrganizationUsersPage,
   SuccessPage,
 } from './views';
+import { isTokenUser } from '../api-tokens/controllers';
 
 interface IPostPermissions {
   readonly [guid: string]: {
@@ -313,7 +314,8 @@ export async function listUsers(
     accountsClient,
   );
 
-  const uaaUsers = await uaa.getUsers(userOrgRoles.map(u => u.metadata.guid));
+  const notRobotUsers = userOrgRoles.filter(u => !isTokenUser(organization.entity.name, u.entity.username));
+  const uaaUsers = await uaa.getUsers(notRobotUsers.map(u => u.metadata.guid));
   const users = _excludeUsersWithoutUaaRecord(
     userRolesByGuid,
     uaaUsers,

--- a/src/components/spaces/controllers.tsx
+++ b/src/components/spaces/controllers.tsx
@@ -28,6 +28,7 @@ import {
   IStripedUserServices,
   SpacesPage,
 } from './views';
+import { isTokenUser } from '../api-tokens';
 
 function buildURL(route: IRoute): string {
   return [route.host, route.domain.name].filter(x => x).join('.') + route.path;
@@ -418,7 +419,7 @@ export async function listSpaces(
         linkTo={ctx.linkTo}
         organization={summarisedOrganization}
         spaces={summarisedSpaces}
-        users={users}
+        users={users.filter(u => !isTokenUser(organization.entity.name, u.entity.username))}
       />,
     ),
   };

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -245,6 +245,19 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
               members
             </a>
           </p>
+
+          {props.isAdmin || props.isManager
+            ? <p className="govuk-body">
+                <a
+                  href={props.linkTo('admin.organizations.tokens.list', {
+                    organizationGUID: props.organization.metadata.guid,
+                  })}
+                  className="govuk-link"
+                >
+                  View and manage API Tokens
+                </a>
+              </p>
+            : <></>}
         </div>
 
         <div className="govuk-grid-column-one-third">

--- a/src/lib/uaa/uaa.test.ts
+++ b/src/lib/uaa/uaa.test.ts
@@ -317,4 +317,18 @@ describe('lib/uaa test suite', () => {
     const user = await client.resetPassword('FAKE_PASSWORD_RESET_CODE', 'myNewPassword123!');
     expect(user.id).toEqual('FAKE_USER_GUID');
   });
+
+  it('should successfully call /Users/${userGUID}/password', async () => {
+    nockUAA
+      .post('/oauth/token')
+      .query((x: any) => x.grant_type === 'client_credentials')
+      .reply(200, { access_token: 'FAKE_ACCESS_TOKEN' })
+
+      .put('/Users/FAKE_USER_GUID/password')
+      .reply(200, {});
+
+    const client = new UAAClient(config);
+    const user = await client.forceSetPassword('FAKE_USER_GUID', 'myNewPassword123!');
+    expect(user).toBeDefined();
+  });
 });

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -317,4 +317,10 @@ export default class UAAClient {
 
     return response.data;
   }
+
+  public async forceSetPassword(userGUID: string, password: string): Promise<object> {
+    const response = await this.request('put', `/Users/${userGUID}/password`, { data: { password } });
+
+    return response.data;
+  }
 }


### PR DESCRIPTION
What
----

We’d like to have the ability of modification permissions for users that
are not necessarily humans. PaaS Accounts requirement is restricting
this from happening.

We’re still logging, whilst not throwing any errors.

Users started to come into the support, asking for non-email based users
which could be used for their CI systems to interact with PaaS.

This feature, is simply based on the username and password system, but
relies on specific user naming, in order to differentiate between the
Users and Tokens.

An Admin and Org Manager should be able to create unlimited number of
these tokens, retreive the Key and Secret, setup the permissions for
Robot User and use the feature as they would with a google group user.

Now that we are able to have API Tokens, we don't necessarily want to
display them on the same list as the users. This could be confusing.
Filtering out by name should allow us to have the correct numbers in
place.

[WIP]

It would be great if the feature allowed for easy rotation of the
secret.

At the moment, this could be achieved by deleting the user and
re-creating. This however could be problematic when one would want to
replicate the permissions of the deleted user - especially when revoking
the token and not noting what access it used to have.

This feature however, would require either an Admin token, or the Pazmin
tool to have `uaa.admin` permissions, which it currently doesn't have.

How to review
-------------

- Sanity check the idea
- Deploy to your environment
- Attempt to use the feature
  - Create token
  - Rotate token
  - Revoke token
  - List users - see no tokens
  - List tokens - see no users
