### PR TITLE
Update main navigation menu label

### DIFF
--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -91,7 +91,7 @@ export function Header(props: IHeaderProperties): ReactElement {
             type="button"
             className="govuk-header__menu-button govuk-js-header-toggle"
             aria-controls="navigation"
-            aria-label="Show or hide Top Level Navigation"
+            aria-label="Show or hide Top Level Navigation Menu"
           >
             Menu
           </button>


### PR DESCRIPTION
What
----

Problem:
The aria-label for the 'Menu' button in the header does not include
'menu' despite the button being labelled with the text 'menu'.

This fails WCAG 2.5.3 - Label in name, as flagged in an audit of Digital Marketplace.

Solution:
Add the word 'menu' to the button `aria-label`


Who can review
---------------

not @kr8n3r 
