### PR TITLE
Update org manage quota page

### DIFF
--- a/src/components/organizations/controllers.tsx
+++ b/src/components/organizations/controllers.tsx
@@ -74,7 +74,7 @@ export async function editOrgQuota(ctx: IContext, params: IParameters): Promise<
   ]);
 
   const realQuotas = quotas.filter(quota => !quota.name.match(/^(CATS|ACC|BACC|SMOKE|PERF|AIVENBACC)-/));
-  const template = new Template(ctx.viewContext, `Organisation ${organization.entity.name}`);
+  const template = new Template(ctx.viewContext, `Organisation ${organization.entity.name} Manage Quota`);
 
   template.breadcrumbs = [
     { href: ctx.linkTo('admin.organizations'), text: 'Organisations' },

--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -255,8 +255,11 @@ export function EditOrganizationQuota(props: IEditOrganizationQuotaProperties): 
   return <div className="govuk-grid-row">
     <div className="govuk-grid-column-full">
       <h1 className="govuk-heading-l">
-        <span className="govuk-caption-l">Organisation</span>{' '}
-        {props.organization.entity.name}
+        <span className="govuk-caption-l">
+          <span className="govuk-visually-hidden">Organisation</span>{' '}
+          {props.organization.entity.name}
+        </span>{' '}
+        Manage Quota
       </h1>
     </div>
 
@@ -266,7 +269,7 @@ export function EditOrganizationQuota(props: IEditOrganizationQuotaProperties): 
 
         <div className="govuk-form-group">
           <label className="govuk-label" htmlFor="quota">
-            Quota
+            Select a Quota
           </label>
           <span id="quota-hint" className="govuk-hint">
             The <code>default</code> quota represents a trial account for specific organisation and will not be billed
@@ -276,7 +279,9 @@ export function EditOrganizationQuota(props: IEditOrganizationQuotaProperties): 
             {props.quotas.map(quota => <option
               key={quota.guid}
               selected={props.organization.entity.quota_definition_guid === quota.guid}
-              value={quota.guid}>
+              value={quota.guid}
+              aria-describedby="quota-hint"
+              >
                 {quota.name}
               </option>)}
           </select>


### PR DESCRIPTION
What
----

- update heading and title to be consistent with https://github.com/alphagov/paas-admin/pull/1016
- update quota `select` label
- associate select and hint with `aria-describedby`

**Before**

<img width="517" alt="before" src="https://user-images.githubusercontent.com/3758555/91131076-98c08400-e6a4-11ea-8b35-05e5960e24e8.png">


**After**

<img width="513" alt="after" src="https://user-images.githubusercontent.com/3758555/91131137-b5f55280-e6a4-11ea-9461-9a5b14f3f293.png">


How to review
-------------

- deploy to env (doesn't work in local dev)
- go to org -> manage quota
- check title and page heading match (page heading has visually-hidden text "organisation)
- check select `aria-describedby` attribute value matches hint's `id`

Who can review
---------------

not @kr8n3r 
