### PR TITLE
Wrap Metrics custom-date details text

### DIFF
--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -264,7 +264,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
             Change time period
           </span>
         </summary>
-
+        <div className="govuk-details__text">
         <ol className="govuk-list">
           {[
             { long: '1 hour', short: '1h' },
@@ -345,6 +345,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
             Update
           </button>
         </form>
+        </div>
       </details>
     </div>
   );


### PR DESCRIPTION
What
----

Wrap the body of the Custom date details on the Metrics page inside a div, as per the [Design System implementation](https://design-system.service.gov.uk/components/details/).

This is needed for the legacy browser polyfill which adds aria- attributes to mark open /closed states.

There is a minor visual change, but now consistent with other `detail` elements on the site

**Before**

<img width="438" alt="before" src="https://user-images.githubusercontent.com/3758555/91142394-9bbd7380-e6a8-11ea-86b5-811b499e1634.png">


**After**
<img width="402" alt="after" src="https://user-images.githubusercontent.com/3758555/91142447-af68da00-e6a8-11ea-9742-39767feec0df.png">


Who can review
---------------

not @kr8n3r 
