### PR TITLE
Billing statements page updates

### DIFF
--- a/src/components/statements/_statements.scss
+++ b/src/components/statements/_statements.scss
@@ -78,10 +78,6 @@
   @include hidden;
 }
 
-.paas-billing-heading {
-  margin-bottom: 20px;
-}
-
 .paas-table-notification {
   @include govuk-font($size: 24);
   padding: 25px 0;

--- a/src/components/statements/_statements.scss
+++ b/src/components/statements/_statements.scss
@@ -53,14 +53,20 @@
     &::after {
       display: inline-block;
       margin-left: .5rem;
+      content: "";
     }
 
-    &.asc::after {
-      content: "\25b2";
+    // use border for trianglr shape instead of content
+    // as content get's read by screenreaders
+
+    &.asc:after {
+      @include govuk-shape-arrow($direction: up, $base: 12px, $display: inline-block);
+      border-bottom-color: currentColor;
     }
 
-    &.desc::after {
-      content: "\25bc";
+    &.desc:after {
+      @include govuk-shape-arrow($direction: down, $base: 12px, $display: inline-block);
+      border-top-color: currentColor;
     }
   }
 }

--- a/src/components/statements/controllers.test.tsx
+++ b/src/components/statements/controllers.test.tsx
@@ -118,7 +118,7 @@ describe('statements test suite', () => {
       rangeStart: '2018-01-01',
     });
 
-    expect(response.body).toContain('Statement');
+    expect(response.body).toContain('Organisation the-system_domain-org-name Monthly billing statement');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);
@@ -158,7 +158,7 @@ describe('statements test suite', () => {
       rangeStart: '2018-01-01',
     });
 
-    expect(response.body).toContain('Statement');
+    expect(response.body).toContain('Organisation deleted-org Monthly billing statement');
     expect(response.body).toContain('deleted-org');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
@@ -218,7 +218,7 @@ describe('statements test suite', () => {
       space: 'bc8d3381-390d-4bd7-8c71-25309900a2e3',
     });
 
-    expect(response.body).toContain('Statement');
+    expect(response.body).toContain('Organisation the-system_domain-org-name Monthly billing statement');
     expect(response.body).toContain('batman');
   });
 

--- a/src/components/statements/controllers.test.tsx
+++ b/src/components/statements/controllers.test.tsx
@@ -222,6 +222,37 @@ describe('statements test suite', () => {
     expect(response.body).toContain('batman');
   });
 
