### PR TITLE
Add number of service instances to spaces list

### DIFF
--- a/src/components/applications/views.tsx
+++ b/src/components/applications/views.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, ReactNode } from 'react';
 import { CommandLineAlternative } from '../../layouts/partials';
 import { IApplication } from '../../lib/cf/types';
 import { RouteActiveChecker, RouteLinker } from '../app';
-import { IEnchancedApplication } from '../spaces/views';
+import { IEnhancedApplication } from '../spaces/views';
 
 interface IApplicationTabProperties {
   readonly application: IApplication;
@@ -19,7 +19,7 @@ interface IApplicationPageProperties {
   readonly additionalRuntimeInfo: ReadonlyArray<
     ReadonlyArray<{ readonly text: string | null }>
   >;
-  readonly application: IEnchancedApplication;
+  readonly application: IEnhancedApplication;
   readonly linkTo: RouteLinker;
   readonly organizationGUID: string;
   readonly routePartOf: RouteActiveChecker;

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -8,13 +8,13 @@ import { CommandLineAlternative } from '../../layouts/partials';
 import { IService, IServiceInstance, IServicePlan } from '../../lib/cf/types';
 import { RouteActiveChecker, RouteLinker } from '../app';
 
-interface IEnchancedServiceInstance extends IServiceInstance {
+interface IEnhancedServiceInstance extends IServiceInstance {
   readonly service?: IService;
   readonly service_plan?: IServicePlan;
 }
 
 interface IServicePageProperties {
-  readonly service: IEnchancedServiceInstance;
+  readonly service: IEnhancedServiceInstance;
   readonly linkTo: RouteLinker;
   readonly pageTitle: string;
   readonly organizationGUID: string;

--- a/src/components/spaces/controllers.test.tsx
+++ b/src/components/spaces/controllers.test.tsx
@@ -195,6 +195,9 @@ describe('spaces test suite', () => {
         ),
       )
 
+      .get(`/v2/spaces/${spaceGUID}/service_instances`)
+      .reply(200, data.services)
+
       .get('/v2/quota_definitions/ORG-QUOTA-GUID')
       .reply(200, data.organizationQuota)
 
@@ -208,7 +211,10 @@ describe('spaces test suite', () => {
             }),
           ),
         ),
-      );
+      )
+
+      .get(`/v2/spaces/${secondSpace}/service_instances`)
+      .reply(200, data.services);
     const response = await spaces.listSpaces(ctx, { organizationGUID });
 
     expect(response.body).toContain('Quota usage');

