### PR TITLE
Update metrics user range input and page layout

### DIFF
--- a/src/components/service-metrics/controllers.test.tsx
+++ b/src/components/service-metrics/controllers.test.tsx
@@ -879,5 +879,19 @@ describe(parseRange, () => {
       .toEqual(moment(userStopInput).subtract('1','month').format('YYYY-MM-DD[T]HH:mm'));
     // momentjs months are Zero-based hence the subtraction
   });
+
+  it('should use current\' date-time values if user-entered values are not a valid date', () => {
+
+    const userStartInput = { day: 13, month: 13 , year: 2019, hour: 14, minute: 25 }
+    const userStopInput = { day: 14, month: 13 , year: 2020, hour: 15, minute: 25 }
+    const today = moment()
+    
+    const userEnteredRange = parseRange(userStartInput, userStopInput)
+    expect((userEnteredRange.rangeStart).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(today.format('YYYY-MM-DD[T]HH:mm')); 
+    expect((userEnteredRange.rangeStop).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(today.format('YYYY-MM-DD[T]HH:mm'));
+    // momentjs months are Zero-based hence the subtraction
+  });
 });
 

--- a/src/components/service-metrics/controllers.test.tsx
+++ b/src/components/service-metrics/controllers.test.tsx
@@ -22,6 +22,7 @@ import { IContext } from '../app/context';
 import {
   composeValue,
   downloadServiceMetrics,
+  isNumeric,
   parseRange,
   resolveServiceMetrics,
   sanitiseMomentInput,
@@ -815,6 +816,15 @@ describe(composeValue, () => {
     expect(composeValue(128)).toEqual('128.00');
   });
 });
