### PR TITLE
Keyboard accessible <abbr>eviation expansion

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -63,6 +63,7 @@
     "import/no-commonjs": "error",
     "import/order": ["warn", {"alphabetize": {"order": "asc", "caseInsensitive": true}, "newlines-between": "always"}],
     "jsx-quotes": ["error", "prefer-double"],
+    "jsx-a11y/no-noninteractive-tabindex": "warn",
     "jsx-a11y/no-redundant-roles": ["error", {"details": ["group"]}],
     "linebreak-style": ["error", "unix"],
     "max-len": ["warn", {"code": 120}],

--- a/src/components/marketplace/views.tsx
+++ b/src/components/marketplace/views.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 
 import { CommandLineAlternative, NoTick, Tick } from '../../layouts/partials';
+import { Abbreviation } from '../../layouts/helpers';
 import { IV3Service, IV3ServicePlan } from '../../lib/cf/types';
 import { RouteLinker } from '../app';
 
@@ -267,7 +268,7 @@ export function PlanTab(props: IPlanTabProperties): ReactElement {
                 <th scope="col" className="govuk-table__header">Available in trial</th>
                 {canBeHighIOPS
                   ? <th scope="col" className="govuk-table__header">
-                      High <abbr title="Input/Output Operations Per Second">IOPS</abbr>
+                      High <Abbreviation description="Input/Output Operations Per Second">IOPS</Abbreviation>
                     </th>
                   : null}
                 {providesBackups
@@ -277,11 +278,11 @@ export function PlanTab(props: IPlanTabProperties): ReactElement {
                   ? <th scope="col" className="govuk-table__header">Encrypted</th>
                   : null}
                 {canBeHA
-                  ? <th scope="col" className="govuk-table__header"><abbr title="Highly Available">HA</abbr></th>
+                  ? <th scope="col" className="govuk-table__header"><Abbreviation description="Highly Available">HA</Abbreviation></th>
                   : null}
                 {limitsCC
                   ? <th scope="col" className="govuk-table__header govuk-table__header--numeric">
-                      <abbr title="Concurrent Connections">Connections</abbr>
+                      <Abbreviation description="Concurrent Connections">Connections</Abbreviation>
                     </th>
                   : null}
                 {limitsMemory

--- a/src/components/service-metrics/metrics.tsx
+++ b/src/components/service-metrics/metrics.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { bytesConvert } from '../../layouts';
+import { Abbreviation } from '../../layouts/helpers';
 import { IMetricSerie, IMetricSerieSummary } from '../../lib/metrics';
 import { drawLineGraph } from '../charts/line-graph';
 
@@ -231,8 +232,8 @@ export function rdsMetrics(
       title: 'Freeable Memory',
       description: (
         <>
-          How much <abbr title="Random Access Memory">RAM</abbr> the{' '}
-          <abbr title="Virtual Machine">VM</abbr> your database is running on
+          How much <Abbreviation description="Random Access Memory">RAM</Abbreviation> the{' '}
+          <Abbreviation description="Virtual Machine">VM</Abbreviation> your database is running on
           has remaining. Values near zero may indicate you need to optimise your
           database queries or{' '}
           <a
@@ -259,7 +260,7 @@ export function rdsMetrics(
       id: 'read-iops',
       title: (
         <>
-          Read <abbr title="Input / Output Operations per Second">IOPS</abbr>
+          Read <Abbreviation description="Input / Output Operations per Second">IOPS</Abbreviation>
         </>
       ),
       titleText: 'Read Input / Output Operations per Second',
@@ -267,10 +268,10 @@ export function rdsMetrics(
         <>
           How many read operations your database is performing per second.
           Databases are limited to a number of{' '}
-          <abbr title="Input / Output Operations per Second">IOPS</abbr> (read +
+          <Abbreviation description="Input / Output Operations per Second">IOPS</Abbreviation> (read +
           write) based on how big their hard disk is. You get 3{' '}
-          <abbr title="Input / Output Operations per Second">IOPS</abbr> per{' '}
-          <abbr title="GibiByte">GiB</abbr>, so a 100 GiB database would be
+          <Abbreviation description="Input / Output Operations per Second">IOPS</Abbreviation> per{' '}
+          <Abbreviation description="GibiByte">GiB</Abbreviation>, so a 100 GiB database would be
           limited to 300 IOPS. If it looks like your database is hitting its
           IOPS limit you may need to{' '}
           <a
@@ -297,7 +298,7 @@ export function rdsMetrics(
       id: 'write-iops',
       title: (
         <>
-          Write <abbr title="Input / Output Operations per Second">IOPS</abbr>
+          Write <Abbreviation description="Input / Output Operations per Second">IOPS</Abbreviation>
         </>
       ),
       titleText: 'Write Input / Output Operations per Second',
@@ -305,10 +306,10 @@ export function rdsMetrics(
         <>
           How many write operations your database is performing per second.
           Databases are limited to a number of{' '}
-          <abbr title="Input / Output Operations per Second">IOPS</abbr> (read +
+          <Abbreviation description="Input / Output Operations per Second">IOPS</Abbreviation> (read +
           write) based on how big their hard disk is. You get 3{' '}
-          <abbr title="Input / Output Operations per Second">IOPS</abbr> per{' '}
-          <abbr title="GibiByte">GiB</abbr>, so a 100 GiB database would be
+          <Abbreviation description="Input / Output Operations per Second">IOPS</Abbreviation> per{' '}
+          <Abbreviation description="GibiByte">GiB</Abbreviation>, so a 100 GiB database would be
           limited to 300 IOPS. If it looks like your database is hitting its
           IOPS limit you may need to{' '}
           <a
@@ -395,7 +396,7 @@ export function elastiCacheMetrics(
         <>
           If redis is running low on memory it will start to swap memory onto
           the hard disk. If redis is using more than 50{' '}
-          <abbr title="MegaBytes">MB</abbr> of swap memory you may need to
+          <Abbreviation description="MegaBytes">MB</Abbreviation> of swap memory you may need to
           reduce your usage or{' '}
           <a
             href="https://docs.cloud.service.gov.uk/deploying_services/redis/#redis-service-plans"

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import React, { ReactElement, ReactNode } from 'react';
 
 import { bytesToHuman, DATE_TIME } from '../../layouts';
+import { Abbreviation } from '../../layouts/helpers';
 import { IServiceInstance } from '../../lib/cf/types';
 import { IMetricSerieSummary } from '../../lib/metrics';
 import { RouteActiveChecker, RouteLinker } from '../app';
@@ -171,9 +172,7 @@ function Metric(props: IMetricProperties): ReactElement {
                 >
                   <small>
                     {series.label.length > 3 ? (
-                      <abbr title={series.label}>
-                        {String(index).padStart(3, '0')}
-                      </abbr>
+                      <Abbreviation description={series.label}>{String(index).padStart(3, '0')}</Abbreviation>
                     ) : (
                       series.label
                     )}

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import React, { ReactElement, ReactNode } from 'react';
 
 import { DATE_TIME } from '../../layouts/constants';
-import { bytesToHuman } from '../../layouts/helpers';
+import { bytesToHuman, Abbreviation } from '../../layouts/helpers';
 import { CommandLineAlternative } from '../../layouts/partials';
 import { IService, IServiceInstance, IServicePlan } from '../../lib/cf/types';
 import { RouteActiveChecker, RouteLinker } from '../app';
@@ -220,7 +220,7 @@ function FileListingItem(props: IFileListingItemProperties): ReactElement {
 
     <p className="govuk-body" id={`download-${props.date.getTime()}`}>
       <span className="govuk-visually-hidden">file type </span>
-      <span className="service-log-list-item__attribute"><abbr title="record of events">LOG</abbr></span>,
+      <span className="service-log-list-item__attribute"><Abbreviation description="record of events">LOG</Abbreviation></span>,
       {' '}
       <span className="govuk-visually-hidden">file size </span>
       <span className="service-log-list-item__attribute">{bytesToHuman(props.size)}</span>

--- a/src/components/spaces/controllers.test.tsx
+++ b/src/components/spaces/controllers.test.tsx
@@ -220,7 +220,7 @@ describe('spaces test suite', () => {
     expect(response.body).toContain('Quota usage');
     expect(response.body).toContain('5.0%');
     expect(response.body).toMatch(
-      /Using\s+1[.]00\s<abbr title="gibibytes">GiB<\/abbr>\s+of memory/m,
+      /Using\s+1[.]00\s<abbr role="tooltip" tabindex="0" data-module="tooltip" aria-label="gibibytes">GiB<\/abbr>\s+of memory/m,
     );
 
     expect(response.body).toContain('Spaces');

--- a/src/frontend/javascript/init.js
+++ b/src/frontend/javascript/init.js
@@ -1,3 +1,5 @@
+import Tooltip from './tooltip';
+
 // there is ever only one header per page
 var $headerMenuButton = document.querySelector('[data-module="govuk-header"]');
 var GOVUKHeader = window.GOVUKFrontend.Header;
@@ -33,5 +35,12 @@ var GOVUKRadios = window.GOVUKFrontend.Radios;
 if ($radios) {
   for (var i = 0; i < $radios.length; i++) {
     new GOVUKRadios($radios[i]).init();
+  };
+}
+
+var $tooltips = document.querySelectorAll('[data-module="tooltip"]');
+if ($tooltips) {
+  for (var i = 0; i < $tooltips.length; i++) {
+    new Tooltip($tooltips[i]).init();
   };
 }

--- a/src/frontend/javascript/tooltip.js
+++ b/src/frontend/javascript/tooltip.js
@@ -1,0 +1,54 @@
+var KEY_ESC = 27
+
+function Tooltip ($module) {
+  this.$module = $module
+}
+
+Tooltip.prototype.init = function () {
+  if (!this.$module) {
+    return
+  }
+  this.$module.addEventListener('keyup',  this.handleKeyUp.bind(this))
+  this.$module.addEventListener('focus', this.handleFocus.bind(this))
+  this.$module.addEventListener('blur', this.handleBlur.bind(this))
+  this.$module.addEventListener('mouseenter', this.handleMouseEnter.bind(this))
+  this.$module.addEventListener('mouseleave', this.handleMouseLeave.bind(this))
+}
+
+Tooltip.prototype.makeActive = function () {
+  this.$module.setAttribute("tooltip", "active"); 
+}
+
+Tooltip.prototype.makeInActive = function () {
+  this.$module.setAttribute("tooltip", "inactive");
+}
+
+Tooltip.prototype.keyboardEvents = function (event) {
+  if (event.keyCode === KEY_ESC) {
+    this.makeInActive();
+  }
+}
+
+Tooltip.prototype.handleKeyUp = function (event) {
+  if (event.keyCode === KEY_ESC) {
+    this.makeInActive();
+  }
+}
+
+Tooltip.prototype.handleFocus = function () {
+  this.makeActive();
+}
+Tooltip.prototype.handleBlur = function () {
+  this.makeInActive();
+}
+
+Tooltip.prototype.handleMouseEnter = function () {
+  this.makeActive();
+}
+
+Tooltip.prototype.handleMouseLeave = function () {
+  this.makeInActive();
+}
+
+
+export default Tooltip

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -51,10 +51,6 @@ $govuk-breakpoints: (
   }
 }
 
-abbr {
-  text-underline-position: under;
-}
-
 .govuk-summary-list__key {
   vertical-align: top;
 }
@@ -91,4 +87,50 @@ abbr {
 // that's useful, but for an admin interface not necessary
 .govuk-table__header--non-bold {
   font-weight: 400;
+}
+
+//abbreviation tooltip
+
+[data-module="tooltip"] {
+  position: relative;
+}
+
+[data-module="tooltip"]:focus {
+  @include govuk-focused-text;
+}
+
+[data-module="tooltip"]:after { 
+  color: govuk-colour("white");
+  background-color: govuk-colour("black");
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+  content: attr(aria-label);
+}
+
+.js-enabled [data-module="tooltip"] {
+  text-decoration: underline dotted;
+  text-underline-position: under;
+  cursor: help;
+}
+
+[data-module="tooltip"][tooltip=active]:after,
+[data-module="tooltip"]:hover:after {
+    width: auto;
+    height: auto;
+    overflow: visible;
+    clip: auto;
+    -webkit-clip-path: none;
+    clip-path: none;
+    white-space: inherit;
+    z-index: 99;
+    margin-top: -(govuk-spacing(5));
+    padding: 2px 3px;  
 }

--- a/src/layouts/helpers.test.tsx
+++ b/src/layouts/helpers.test.tsx
@@ -1,8 +1,10 @@
+import cheerio from 'cheerio';
 import { shallow } from 'enzyme';
 import React from 'react';
 
 import { GIBIBYTE, KIBIBYTE, MEBIBYTE, TEBIBYTE } from './constants';
 import {
+  Abbreviation,
   bytesToHuman,
   capitalize,
   conditionallyDisplay,
@@ -23,19 +25,20 @@ describe(bytesToHuman, () => {
     const mebibytes = <span>{bytesToHuman(5.3 * MEBIBYTE)}</span>;
     const gibibytes = <span>{bytesToHuman(5.3 * GIBIBYTE)}</span>;
     const tebibytes = <span>{bytesToHuman(5.3 * TEBIBYTE)}</span>;
-
-    expect(shallow(bytes).html()).toContain('5 <abbr title="bytes">B</abbr>');
+    expect(shallow(bytes).html()).toContain(
+      '5 <abbr role="tooltip" tabindex="0" data-module="tooltip" aria-label="bytes">B</abbr>',
+    );
     expect(shallow(kibibytes).html()).toContain(
-      '5.30 <abbr title="kibibytes">KiB</abbr>',
+      '5.30 <abbr role="tooltip" tabindex="0" data-module="tooltip" aria-label="kibibytes">KiB</abbr>',
     );
     expect(shallow(mebibytes).html()).toContain(
-      '5.30 <abbr title="mebibytes">MiB</abbr>',
+      '5.30 <abbr role="tooltip" tabindex="0" data-module="tooltip" aria-label="mebibytes">MiB</abbr>',
     );
     expect(shallow(gibibytes).html()).toContain(
-      '5.30 <abbr title="gibibytes">GiB</abbr>',
+      '5.30 <abbr role="tooltip" tabindex="0" data-module="tooltip" aria-label="gibibytes">GiB</abbr>',
     );
     expect(shallow(tebibytes).html()).toContain(
-      '5.30 <abbr title="tebibytes">TiB</abbr>',
+      '5.30 <abbr role="tooltip" tabindex="0" data-module="tooltip" aria-label="tebibytes">TiB</abbr>',
     );
   });
 });
@@ -53,5 +56,16 @@ describe(conditionallyDisplay, () => {
 describe(capitalize, () => {
   it('should do the right thing', () => {
     expect(capitalize('test')).toEqual('Test');
+  });
+});
+
+describe(Abbreviation, () => {
+  it('it should render the abbreviation tooltip correctly', () => {
+    const output = <Abbreviation description="For the win">FTW</Abbreviation>;
+    const $ = cheerio.load(shallow(output).html());
+    expect($('abbr').attr('tabindex')).toBe('0');
+    expect($('abbr').text()).toBe('FTW');
+    expect($('abbr').attr('aria-label')).toBe('For the win');
+    expect($('abbr').attr('role')).toBe('tooltip');
   });
 });

--- a/src/layouts/helpers.tsx
+++ b/src/layouts/helpers.tsx
@@ -8,6 +8,11 @@ interface IConvertedBytes {
   readonly value: string;
 }
 
+interface IAbbreviationProperties {
+  readonly children: string;
+  readonly description: string;
+}
+
 const longUnits: { readonly [key: string]: string } = {
   KiB: 'kibibytes',
   MiB: 'mebibytes',
@@ -42,14 +47,19 @@ export function bytesConvert(startingBytes: number, precision = 2): IConvertedBy
   };
 }
 
-export function bytesToHuman(startingBytes: number, precision = 2): ReactElement {
-  const converted = bytesConvert(startingBytes, precision);
+export function Abbreviation(props: IAbbreviationProperties): ReactElement {
+  return (
+    <abbr role="tooltip" tabIndex={0} data-module="tooltip" aria-label={props.description}>{props.children}</abbr>
+  );
+}
 
+export function bytesToHuman(startingBytes: number, precision = 2) {
+  const converted = bytesConvert(startingBytes, precision);
   return (
     <>
-      {converted.value} <abbr title={converted.long}>{converted.short}</abbr>
+     {converted.value} <Abbreviation description={converted.long}>{converted.short}</Abbreviation> 
     </>
-  );
+  )
 }
 
 export function conditionallyDisplay(


### PR DESCRIPTION
**Note: will squash commits after review**

What
----

**Problem**: 
The acronyms such as (MiB/KIB/GiB and others) are expanded with mouse hover, however, this functionality is not accessible to standard keyboard commands. This means that some users who are unfamiliar with the acronym and are not able to access its expanded form may not understand its purpose or meaning.

**Solution**
Create a keyboard tabbable and dismissible tooltip that expands the acronym. 

Note about WCAG 2.1 Success Criterion 1.4.13 Content on Hover or Focus:
This success criterion advises that if anything is covering any other content on mouse hover
or keyboard focus, it must be ‘dismissible’ without moving the mouse or keyboard focus.
(e.g. by using the ‘Esc’ key)

To achieve this, we modified the `abbr` to no longer have the description in the tittle attribute. Instead, we add an `aria-label` attribute that holds that description which becomes visible as a "tooltip" on `:after` pseudo on keyboard focus or mouse hover of `abbr`.
To make it keyboard focusable, we added `tabindex=0` to `abbr` element.

Additionally it requires so javascript that listens to events on the target element and makes the expanded description visible. If Javascript is disabled, we do not show the tooltip, but the description is still accessible via keyboard.

Fixes: https://www.pivotaltracker.com/n/projects/1275640/stories/174195569

How to review
-------------

- checkout branch, run locally
- best to review commit by commit
- go to any page with acronyms
- use mouse to hover of the element. 
  - Tooltip should appear/disappear
- use keyboard TAB key to tab to the element
  - on focus tooltip should appear
  - it should be dismissed with ESC key
  - it should also disappear when focus moves away


Who can review
---------------

not @kr8n3r 

Visual changes
----

### On mouse hover
<img width="257" alt="Screenshot 2020-08-28 at 08 16 41" src="https://user-images.githubusercontent.com/3758555/91534030-c574d580-e908-11ea-98c4-bfcad62285e5.png">

### On keyboard focus
<img width="264" alt="Screenshot 2020-08-28 at 08 16 50" src="https://user-images.githubusercontent.com/3758555/91534049-d0c80100-e908-11ea-84b7-f98c14cb5aff.png">

### Interactive example showing hover/focus/dismiss
![tooltip interactive example](https://user-images.githubusercontent.com/3758555/91536393-8d6f9180-e90c-11ea-8338-e6392eb4b64d.gif)