+  it('should be reflect the selected filters in the main heading', async () => {
+    nockBilling
+      .get(
+        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+      )
+      .reply(200, billingData.billableEvents)
+
+      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .reply(200, billingData.currencyRates);
+
+    nockCF
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275/user_roles')
+      .times(2)
+      .reply(200, data.userRolesForOrg)
+
+      .get('/v2/organizations/3deb9f04-b449-4f94-b3dd-c73cefe5b275')
+      .reply(200, JSON.stringify(defaultOrg()));
+
+    const response = await statement.viewStatement(ctx, {
+      organizationGUID: '3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+      rangeStart: '2018-01-01',
+      service: 'f4d4b95a-f55e-4593-8d54-3364c25798c4',
+      space: 'bc8d3381-390d-4bd7-8c71-25309900a2e3',
+      sort: 'amount',
+      order: 'desc',
+    });
+
+    expect(response.body).toContain('sorted by Inc VAT column');
+    expect(response.body).toContain('in descending order');
+  });
+
   it('populates filter dropdowns with all spaces / services', async () => {
     nockBilling
       .get(

--- a/src/components/statements/controllers.tsx
+++ b/src/components/statements/controllers.tsx
@@ -385,7 +385,21 @@ export async function viewStatement(
     incVAT: filteredItems.reduce((sum, event) => sum + event.price.incVAT, 0),
   };
 
-  const template = new Template(ctx.viewContext, `Organisation ${organization.entity.name} Monthly billing statement`);
+  const updatedTitle = `Organisation ${organization.entity.name} Monthly billing statement\
+    for ${currentMonth}\
+    ${listSpaces
+      .filter(space => space.guid === (params.space || 'none'))
+      .map(space => (space.guid === 'none' ? '' : `in ${space.name.toLowerCase()} space`))
+    }
+    ${listPlans
+      .filter(service => service.guid === (params.service || 'none'))
+      .map(service => (service.guid === 'none' ? '' : `with ${service.name.toLowerCase()} services`))
+    }\
+    ordered by ${orderBy === 'amount' ? 'Inc VAT' : orderBy} column
+    in ${orderDirection === 'asc' ? 'ascending' : 'descending'} order
+  `;
+
+  const template = new Template(ctx.viewContext, updatedTitle);
   template.breadcrumbs = fromOrg(ctx, organization, [
     { text: 'Monthly billing statement' },
   ]);

--- a/src/components/statements/controllers.tsx
+++ b/src/components/statements/controllers.tsx
@@ -385,7 +385,7 @@ export async function viewStatement(
     incVAT: filteredItems.reduce((sum, event) => sum + event.price.incVAT, 0),
   };
 
-  const template = new Template(ctx.viewContext, 'Statement');
+  const template = new Template(ctx.viewContext, `Organisation ${organization.entity.name} Monthly billing statement`);
   template.breadcrumbs = fromOrg(ctx, organization, [
     { text: 'Monthly billing statement' },
   ]);
@@ -411,6 +411,7 @@ export async function viewStatement(
         filterSpace={listSpaces.find(i => i.guid === (params.space || 'none'))}
         linkTo={ctx.linkTo}
         organizationGUID={organization.metadata.guid}
+        organisationName={organization.entity.name}
         orderBy={orderBy}
         orderDirection={orderDirection}
         items={filteredItems}

--- a/src/components/statements/views.test.tsx
+++ b/src/components/statements/views.test.tsx
@@ -80,7 +80,7 @@ describe(StatementsPage, () => {
     expect($('td').text()).toContain('£33.01');
     expect($('tr').text()).toContain('Exchange rate: £1 to $1.25');
     expect($('.paas-table-billing-statement caption').text()).toContain(
-      'Cost itemisation for January in space-name space with service-name services sorted by name column, ascending',
+      'Cost itemisation for January in space-name space with service-name services sorted by name column in ascending order',
     );
     expect($('.paas-table-billing-statement th:first-child').attr('aria-sort')).toEqual('ascending');
   });
@@ -115,7 +115,7 @@ describe(StatementsPage, () => {
     expect($('input[name="order"]').prop('value')).toEqual('desc');
 
     expect($('.paas-table-billing-statement caption').text()).toContain(
-      'Cost itemisation for January in space-name space with service-name services sorted by space column, descending',
+      'Cost itemisation for January in space-name space with service-name services sorted by space column in descending order',
     );
     expect($('.paas-table-billing-statement th:nth-child(2)').attr('aria-sort')).toEqual('descending');
   });
@@ -150,7 +150,7 @@ describe(StatementsPage, () => {
     expect($('input[name="order"]').prop('value')).toEqual('desc');
 
     expect($('.paas-table-billing-statement caption').text()).toContain(
-      'Cost itemisation for January in space-name space with service-name services sorted by Inc VAT column, descending',
+      'Cost itemisation for January in space-name space with service-name services sorted by Inc VAT column in descending order',
     );
     expect($('.paas-table-billing-statement th:nth-child(5)').attr('aria-sort')).toEqual('descending');
   });

--- a/src/components/statements/views.test.tsx
+++ b/src/components/statements/views.test.tsx
@@ -80,7 +80,7 @@ describe(StatementsPage, () => {
     expect($('td').text()).toContain('£33.01');
     expect($('tr').text()).toContain('Exchange rate: £1 to $1.25');
     expect($('.paas-table-billing-statement caption').text()).toContain(
-      'Cost itemisation for January in space-name space with service-name services sorted by name column, ascending'
+      'Cost itemisation for January in space-name space with service-name services sorted by name column, ascending',
     );
     expect($('.paas-table-billing-statement th:first-child').attr('aria-sort')).toEqual('ascending');
   });
@@ -115,7 +115,7 @@ describe(StatementsPage, () => {
     expect($('input[name="order"]').prop('value')).toEqual('desc');
 
     expect($('.paas-table-billing-statement caption').text()).toContain(
-      'Cost itemisation for January in space-name space with service-name services sorted by space column, descending'
+      'Cost itemisation for January in space-name space with service-name services sorted by space column, descending',
     );
     expect($('.paas-table-billing-statement th:nth-child(2)').attr('aria-sort')).toEqual('descending');
   });
@@ -150,7 +150,7 @@ describe(StatementsPage, () => {
     expect($('input[name="order"]').prop('value')).toEqual('desc');
 
     expect($('.paas-table-billing-statement caption').text()).toContain(
-      'Cost itemisation for January in space-name space with service-name services sorted by Inc VAT column, descending'
+      'Cost itemisation for January in space-name space with service-name services sorted by Inc VAT column, descending',
     );
     expect($('.paas-table-billing-statement th:nth-child(5)').attr('aria-sort')).toEqual('descending');
   });
@@ -182,9 +182,6 @@ describe(StatementsPage, () => {
     expect($('input[name="sort"]').prop('value')).toEqual('plan');
     expect($('input[name="order"]').prop('value')).toEqual('desc');
 
-    expect($('.paas-table-billing-statement caption').text()).toContain(
-      'Cost itemisation for January sorted by plan column, ascending'
-    );
     expect($('.paas-table-billing-statement th:nth-child(3)').attr('aria-sort')).toEqual('descending');
   });
 
@@ -218,4 +215,186 @@ describe(StatementsPage, () => {
       'There is no record of any usage for that period.',
     );
   });
+
+  describe('statement column header sort order', () => {
+    it('where NAME column header should have an aria-sort="descending" label when sorted with "descending order"', () => {
+      const markup = shallow(
+        <StatementsPage
+          spaces={[{ guid: 'SPACE_GUID', name: 'space name' }]}
+          plans={[{ guid: 'PLAN_GUID', name: 'plan name' }]}
+          currentMonth="January"
+          adminFee={0.1}
+          totals={{
+            exVAT: 275.11,
+            incVAT: 330.14,
+          }}
+          usdCurrencyRates={[{ validFrom: '2020-01-24', rate: 0.8 }]}
+          listOfPastYearMonths={{ 20200101: 'January 2020' }}
+          isCurrentMonth={true}
+          csrf="qwert"
+          filterMonth="2020-01-01"
+          filterService={{ guid: 'service-guid', name: 'service-name' }}
+          filterSpace={{ guid: 'space-guid', name: 'space-name' }}
+          orderBy="name"
+          orderDirection="desc"
+          linkTo={route => `__LINKS_TO__${route}`}
+          organizationGUID="ORG_GUID"
+          items={[
+            {
+              resourceGUID: 'resource-guid',
+              resourceName: 'resource-name',
+              resourceType: 'resource-type',
+              orgGUID: 'org-guid',
+              spaceGUID: 'space-guid',
+              spaceName: 'space-name',
+              planGUID: 'plan-guid',
+              planName: 'plan-name',
+              price: {
+                incVAT: 330.14,
+                exVAT: 275.11,
+              },
+            },
+            item,
+          ]}
+        />,
+      );
+      const $ = cheerio.load(markup.html());    
+      expect($('.paas-table-billing-statement th:first-child').attr('aria-sort')).toEqual('descending');
+    })
+
+    it('where SPACE column header should have an aria-sort="descending" label when sorted with "ascending order"', () => {
+      const markup = shallow(
+        <StatementsPage
+          spaces={[{ guid: 'SPACE_GUID', name: 'space name' }]}
+          plans={[{ guid: 'PLAN_GUID', name: 'plan name' }]}
+          currentMonth="January"
+          adminFee={0.1}
+          totals={{
+            exVAT: 275.11,
+            incVAT: 330.14,
+          }}
+          usdCurrencyRates={[{ validFrom: '2020-01-24', rate: 0.8 }]}
+          listOfPastYearMonths={{ 20200101: 'January 2020' }}
+          isCurrentMonth={true}
+          csrf="qwert"
+          filterMonth="2020-01-01"
+          filterService={{ guid: 'service-guid', name: 'service-name' }}
+          filterSpace={{ guid: 'space-guid', name: 'space-name' }}
+          orderBy="space"
+          orderDirection="asc"
+          linkTo={route => `__LINKS_TO__${route}`}
+          organizationGUID="ORG_GUID"
+          items={[
+            {
+              resourceGUID: 'resource-guid',
+              resourceName: 'resource-name',
+              resourceType: 'resource-type',
+              orgGUID: 'org-guid',
+              spaceGUID: 'space-guid',
+              spaceName: 'space-name',
+              planGUID: 'plan-guid',
+              planName: 'plan-name',
+              price: {
+                incVAT: 330.14,
+                exVAT: 275.11,
+              },
+            },
+            item,
+          ]}
+        />,
+      );
+      const $ = cheerio.load(markup.html());    
+      expect($('.paas-table-billing-statement th:nth-child(2)').attr('aria-sort')).toEqual('ascending');
+    })
+
+    it('where PLAN column header should have an aria-sort="descending" label when sorted with "ascending order"', () => {
+      const markup = shallow(
+        <StatementsPage
+          spaces={[{ guid: 'SPACE_GUID', name: 'space name' }]}
+          plans={[{ guid: 'PLAN_GUID', name: 'plan name' }]}
+          currentMonth="January"
+          adminFee={0.1}
+          totals={{
+            exVAT: 275.11,
+            incVAT: 330.14,
+          }}
+          usdCurrencyRates={[{ validFrom: '2020-01-24', rate: 0.8 }]}
+          listOfPastYearMonths={{ 20200101: 'January 2020' }}
+          isCurrentMonth={true}
+          csrf="qwert"
+          filterMonth="2020-01-01"
+          filterService={{ guid: 'service-guid', name: 'service-name' }}
+          filterSpace={{ guid: 'space-guid', name: 'space-name' }}
+          orderBy="plan"
+          orderDirection="asc"
+          linkTo={route => `__LINKS_TO__${route}`}
+          organizationGUID="ORG_GUID"
+          items={[
+            {
+              resourceGUID: 'resource-guid',
+              resourceName: 'resource-name',
+              resourceType: 'resource-type',
+              orgGUID: 'org-guid',
+              spaceGUID: 'space-guid',
+              spaceName: 'space-name',
+              planGUID: 'plan-guid',
+              planName: 'plan-name',
+              price: {
+                incVAT: 330.14,
+                exVAT: 275.11,
+              },
+            },
+            item,
+          ]}
+        />,
+      );
+      const $ = cheerio.load(markup.html());    
+      expect($('.paas-table-billing-statement th:nth-child(3)').attr('aria-sort')).toEqual('ascending');
+    })
+
+    it('where Inc VAT column header should have an aria-sort="descending" label when sorted with "ascending order"', () => {
+      const markup = shallow(
+        <StatementsPage
+          spaces={[{ guid: 'SPACE_GUID', name: 'space name' }]}
+          plans={[{ guid: 'PLAN_GUID', name: 'plan name' }]}
+          currentMonth="January"
+          adminFee={0.1}
+          totals={{
+            exVAT: 275.11,
+            incVAT: 330.14,
+          }}
+          usdCurrencyRates={[{ validFrom: '2020-01-24', rate: 0.8 }]}
+          listOfPastYearMonths={{ 20200101: 'January 2020' }}
+          isCurrentMonth={true}
+          csrf="qwert"
+          filterMonth="2020-01-01"
+          filterService={{ guid: 'service-guid', name: 'service-name' }}
+          filterSpace={{ guid: 'space-guid', name: 'space-name' }}
+          orderBy="amount"
+          orderDirection="asc"
+          linkTo={route => `__LINKS_TO__${route}`}
+          organizationGUID="ORG_GUID"
+          items={[
+            {
+              resourceGUID: 'resource-guid',
+              resourceName: 'resource-name',
+              resourceType: 'resource-type',
+              orgGUID: 'org-guid',
+              spaceGUID: 'space-guid',
+              spaceName: 'space-name',
+              planGUID: 'plan-guid',
+              planName: 'plan-name',
+              price: {
+                incVAT: 330.14,
+                exVAT: 275.11,
+              },
+            },
+            item,
+          ]}
+        />,
+      );
+      const $ = cheerio.load(markup.html());    
+      expect($('.paas-table-billing-statement th:nth-child(5)').attr('aria-sort')).toEqual('ascending');
+    })
+  })
 });

--- a/src/components/statements/views.test.tsx
+++ b/src/components/statements/views.test.tsx
@@ -79,6 +79,10 @@ describe(StatementsPage, () => {
     expect($('td').text()).toContain('£27.51');
     expect($('td').text()).toContain('£33.01');
     expect($('tr').text()).toContain('Exchange rate: £1 to $1.25');
+    expect($('.paas-table-billing-statement caption').text()).toContain(
+      'Cost itemisation for January in space-name space with service-name services sorted by name column, ascending'
+    );
+    expect($('.paas-table-billing-statement th:first-child').attr('aria-sort')).toEqual('ascending');
   });
 
   it('should parse statements page when ordering by space', () => {
@@ -109,6 +113,11 @@ describe(StatementsPage, () => {
     const $ = cheerio.load(markup.html());
     expect($('input[name="sort"]').prop('value')).toEqual('space');
     expect($('input[name="order"]').prop('value')).toEqual('desc');
+
+    expect($('.paas-table-billing-statement caption').text()).toContain(
+      'Cost itemisation for January in space-name space with service-name services sorted by space column, descending'
+    );
+    expect($('.paas-table-billing-statement th:nth-child(2)').attr('aria-sort')).toEqual('descending');
   });
 
   it('should parse statements page when ordering by amount', () => {
@@ -139,6 +148,11 @@ describe(StatementsPage, () => {
     const $ = cheerio.load(markup.html());
     expect($('input[name="sort"]').prop('value')).toEqual('amount');
     expect($('input[name="order"]').prop('value')).toEqual('desc');
+
+    expect($('.paas-table-billing-statement caption').text()).toContain(
+      'Cost itemisation for January in space-name space with service-name services sorted by Inc VAT column, descending'
+    );
+    expect($('.paas-table-billing-statement th:nth-child(5)').attr('aria-sort')).toEqual('descending');
   });
 
   it('should parse statements page when ordering by plan', () => {
@@ -167,6 +181,11 @@ describe(StatementsPage, () => {
     const $ = cheerio.load(markup.html());
     expect($('input[name="sort"]').prop('value')).toEqual('plan');
     expect($('input[name="order"]').prop('value')).toEqual('desc');
+
+    expect($('.paas-table-billing-statement caption').text()).toContain(
+      'Cost itemisation for January sorted by plan column, ascending'
+    );
+    expect($('.paas-table-billing-statement th:nth-child(3)').attr('aria-sort')).toEqual('descending');
   });
 
   it('should parse statements page and notify tenant that there\'s no information for this month', () => {

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -58,6 +58,12 @@ function orderDirection(value: string): string {
   return value === 'asc' ? 'asc' : 'desc';
 }
 
+function convertDateToMonthLong(dateString: string): string {
+  const date = new Date(dateString)
+  const month = date.toLocaleString('default', { month: 'long' });
+  return month
+}
+
 export function StatementsPage(props: IStatementsPageProperties): ReactElement {
   return (
     <>
@@ -314,7 +320,14 @@ function Statement(props: IStatementProps): ReactElement {
         <input type="hidden" name="service" value={props.filterService?.guid} />
 
         <div className="scrollable-table-container">
-          <table className="govuk-table paas-table-billing-statement">
+          <table className="govuk-table paas-table-billing-statement" aria-readonly="true">
+          <caption className="govuk-visually-hidden">
+            Cost itemisation for {convertDateToMonthLong(props.filterMonth)}
+            {props.filterSpace?.guid !== 'none' ? ` in ${props.filterSpace?.name.toLowerCase()} space` : ''}
+            {props.filterService?.guid !== 'none' ? ` with ${props.filterService?.name.toLowerCase()} services` : ''}{' '}sorted by{' '} 
+            {props.orderBy === 'amount' ? 'Inc VAT' : props.orderBy} column,{' '} 
+            {orderDirection(props.orderDirection) === 'asc' ? 'ascending': 'descending'}
+          </caption>
           <thead className="govuk-table__head">
             <tr className="govuk-table__row">
               <th className="govuk-table__header" scope="col">

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -37,6 +37,7 @@ interface IStatementProps {
   readonly filterService?: IFilterResource;
   readonly linkTo: RouteLinker;
   readonly organizationGUID: string;
+  readonly organisationName: string;
   readonly orderDirection: string;
   readonly orderBy: string;
   readonly items: ReadonlyArray<IResourceUsage>;
@@ -50,6 +51,7 @@ interface IStatementsPageProperties extends IStatementProps {
   readonly adminFee: number;
   readonly totals: ITotals;
   readonly usdCurrencyRates: ReadonlyArray<any>;
+  
 }
 
 function orderDirection(value: string): string {
@@ -61,8 +63,12 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <h1 className="govuk-heading-l paas-billing-heading">
-            Monthly billing statement
+          <h1 className="govuk-heading-l">
+            <span className="govuk-caption-l">
+              <span className="govuk-visually-hidden">Organisation</span>{' '}
+                {props.organisationName}
+              </span>{' '}
+              Monthly billing statement
           </h1>
         </div>
 

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -206,6 +206,9 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
         <div className="govuk-grid-column-full">
           <div className="scrollable-table-container">
             <table className="govuk-table paas-exchange-rate">
+            <caption className="govuk-visually-hidden">
+              Summary of total cost inclusive of 10% admin fee, shown with and without VAT
+            </caption>
             <tr className="govuk-table__row">
               <th className="govuk-table__header" scope="row">
                 Total cost for {props.currentMonth}{' '}

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -74,7 +74,21 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
               <span className="govuk-visually-hidden">Organisation</span>{' '}
                 {props.organisationName}
               </span>{' '}
-              Monthly billing statement
+              Monthly billing statement{' '}
+              <span className="govuk-visually-hidden">
+                for {props.currentMonth}
+                {props.filterSpace?.guid !== 'none' ?
+                  ` in ${props.filterSpace?.name.toLowerCase()} space`
+                : ''
+                }
+                {props.filterService?.guid !== 'none' ?
+                  ` with ${props.filterService?.name.toLowerCase()} services`
+                  : ''
+                }{' '}
+                sorted by{' '} 
+                {props.orderBy === 'amount' ? 'Inc VAT' : props.orderBy} column{' '}
+                in{' '}{orderDirection(props.orderDirection) === 'asc' ? 'ascending': 'descending'}{' '}order
+              </span>
           </h1>
         </div>
 
@@ -325,8 +339,8 @@ function Statement(props: IStatementProps): ReactElement {
             Cost itemisation for {convertDateToMonthLong(props.filterMonth)}
             {props.filterSpace?.guid !== 'none' ? ` in ${props.filterSpace?.name.toLowerCase()} space` : ''}
             {props.filterService?.guid !== 'none' ? ` with ${props.filterService?.name.toLowerCase()} services` : ''}{' '}sorted by{' '} 
-            {props.orderBy === 'amount' ? 'Inc VAT' : props.orderBy} column,{' '} 
-            {orderDirection(props.orderDirection) === 'asc' ? 'ascending': 'descending'}
+            {props.orderBy === 'amount' ? 'Inc VAT' : props.orderBy} column{' '}in{' '} 
+            {orderDirection(props.orderDirection) === 'asc' ? 'ascending': 'descending'}{' '}order
           </caption>
           <thead className="govuk-table__head">
             <tr className="govuk-table__row">

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -337,7 +337,7 @@ function Statement(props: IStatementProps): ReactElement {
                       : ''
                   }`}
                 >
-                  Name
+                  <span className="govuk-visually-hidden">Sort by</span>{' '}Name
                 </button>
               </th>
               <th className="govuk-table__header" scope="col">
@@ -360,7 +360,7 @@ function Statement(props: IStatementProps): ReactElement {
                       : ''
                   }`}
                 >
-                  Space
+                  <span className="govuk-visually-hidden">Sort by</span>{' '}Space
                 </button>
               </th>
               <th className="govuk-table__header" scope="col">
@@ -383,7 +383,7 @@ function Statement(props: IStatementProps): ReactElement {
                       : ''
                   }`}
                 >
-                  Plan
+                  <span className="govuk-visually-hidden">Sort by</span>{' '}Plan
                 </button>
               </th>
               <th className="govuk-table__header text-right" scope="col">
@@ -409,7 +409,7 @@ function Statement(props: IStatementProps): ReactElement {
                       : ''
                   }`}
                 >
-                  Inc VAT
+                  <span className="govuk-visually-hidden">Sort by</span>{' '}Inc VAT
                 </button>
               </th>
             </tr>

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -330,7 +330,14 @@ function Statement(props: IStatementProps): ReactElement {
           </caption>
           <thead className="govuk-table__head">
             <tr className="govuk-table__row">
-              <th className="govuk-table__header" scope="col">
+              <th className="govuk-table__header" 
+                scope="col"
+                aria-sort={
+                  props.orderBy === 'name' ?
+                  orderDirection(props.orderDirection) === 'asc' ? 'ascending': 'descending'
+                  : undefined
+                }
+              >
                 {props.orderBy === 'name' ? (
                   <input
                     type="hidden"
@@ -353,7 +360,15 @@ function Statement(props: IStatementProps): ReactElement {
                   <span className="govuk-visually-hidden">Sort by</span>{' '}Name
                 </button>
               </th>
-              <th className="govuk-table__header" scope="col">
+              <th 
+                className="govuk-table__header" 
+                scope="col"
+                aria-sort={
+                  props.orderBy === 'space' ?
+                  orderDirection(props.orderDirection) === 'asc' ? 'ascending': 'descending'
+                  : undefined
+                }
+                >
                 {props.orderBy === 'space' ? (
                   <input
                     type="hidden"
@@ -376,7 +391,15 @@ function Statement(props: IStatementProps): ReactElement {
                   <span className="govuk-visually-hidden">Sort by</span>{' '}Space
                 </button>
               </th>
-              <th className="govuk-table__header" scope="col">
+              <th 
+                className="govuk-table__header" 
+                scope="col"
+                aria-sort={
+                  props.orderBy === 'plan' ?
+                  orderDirection(props.orderDirection) === 'asc' ? 'ascending': 'descending'
+                  : undefined
+                }
+                >
                 {props.orderBy === 'plan' ? (
                   <input
                     type="hidden"
@@ -402,7 +425,15 @@ function Statement(props: IStatementProps): ReactElement {
               <th className="govuk-table__header text-right" scope="col">
                 Ex VAT
               </th>
-              <th className="govuk-table__header text-right" scope="col">
+              <th 
+                className="govuk-table__header text-right" 
+                scope="col"
+                aria-sort={
+                  props.orderBy === 'amount' ?
+                  orderDirection(props.orderDirection) === 'asc' ? 'ascending': 'descending'
+                  : undefined
+                }
+                >
                 {props.orderBy === 'amount' ? (
                   <input
                     type="hidden"


### PR DESCRIPTION
What
----
_Note: will squash commits after review_

Problem:

The table contains form elements that are not descriptive enough for screen reader users to determine that their purpose is to filter the options in the corresponding column:
• Name
• Space
• Plan
• Inc VAT

Ensure that the table column/buttons are uniquely descriptive of their function or purpose and enable users to identify which column/button is currently selected (i.e. Filter by ‘Name’ selected).
Also, users need to be informed that the filter has been applied.

Solution:
We have address above with the following:

- Update statements title & heading to reflect selected filters
- Add visually hidden "Sort by" text to table sort column buttons
- Provide a visually-hidden table caption
- Add `aria-sort` attribute to table columns
- add a visually-hidden caption to cost summary table


How to review
-------------
Suggest reviewing by commit
- checkout branch, run locally
- go to org billing page
- apply filters and sort table by a column
- inspect page title and h1 for text that reflects selected filters and sort option
- inspect table caption for text that reflects selected filters and sort option
- inspect table header (`th`). only the selected filter should have `aria-sort` attribute

### Heading and title reflecting selected filters and sort order
<img width="866" alt="Screenshot 2020-08-26 at 09 08 45" src="https://user-images.githubusercontent.com/3758555/91278158-c4fb0400-e77b-11ea-870d-1d58fff68f55.png">


### Table caption read by screen reader before and after

<img width="1007" alt="Screenshot 2020-08-25 at 11 26 49" src="https://user-images.githubusercontent.com/3758555/91181521-f2df3a80-e6e0-11ea-922b-c6e273242132.png">
<img width="1006" alt="Screenshot 2020-08-25 at 11 27 10" src="https://user-images.githubusercontent.com/3758555/91181526-f4a8fe00-e6e0-11ea-83a1-da0b999032e0.png">

### Updated sort button text showing descriptive text and sort direction
<img width="667" alt="button VO text" src="https://user-images.githubusercontent.com/3758555/91182193-c4159400-e6e1-11ea-8cb6-af9312b1445b.png">

### Cost summary table caption
<img width="1232" alt="Screenshot 2020-08-26 at 10 11 51" src="https://user-images.githubusercontent.com/3758555/91285089-aa795880-e784-11ea-92f3-8ae5158ac651.png">
 


Who can review
---------------

not @kr8n3r