+describe(isNumeric, () => {
+  it('should return true if a string resembles a number', () => {
+    expect(isNumeric('01')).toBeTruthy();
+  });
+  it('should return false if a string doesn\'t resemeble a number', () => {
+    expect(isNumeric('bb')).not.toBeTruthy();
+  });
+});
+
 
 describe(sanitiseMomentInput, () => {
   it('should populate values with today\'s date-time if input values are missing', () => {

--- a/src/components/service-metrics/controllers.test.tsx
+++ b/src/components/service-metrics/controllers.test.tsx
@@ -408,20 +408,6 @@ describe('service metrics test suite', () => {
     expect(response.redirect).toContain('rangeStop');
   });
 
-  it('should throw an error if rangeStop is sooner than rangeStart', async () => {
-    await expect(
-      viewServiceMetrics(ctx, {
-        organizationGUID: '6e1ca5aa-55f1-4110-a97f-1f3473e771b9',
-        rangeStart: moment().format('YYYY-MM-DD[T]HH:mm'),
-        rangeStop: moment()
-          .subtract(1, 'hour')
-          .format('YYYY-MM-DD[T]HH:mm'),
-        serviceGUID: '54e4c645-7d20-4271-8c27-8cc904e1e7ee',
-        spaceGUID: '38511660-89d9-4a6e-a889-c32c7e94f139',
-      }),
-    ).rejects.toThrow(/Invalid time range provided/);
-  });
-
   it('should throw an error if asking for more than a year of metrics', async () => {
     await expect(
       viewServiceMetrics(ctx, {
@@ -877,7 +863,6 @@ describe(parseRange, () => {
       .toEqual(moment(userStartInput).subtract('1','month').format('YYYY-MM-DD[T]HH:mm')); 
     expect((userEnteredRange.rangeStop).format('YYYY-MM-DD[T]HH:mm'))
       .toEqual(moment(userStopInput).subtract('1','month').format('YYYY-MM-DD[T]HH:mm'));
-    // momentjs months are Zero-based hence the subtraction
   });
 
   it('should use current\' date-time values if user-entered values are not a valid date', () => {
@@ -891,7 +876,16 @@ describe(parseRange, () => {
       .toEqual(today.format('YYYY-MM-DD[T]HH:mm')); 
     expect((userEnteredRange.rangeStop).format('YYYY-MM-DD[T]HH:mm'))
       .toEqual(today.format('YYYY-MM-DD[T]HH:mm'));
-    // momentjs months are Zero-based hence the subtraction
+  });
+
+  it('should use current datetime and current datetime minus 1 hour if stop date is before start date', () => {
+    
+    const rangeStartBeforeStop = parseRange('2020-11-01T14:25', '2020-09-01T15:25')
+
+    expect((rangeStartBeforeStop.rangeStart).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(moment().subtract(1,'hour').format('YYYY-MM-DD[T]HH:mm')); 
+    expect((rangeStartBeforeStop.rangeStop).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(moment().format('YYYY-MM-DD[T]HH:mm')); 
   });
 });
 

--- a/src/components/service-metrics/controllers.test.tsx
+++ b/src/components/service-metrics/controllers.test.tsx
@@ -22,7 +22,9 @@ import { IContext } from '../app/context';
 import {
   composeValue,
   downloadServiceMetrics,
+  parseRange,
   resolveServiceMetrics,
+  sanitiseMomentInput,
   viewServiceMetrics,
 } from '.';
 
@@ -813,3 +815,59 @@ describe(composeValue, () => {
     expect(composeValue(128)).toEqual('128.00');
   });
 });
+
+describe(sanitiseMomentInput, () => {
+  it('should populate values with today\'s date-time if input values are missing', () => {
+    const userInput = sanitiseMomentInput(
+      { day: undefined, month: undefined, year: undefined, hour: undefined, minute: undefined },
+    )
+    const currentDay = Number(moment().format('DD'))
+    const currentMonth = Number(moment().format('MM')) - 1  // momentjs months are Zero-based
+    const currentYear = Number(moment().format('YYYY'))
+    const currentHour = Number(moment().format('HH'))
+    const currentMinute = Number(moment().format('mm'))
+    expect(userInput.day).toEqual(currentDay);
+    expect(userInput.month).toEqual(currentMonth);
+    expect(userInput.year).toEqual(currentYear);
+    expect(userInput.hour).toEqual(currentHour);
+    expect(userInput.minute).toEqual(currentMinute);
+  });
+});
+
+describe(parseRange, () => {
+  it('should do nothing if user hasn\'t submitted anything', () => {
+
+    const defaultRange = parseRange('2020-09-13T14:25', '2020-09-14T15:25')
+    expect((defaultRange.rangeStart).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(moment('2020-09-13T14:25').format('YYYY-MM-DD[T]HH:mm'));
+    expect((defaultRange.rangeStop).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(moment('2020-09-14T15:25').format('YYYY-MM-DD[T]HH:mm'));
+
+  });
+  it('should return a sanitized user input', () => {
+
+    const userStartInput = { day: 13, month: 9 , year: 2020, hour: 14, minute: 25 }
+    const userStopInput = { day: 14, month: 9 , year: 2020, hour: 15, minute: 25 }
+    
+    const userEnteredRange = parseRange(userStartInput, userStopInput)
+    expect((userEnteredRange.rangeStart).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(moment(userStartInput).subtract('1','month').format('YYYY-MM-DD[T]HH:mm')); 
+    expect((userEnteredRange.rangeStop).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(moment(userStopInput).subtract('1','month').format('YYYY-MM-DD[T]HH:mm'));
+    // momentjs months are Zero-based hence the subtraction
+  });
+
+  it('should return a sanitized user input', () => {
+
+    const userStartInput = { day: 13, month: 9 , year: 2020, hour: 14, minute: 25 }
+    const userStopInput = { day: 14, month: 9 , year: 2020, hour: 15, minute: 25 }
+    
+    const userEnteredRange = parseRange(userStartInput, userStopInput)
+    expect((userEnteredRange.rangeStart).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(moment(userStartInput).subtract('1','month').format('YYYY-MM-DD[T]HH:mm')); 
+    expect((userEnteredRange.rangeStop).format('YYYY-MM-DD[T]HH:mm'))
+      .toEqual(moment(userStopInput).subtract('1','month').format('YYYY-MM-DD[T]HH:mm'));
+    // momentjs months are Zero-based hence the subtraction
+  });
+});
+

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -46,7 +46,7 @@ interface IRange {
   readonly rangeStop: moment.Moment;
 }
 
-function sanitiseMomentInput(date: moment.MomentInputObject): moment.MomentInputObject {
+export function sanitiseMomentInput(date: moment.MomentInputObject): moment.MomentInputObject {
   return {
     // if users enter something other than a number, return current date-time value
     day: typeof date.day === 'number' ? date.day : moment().date(),
@@ -57,7 +57,7 @@ function sanitiseMomentInput(date: moment.MomentInputObject): moment.MomentInput
   };
 }
 
-function parseRange(start: string | moment.MomentInputObject, stop: string | moment.MomentInputObject): IRange {
+export function parseRange(start: string | moment.MomentInputObject, stop: string | moment.MomentInputObject): IRange {
   const rangeStart = moment(typeof start === 'object' ? sanitiseMomentInput(start) : start);
   const rangeStop = moment(typeof stop === 'object' ? sanitiseMomentInput(stop) : stop);
   if (

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -63,8 +63,11 @@ export function sanitiseMomentInput(date: moment.MomentInputObject): moment.Mome
 }
 
 export function parseRange(start: string | moment.MomentInputObject, stop: string | moment.MomentInputObject): IRange {
-  const rangeStart = moment(typeof start === 'object' ? sanitiseMomentInput(start) : start);
-  const rangeStop = moment(typeof stop === 'object' ? sanitiseMomentInput(stop) : stop);
+  const rangeStart = typeof start === 'object' ? moment(sanitiseMomentInput(start)).isValid() ? 
+    moment(sanitiseMomentInput(start)) : moment() : moment(start);
+  const rangeStop = typeof stop === 'object' ? moment(sanitiseMomentInput(stop)).isValid() ? 
+    moment(sanitiseMomentInput(stop)) : moment() : moment(stop);
+
   if (
     rangeStart.isBefore(
       rangeStop

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -63,9 +63,9 @@ export function sanitiseMomentInput(date: moment.MomentInputObject): moment.Mome
 }
 
 export function parseRange(start: string | moment.MomentInputObject, stop: string | moment.MomentInputObject): IRange {
-  const rangeStart = typeof start === 'object' ? moment(sanitiseMomentInput(start)).isValid() ? 
+  let rangeStart = typeof start === 'object' ? moment(sanitiseMomentInput(start)).isValid() ? 
     moment(sanitiseMomentInput(start)) : moment() : moment(start);
-  const rangeStop = typeof stop === 'object' ? moment(sanitiseMomentInput(stop)).isValid() ? 
+  let rangeStop = typeof stop === 'object' ? moment(sanitiseMomentInput(stop)).isValid() ? 
     moment(sanitiseMomentInput(stop)) : moment() : moment(stop);
 
   if (
@@ -99,7 +99,8 @@ export function parseRange(start: string | moment.MomentInputObject, stop: strin
   }
 
   if (rangeStop.isBefore(rangeStart)) {
-    throw new UserFriendlyError('Invalid time range provided');
+    rangeStart = moment().subtract(1,'hour');
+    rangeStop = moment();
   }
 
   const period = moment.duration(getPeriod(rangeStart, rangeStop), 'seconds');

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -5,7 +5,7 @@ import { mapValues, values } from 'lodash';
 import moment from 'moment';
 import React from 'react';
 
-import { bytesConvert, Template } from '../../layouts';
+import { bytesConvert, DATE_TIME, Template } from '../../layouts';
 import CloudFoundryClient from '../../lib/cf';
 import {
   CloudFrontMetricDataGetter,
@@ -207,7 +207,8 @@ export async function viewServiceMetrics(
 
   const template = new Template(
     ctx.viewContext,
-    `Service ${service.entity.name} Metrics`,
+    `Service ${service.entity.name} Metrics between 
+    ${moment(rangeStart).format(DATE_TIME)} and ${moment(rangeStop).format(DATE_TIME)}`,
   );
   template.breadcrumbs = fromOrg(ctx, organization, [
     {

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -46,14 +46,19 @@ interface IRange {
   readonly rangeStop: moment.Moment;
 }
 
+// check if user-provided string is a number
+export function isNumeric(value: any) {
+  return /^\d+$/.test(value);
+}
+
 export function sanitiseMomentInput(date: moment.MomentInputObject): moment.MomentInputObject {
   return {
     // if users enter something other than a number, return current date-time value
-    day: typeof date.day === 'number' ? date.day : moment().date(),
-    hour: typeof date.hour === 'number' ? date.hour : moment().hour(),
-    minute: typeof date.minute === 'number' ? date.minute : moment().minute(),
-    month: typeof date.month === 'number' ? date.month - 1 : moment().month(),
-    year: typeof date.year === 'number' ? date.year : moment().year(),
+    day: isNumeric(date.day) ? date.day : moment().date(),
+    hour: isNumeric(date.hour) ? date.hour : moment().hour(),
+    minute: isNumeric(date.minute) ? date.minute : moment().minute(),
+    month: isNumeric(date.month) ? date.month - 1 : moment().month(),
+    year: isNumeric(date.year) ? date.year : moment().year(),
   };
 }
 

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -46,9 +46,20 @@ interface IRange {
   readonly rangeStop: moment.Moment;
 }
 
-function parseRange(start: string, stop: string): IRange {
-  const rangeStart = moment(start);
-  const rangeStop = moment(stop);
+function sanitiseMomentInput(date: moment.MomentInputObject): moment.MomentInputObject {
+  return {
+    // if users enter something other than a number, return current date-time value
+    day: typeof date.day === 'number' ? date.day : moment().date(),
+    hour: typeof date.hour === 'number' ? date.hour : moment().hour(),
+    minute: typeof date.minute === 'number' ? date.minute : moment().minute(),
+    month: typeof date.month === 'number' ? date.month - 1 : moment().month(),
+    year: typeof date.year === 'number' ? date.year : moment().year(),
+  };
+}
+
+function parseRange(start: string | moment.MomentInputObject, stop: string | moment.MomentInputObject): IRange {
+  const rangeStart = moment(typeof start === 'object' ? sanitiseMomentInput(start) : start);
+  const rangeStop = moment(typeof stop === 'object' ? sanitiseMomentInput(stop) : stop);
   if (
     rangeStart.isBefore(
       rangeStop

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -276,7 +276,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input 
                       className="govuk-input govuk-date-input__input govuk-input--width-2" 
                       id="rangeStartDay"
-                      name="rangeStartDay"
+                      name="rangeStart[day]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
@@ -292,7 +292,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input 
                       className="govuk-input govuk-date-input__input govuk-input--width-2" 
                       id="rangeStartMonth"
-                      name="rangeStartMonth"
+                      name="rangeStart[month]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
@@ -308,7 +308,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input
                       className="govuk-input govuk-date-input__input govuk-input--width-4"
                       id="rangeStartYear"
-                      name="rangeStartYear"
+                      name="rangeStart[year]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
@@ -336,7 +336,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input
                       className="govuk-input govuk-date-input__input govuk-input--width-2"
                       id="rangeStartHour"
-                      name="rangeStartHour"
+                      name="rangeStart[hour]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
@@ -352,7 +352,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input 
                       className="govuk-input govuk-date-input__input govuk-input--width-2"
                       id="rangeStartMinute"
-                      name="rangeStartMinute"
+                      name="rangeStart[minute]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
@@ -381,7 +381,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input
                       className="govuk-input govuk-date-input__input govuk-input--width-2"
                       id="rangeStopDay"
-                      name="rangeStopDay"
+                      name="rangeStop[day]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
@@ -397,7 +397,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input
                     className="govuk-input govuk-date-input__input govuk-input--width-2"
                     id="rangeStopMonth"
-                    name="rangeStopMonth"
+                    name="rangeStop[month]"
                     type="text"
                     pattern="[0-9]*"
                     inputMode="numeric"
@@ -413,7 +413,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input
                       className="govuk-input govuk-date-input__input govuk-input--width-4"
                       id="rangeStopYear"
-                      name="rangeStopYear"
+                      name="rangeStop[year]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
@@ -441,7 +441,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input
                       className="govuk-input govuk-date-input__input govuk-input--width-2"
                       id="rangeStopHour"
-                      name="rangeStopHour"
+                      name="rangeStop[hour]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
@@ -457,7 +457,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     <input
                       className="govuk-input govuk-date-input__input govuk-input--width-2"
                       id="rangeStopMinute"
-                      name="rangeStopMinute"
+                      name="rangeStop[minute]"
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric" 

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -363,7 +363,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
               </div>
             </fieldset>
           </div>
-          
+          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
           <div className="govuk-form-group">
             <fieldset className="govuk-fieldset" role="group" aria-describedby="range-end-date-hint">
               <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -520,8 +520,14 @@ export function UnsupportedServiceMetricsPage(
 }
 
 export function MetricPage(props: IMetricPageProperties): ReactElement {
+  const title = `Metrics <span class="govuk-visually-hidden">
+    between ${' '}${moment(props.rangeStart).format(DATE_TIME)}${' '}
+    and${' '}${moment(props.rangeStop).format(DATE_TIME)}
+  </span>`;
   return (
-    <ServiceTab {...props} pageTitle="Metrics">
+    <ServiceTab
+      {...props}
+      pageTitle={title}>
 
       <div className="govuk-width-container">
         <div className="govuk-grid-row">

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -137,16 +137,11 @@ function Metric(props: IMetricProperties): ReactElement {
         </h2>
       </div>
 
-      <div className="govuk-grid-column-two-thirds-from-desktop">
+      <div className="govuk-grid-column-full">
         <p className="govuk-body">{props.description}</p>
 
         <MetricChart chart={props.chart.outerHTML} />
 
-        <a href={downloadLink.toString()} className="govuk-link" download>
-          Download &quot;{props.titleText || props.title}&quot; as a CSV
-        </a>
-      </div>
-      <div className="govuk-grid-column-one-third-from-desktop">
         <div className="scrollable-table-container">
           <table className="govuk-table">
           <caption className="govuk-table__caption govuk-visually-hidden">
@@ -209,6 +204,9 @@ function Metric(props: IMetricProperties): ReactElement {
           </tbody>
         </table>
         </div>
+        <a href={downloadLink.toString()} className="govuk-link" download>
+          Download &quot;{props.titleText || props.title}&quot; as a CSV
+        </a>
       </div>
     </div>
   );
@@ -217,53 +215,8 @@ function Metric(props: IMetricProperties): ReactElement {
 function RangePicker(props: IRangePickerProperties): ReactElement {
   return (
     <div className="paas-statement-filters">
-      <p className="govuk-body">
-        Showing metrics for{' '}
-        <a
-          href={props.linkTo('admin.organizations.spaces.services.view', {
-            organizationGUID: props.organizationGUID,
-            serviceGUID: props.service.metadata.guid,
-            spaceGUID: props.spaceGUID,
-          })}
-          className="govuk-link non-breaking"
-        >
-          <span className="govuk-visually-hidden">Service name:</span> {props.service.entity.name}
-        </a>{' '}
-        between <br />
-        <strong>{moment(props.rangeStart).format(DATE_TIME)}</strong>
-        <br /> and <br />
-        <strong>{moment(props.rangeStop).format(DATE_TIME)}</strong>
-      </p>
-
-      <p className="govuk-body">
-        Metrics timestamps are in UTC format.
-      </p>
-
-      <p className="govuk-body">
-        Each point on a graph is aggregated over
-        {' '}
-        <strong className="non-breaking">{props.period.humanize()}</strong>
-        {' '}
-        of data.
-      </p>
-
-      {props.persistancePeriod ? (
-        <p className="govuk-body">
-          These metrics are retained for up to{' '}
-          <strong>{props.persistancePeriod}</strong>. While metrics are
-          experimental, we cannot guarantee a minimum metrics retention period.
-        </p>
-      ) : (
-        <></>
-      )}
-
-      <details className="govuk-details" data-module="govuk-details">
-        <summary className="govuk-details__summary">
-          <span className="govuk-details__summary-text">
-            Change time period
-          </span>
-        </summary>
-        <div className="govuk-details__text">
+      <h2 className="govuk-heading-m">Change time period</h2>
+      <h3 className="govuk-heading-s">Chose a predefined period</h3>
         <ol className="govuk-list">
           {[
             { long: '1 hour', short: '1h' },
@@ -291,8 +244,8 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
             </li>
           ))}
         </ol>
-
         <form
+          noValidate
           method="get"
           action={props.linkTo(
             'admin.organizations.spaces.services.metrics.view',
@@ -305,37 +258,217 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
         >
           <input type="hidden" name="_csrf" value={props.csrf} />
 
-          <h2 className="govuk-heading-s">Or provide custom date <span className="govuk-visually-hidden">for showing metrics</span></h2>
+          <h3 className="govuk-heading-s">Provide custom date and time <span className="govuk-visually-hidden">for showing metrics</span></h3>
           <div className="govuk-form-group">
-            <label className="govuk-label" htmlFor="rangeStart">
-              Start time
-            </label>
-            <input
-              type="datetime-local"
-              id="rangeStart"
-              name="rangeStart"
-              className="govuk-input"
-              defaultValue={moment(props.rangeStart).format(
-                'YYYY-MM-DD[T]HH:mm',
-              )}
-            />
+            <fieldset className="govuk-fieldset" role="group" aria-describedby="range-start-date-hint">
+              <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
+                Enter start date
+              </legend>
+              <div id="range-start-date-hint" className="govuk-hint">
+                For example, 12 11 2007
+              </div>
+              <div className="govuk-date-input" id="range-start">
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="rangeStartDay">
+                      Day
+                    </label>
+                    <input 
+                      className="govuk-input govuk-date-input__input govuk-input--width-2" 
+                      id="rangeStartDay"
+                      name="rangeStartDay"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric"
+                      defaultValue={moment(props.rangeStart).format('DD')}
+                    />
+                  </div>
+                </div>
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="startMonth">
+                      Month
+                    </label>
+                    <input 
+                      className="govuk-input govuk-date-input__input govuk-input--width-2" 
+                      id="rangeStartMonth"
+                      name="rangeStartMonth"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric"
+                      defaultValue={moment(props.rangeStart).format('MM')}
+                      />
+                  </div>
+                </div>
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="rangeStartYear">
+                      Year
+                    </label>
+                    <input
+                      className="govuk-input govuk-date-input__input govuk-input--width-4"
+                      id="rangeStartYear"
+                      name="rangeStartYear"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric"
+                      defaultValue={moment(props.rangeStart).format('YYYY')}
+                      />
+                  </div>
+                </div>
+              </div>
+            </fieldset>
           </div>
-
           <div className="govuk-form-group">
-            <label className="govuk-label" htmlFor="rangeStop">
-              End time
-            </label>
-            <input
-              type="datetime-local"
-              id="rangeStop"
-              name="rangeStop"
-              className="govuk-input"
-              defaultValue={moment(props.rangeStop).format(
-                'YYYY-MM-DD[T]HH:mm',
-              )}
-            />
+            <fieldset className="govuk-fieldset" role="group" aria-describedby="range-start-time-hint">
+              <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
+                Enter start time
+              </legend>
+              <div id="range-start-time-hint" className="govuk-hint">
+                For example, 08:10
+              </div>
+              <div className="govuk-date-input" id="range-start-time">
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="rangeStartHour">
+                      Hours
+                    </label>
+                    <input
+                      className="govuk-input govuk-date-input__input govuk-input--width-2"
+                      id="rangeStartHour"
+                      name="rangeStartHour"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric"
+                      defaultValue={moment(props.rangeStart).format('HH')}
+                    />
+                  </div>
+                </div>
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="rangeStartMinute">
+                      Minutes
+                    </label>
+                    <input 
+                      className="govuk-input govuk-date-input__input govuk-input--width-2"
+                      id="rangeStartMinute"
+                      name="rangeStartMinute"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric"
+                      defaultValue={moment(props.rangeStart).format('mm')} 
+                    />
+                  </div>
+                </div>
+              </div>
+            </fieldset>
           </div>
-
+          
+          <div className="govuk-form-group">
+            <fieldset className="govuk-fieldset" role="group" aria-describedby="range-end-date-hint">
+              <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
+                Enter end date
+              </legend>
+              <div id="range-end-date-hint" className="govuk-hint">
+                For example, 12 11 2007
+              </div>
+              <div className="govuk-date-input" id="range-end-date">
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="rangeStopDay">
+                      Day
+                    </label>
+                    <input
+                      className="govuk-input govuk-date-input__input govuk-input--width-2"
+                      id="rangeStopDay"
+                      name="rangeStopDay"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric"
+                      defaultValue={moment(props.rangeStop).format('DD')}
+                      />
+                  </div>
+                </div>
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="rangeStopMonth">
+                      Month
+                    </label>
+                    <input
+                    className="govuk-input govuk-date-input__input govuk-input--width-2"
+                    id="rangeStopMonth"
+                    name="rangeStopMonth"
+                    type="text"
+                    pattern="[0-9]*"
+                    inputMode="numeric"
+                    defaultValue={moment(props.rangeStop).format('MM')}
+                  />
+                  </div>
+                </div>
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="rangeStopYear">
+                      Year
+                    </label>
+                    <input
+                      className="govuk-input govuk-date-input__input govuk-input--width-4"
+                      id="rangeStopYear"
+                      name="rangeStopYear"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric"
+                      defaultValue={moment(props.rangeStop).format('YYYY')}
+                    />
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <div className="govuk-form-group">
+            <fieldset className="govuk-fieldset" role="group" aria-describedby="range-end-time-hint">
+              <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
+                Enter end time
+              </legend>
+              <div id="range-end-time-hint" className="govuk-hint">
+                For example, 16:10
+              </div>
+              <div className="govuk-date-input" id="range-end-time">
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                    <label className="govuk-label govuk-date-input__label" htmlFor="rangeStopHour">
+                      Hours
+                    </label>
+                    <input
+                      className="govuk-input govuk-date-input__input govuk-input--width-2"
+                      id="rangeStopHour"
+                      name="rangeStopHour"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric"
+                      defaultValue={moment(props.rangeStop).format('HH')}
+                    />
+                  </div>
+                </div>
+                <div className="govuk-date-input__item">
+                  <div className="govuk-form-group">
+                  <label className="govuk-label govuk-date-input__label" htmlFor="rangeStopMinute">
+                      Minutes
+                    </label>
+                    <input
+                      className="govuk-input govuk-date-input__input govuk-input--width-2"
+                      id="rangeStopMinute"
+                      name="rangeStopMinute"
+                      type="text"
+                      pattern="[0-9]*"
+                      inputMode="numeric" 
+                      defaultValue={moment(props.rangeStop).format('mm')}
+                      />
+                    </div>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          
           <button
             className="govuk-button"
             data-module="govuk-button"
@@ -344,8 +477,6 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
             Update
           </button>
         </form>
-        </div>
-      </details>
     </div>
   );
 }
@@ -391,11 +522,11 @@ export function UnsupportedServiceMetricsPage(
 export function MetricPage(props: IMetricPageProperties): ReactElement {
   return (
     <ServiceTab {...props} pageTitle="Metrics">
-      <ExperimentalWarning />
 
       <div className="govuk-width-container">
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds-from-desktop">
+            <ExperimentalWarning />
             <p className="govuk-body">
               Currently the available metrics for {props.serviceLabel} are:
             </p>
@@ -408,6 +539,51 @@ export function MetricPage(props: IMetricPageProperties): ReactElement {
                 </li>
               ))}
             </ul>
+            <hr className="govuk-section-break govuk-section-break--m" />
+            <p className="govuk-body">
+              Showing metrics between{' '}
+              <strong>{moment(props.rangeStart).format(DATE_TIME)}</strong>{' '}
+              and{' '}
+              <strong>{moment(props.rangeStop).format(DATE_TIME)}</strong>
+            </p>
+
+            <p className="govuk-body">
+              Metrics timestamps are in UTC format.
+            </p>
+
+            <p className="govuk-body">
+              Each point on a graph is aggregated over
+              {' '}
+              <strong className="non-breaking">{props.period.humanize()}</strong>
+              {' '}
+              of data.
+            </p>
+
+            {props.persistancePeriod ? (
+              <p className="govuk-body">
+                These metrics are retained for up to{' '}
+                <strong>{props.persistancePeriod}</strong>. While metrics are
+                experimental, we cannot guarantee a minimum metrics retention period.
+              </p>
+            ) : (
+              <></>
+            )}
+            <hr className="govuk-section-break govuk-section-break--m" />
+
+            {props.metrics.map(metric => (
+              <Metric
+                key={metric.id}
+                id={metric.id}
+                format={metric.format}
+                title={metric.title}
+                description={metric.description}
+                chart={metric.chart}
+                units={metric.units}
+                metric={metric.metric}
+                summaries={metric.summaries}
+                downloadLink={metric.downloadLink}
+              />
+            ))}
           </div>
 
           <div className="govuk-grid-column-one-third-from-desktop">
@@ -420,27 +596,9 @@ export function MetricPage(props: IMetricPageProperties): ReactElement {
               period={props.period}
               linkTo={props.linkTo}
               service={props.service}
-              persistancePeriod={props.persistancePeriod}
             />
           </div>
         </div>
-      </div>
-
-      <div className="govuk-width-container">
-        {props.metrics.map(metric => (
-          <Metric
-            key={metric.id}
-            id={metric.id}
-            format={metric.format}
-            title={metric.title}
-            description={metric.description}
-            chart={metric.chart}
-            units={metric.units}
-            metric={metric.metric}
-            summaries={metric.summaries}
-            downloadLink={metric.downloadLink}
-          />
-        ))}
       </div>
     </ServiceTab>
   );

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -74,7 +74,12 @@ export function ServiceTab(props: IServiceTabProperties): ReactElement {
           <span className="govuk-visually-hidden">Service</span>{' '}
           {props.service.entity.name}
         </span>{' '}
-        {props.pageTitle}
+        
+        <span
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+          __html: (props.pageTitle) as string,
+        }} />
       </h1>
 
       <div className="govuk-tabs" data-module="govuk-tabs">


### PR DESCRIPTION
Co-authored with @paroxp 

What
----

**Problem:**
Screen reader users were initially unsure how to populate the ‘Start time’ and ‘End time’ input fields. The ‘value’ applied is of an American format and not what is visible on screen.

The value attribute is set to an American date format which reads to screen reader users backwards and may confuse some users as this contradicts what is displayed in the input field.

**Solution:**
Replace `input type="date-time"` date-picker with a Date input (and time input) components fields as is recommended by the GOV.UK Design System.

If users enter an invalid date we populate the values from current date-time object.

This makes the change range container much longer.

We've updated the layout so that the graphs and tables take up 2/3 of the width and the other 1/3 is the range container, for the whole of the page.

We've also moved the text about the current time period out of the container to above the metrics.

Page `title` and main heading now have visually-hidden text with dates of the start/stop range

How to review
-------------

- checkout branch, run locally
- go to backing service metrics page
- check date input return metrics for a valid date or if left empty (or chars) values from today's date-time object
- check download CSV links contain correct values
- check that page title and main heading (including visually hidden text) match

Who can review
---------------

not @kr8n3r 

Visual changes
----

## Before
![before](https://user-images.githubusercontent.com/3758555/93124578-bbe9bc80-f6c1-11ea-9088-bc5ae321d9c1.png)


## After
![after](https://user-images.githubusercontent.com/3758555/93124784-13882800-f6c2-11ea-87e7-0a5b843aae5e.png)