--- a/src/components/spaces/controllers.tsx
+++ b/src/components/spaces/controllers.tsx
@@ -358,8 +358,9 @@ export async function listSpaces(
 
   const summarisedSpaces = await Promise.all(
     spaces.map(async (space: ISpace) => {
-      const [applications, quota] = await Promise.all([
+      const [applications, serviceInstances, quota] = await Promise.all([
         await cf.applications(space.metadata.guid),
+        await cf.spaceServices(space.metadata.guid),
         space.entity.space_quota_definition_guid
           ? await cf.spaceQuota(space.entity.space_quota_definition_guid)
           : await Promise.resolve(undefined),
@@ -376,6 +377,7 @@ export async function listSpaces(
 
       return {
         apps: applications,
+        serviceInstances: serviceInstances,
         entity: space.entity,
         memory_allocated: spaceMemoryAllocated,
         metadata: space.metadata,

--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -13,10 +13,10 @@ import {
   ApplicationsPage,
   BackingServicePage,
   EventsPage,
-  IEnchancedApplication,
-  IEnchancedOrganization,
-  IEnchancedServiceInstance,
-  IEnchancedSpace,
+  IEnhancedApplication,
+  IEnhancedOrganization,
+  IEnhancedServiceInstance,
+  IEnhancedSpace,
   IStripedUserServices,
   SpacesPage,
 } from './views';
@@ -207,7 +207,7 @@ describe(ApplicationsPage, () => {
       state: 'running',
     },
     urls: ['test.example.com'],
-  } as unknown) as IEnchancedApplication;
+  } as unknown) as IEnhancedApplication;
 
   it('should print correct phrasing when single service listed', () => {
     const markup = shallow(
@@ -272,7 +272,7 @@ describe(BackingServicePage, () => {
     },
     { metadata: { guid: 'SERVICE_GUID_2' }, entity: { name: 'service-2' } },
   ] as unknown) as ReadonlyArray<
-    IEnchancedServiceInstance | IStripedUserServices
+    IEnhancedServiceInstance | IStripedUserServices
   >;
 
   it('should correctly print the backing service page', () => {
@@ -324,7 +324,7 @@ describe(BackingServicePage, () => {
 
   it('should not display a table of backing service if there no backing services', () => {
     const noServices = ([] as unknown) as ReadonlyArray<
-      IEnchancedServiceInstance | IStripedUserServices
+      IEnhancedServiceInstance | IStripedUserServices
     >;
     const markup = shallow(
       <BackingServicePage
@@ -350,7 +350,7 @@ describe(SpacesPage, () => {
     quota: {
       entity: { name: 'default', memory_limit: (5 * GIBIBYTE) / MEBIBYTE },
     },
-  } as unknown) as IEnchancedOrganization;
+  } as unknown) as IEnhancedOrganization;
   const space = ({
     metadata: { guid: 'SPACE_GUID_1' },
     entity: { name: 'space-name' },
@@ -359,7 +359,7 @@ describe(SpacesPage, () => {
     running_apps: [null],
     stopped_apps: [null],
     serviceInstances: [null],
-  } as unknown) as IEnchancedSpace;
+  } as unknown) as IEnhancedSpace;
 
   it('should correctly render the spaces page', () => {
     const markup = shallow(

--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -358,6 +358,7 @@ describe(SpacesPage, () => {
     quota: { entity: { memory_limit: (5 * GIBIBYTE) / MEBIBYTE } },
     running_apps: [null],
     stopped_apps: [null],
+    serviceInstances: [null],
   } as unknown) as IEnchancedSpace;
 
   it('should correctly render the spaces page', () => {

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -42,6 +42,7 @@ export interface IEnchancedSpace extends ISpace {
   readonly quota?: ISpaceQuota;
   readonly running_apps: ReadonlyArray<IApplication>;
   readonly stopped_apps: ReadonlyArray<IApplication>;
+  readonly serviceInstances: ReadonlyArray<IServiceInstance>;
 }
 
 interface ISpacesPageProperties {
@@ -336,6 +337,12 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
             >
               Stopped apps
             </th>
+            <th
+              scope="col"
+              className="govuk-table__header govuk-table__header--numeric"
+            >
+              Backing services
+            </th>
           </tr>
         </thead>
         <tbody className="govuk-table__body">
@@ -368,6 +375,9 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
               </td>
               <td className="govuk-table__cell govuk-table__cell--numeric">
                 {space.stopped_apps.length}
+              </td>
+              <td className="govuk-table__cell govuk-table__cell--numeric">
+                {space.serviceInstances.length}
               </td>
             </tr>
           ))}

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -27,17 +27,17 @@ import {
   EventTimestamps,
 } from '../events';
 
-export interface IEnchancedApplication extends IApplication {
+export interface IEnhancedApplication extends IApplication {
   readonly summary: IApplicationSummary;
   readonly urls: ReadonlyArray<string>;
 }
 
-export interface IEnchancedOrganization extends IOrganization {
+export interface IEnhancedOrganization extends IOrganization {
   readonly memory_allocated: number;
   readonly quota: IOrganizationQuota;
 }
 
-export interface IEnchancedSpace extends ISpace {
+export interface IEnhancedSpace extends ISpace {
   readonly memory_allocated: number;
   readonly quota?: ISpaceQuota;
   readonly running_apps: ReadonlyArray<IApplication>;
@@ -50,13 +50,13 @@ interface ISpacesPageProperties {
   readonly isAdmin: boolean;
   readonly isManager: boolean;
   readonly isBillingManager: boolean;
-  readonly organization: IEnchancedOrganization;
-  readonly spaces: ReadonlyArray<IEnchancedSpace>;
+  readonly organization: IEnhancedOrganization;
+  readonly spaces: ReadonlyArray<IEnhancedSpace>;
   readonly users: ReadonlyArray<IUser>;
 }
 
 interface IApplicationPageProperties {
-  readonly applications: ReadonlyArray<IEnchancedApplication>;
+  readonly applications: ReadonlyArray<IEnhancedApplication>;
   readonly linkTo: RouteLinker;
   readonly organizationGUID: string;
   readonly routePartOf: RouteActiveChecker;
@@ -72,7 +72,7 @@ interface ISpaceTabProperties {
   readonly space: ISpace;
 }
 
-export interface IEnchancedServiceInstance extends IServiceInstance {
+export interface IEnhancedServiceInstance extends IServiceInstance {
   readonly definition: IService;
   readonly plan: IServicePlan;
 }
@@ -93,7 +93,7 @@ interface IBackingServicePageProperties {
   readonly routePartOf: RouteActiveChecker;
   readonly space: ISpace;
   readonly services: ReadonlyArray<
-    IEnchancedServiceInstance | IStripedUserServices
+    IEnhancedServiceInstance | IStripedUserServices
   >;
 }
 
@@ -646,8 +646,8 @@ export function EventsPage(props: IEventsPageProperties): ReactElement {
         pages={props.pagination.total_pages}
       />
 
-      {props.pagination.total_results > 0 ? 
-        <EventTimestamps /> : 
+      {props.pagination.total_results > 0 ?
+        <EventTimestamps /> :
         <></>
       }
 
@@ -659,7 +659,7 @@ export function EventsPage(props: IEventsPageProperties): ReactElement {
         organizationGUID={props.organizationGUID}
         pagination={props.pagination}
       />
-      
+
       {props.events.length > 0 ?
         <div className="scrollable-table-container">
           <table className="govuk-table">
@@ -698,7 +698,7 @@ export function EventsPage(props: IEventsPageProperties): ReactElement {
             </tbody>
           </table>
         </div>
-        : <></> 
+        : <></>
       }
 
       <Pagination


### PR DESCRIPTION
What
----

This adds the number of backing services to the list of spaces:

<img width="498" alt="Screenshot 2020-09-03 at 17 47 09" src="https://user-images.githubusercontent.com/163111/92143899-d2645e00-ee0d-11ea-981b-73f57bc97410.png">

Without this change, the info isn't available to our users without them doing manual clicking or learning to interact with the CC API. With this change it is very easy to see where the service instances are.

As you can see from the screenshot this looks good even on narrow displays.

How to review
-------------

Happy with the change?
Code review.

Who can review
---------------

Not @46bit.