### PR TITLE
Tweak marketplace service title & heading

### DIFF
--- a/src/components/marketplace/controllers.tsx
+++ b/src/components/marketplace/controllers.tsx
@@ -48,7 +48,7 @@ export async function viewService(ctx: IContext, params: IParameters): Promise<I
 
   const template = new Template(
     ctx.viewContext,
-    `Service ${service.broker_catalog.metadata.displayName} ${version}`,
+    `Service ${service.broker_catalog.metadata.displayName} Version ${version}`,
   );
 
   template.breadcrumbs = [

--- a/src/components/marketplace/views.tsx
+++ b/src/components/marketplace/views.tsx
@@ -338,7 +338,7 @@ export function MarketplaceItemPage(props: IMarketplaceItemPageProperties): Reac
             <span className="govuk-visually-hidden">Service</span>{' '}
             {props.service.broker_catalog.metadata.displayName || props.service.name}
           </span>{' '}
-          {props.version}
+          Version {props.version}
         </h1>
 
         <p className="govuk-body">{props.service.broker_catalog.metadata.longDescription}</p>


### PR DESCRIPTION
What
----

Include the word 'Version" in both as it is in the tab link. Having just the number isn't as telling.

**Before**

<img width="651" alt="before" src="https://user-images.githubusercontent.com/3758555/91080506-92e38800-e63d-11ea-9c58-93aaae1a17d1.png">

**After**

<img width="553" alt="Screenshot 2020-08-24 at 19 09 17" src="https://user-images.githubusercontent.com/3758555/91080561-a5f65800-e63d-11ea-9354-08d2645a3b9f.png">


How to review
-------------
- got to a service in marketplace
- compare title and main heading to see if they match and include the word 'Version'

Who can review
---------------

not @kr8n3r 
