### PR TITLE
Mark suspended orgs

### DIFF
--- a/src/components/organizations/views.test.tsx
+++ b/src/components/organizations/views.test.tsx
@@ -20,6 +20,10 @@ describe(OrganizationsPage, () => {
     metadata: { guid: 'b' },
     entity: { name: 'B', quota_definition_guid: 'billable' },
   } as unknown) as IOrganization;
+  const suspendedOrg = ({
+    metadata: { guid: 'c' },
+    entity: { name: 'Suspended', quota_definition_guid: 'billable', status: 'suspended' },
+  } as unknown) as IOrganization;
   const quotaBillable = ({
     entity: { name: 'not-default' },
   } as unknown) as IOrganizationQuota;
@@ -54,6 +58,27 @@ describe(OrganizationsPage, () => {
     expect($('table tr:last-of-type th a.govuk-link').prop('href')).toBe('/org/b');
     expect($('table tr:last-of-type td:last-of-type').text()).toBe('Billable');
   });
+
+  it('should highlight suspended organizations', () => {
+    const markup = shallow(
+      <OrganizationsPage
+        organizations={[orgA, suspendedOrg]}
+        linkTo={linker}
+        quotas={quotas}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+
+    expect($('table tbody tr')).toHaveLength(2);
+
+    expect($('table tbody tr:first-of-type th a.govuk-link').text()).toBe('Organisation name: A');
+    expect($('table tbody tr:first-of-type th span.govuk-tag--grey').length).toEqual(0);
+
+    expect($('table tbody tr:nth-of-type(2) th a.govuk-link').text()).toBe('Organisation name: Suspended');
+    expect($('table tbody tr:nth-of-type(2) th span.govuk-tag--grey').text()).toBe(
+      'Suspended',
+    );
+  })
 
   it('should display list of organizations with single item', () => {
     const markup = shallow(

--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -7,6 +7,7 @@ interface IOrganizationProperties {
   readonly guid: string;
   readonly name: string;
   readonly billable: boolean;
+  readonly suspended: boolean;
   readonly linkTo: RouteLinker;
 }
 
@@ -23,6 +24,14 @@ interface IEditOrganizationQuotaProperties {
 }
 
 export function Organization(props: IOrganizationProperties): ReactElement {
+  let linkAriaLabel: string;
+
+  if(props.suspended) {
+    linkAriaLabel = `Organisation name: ${props.name}, status: suspended`
+  } else {
+    linkAriaLabel = `Organisation name: ${props.name}`
+  }
+
   return (
     <tr className="govuk-table__row">
       <th scope="row" className="govuk-table__header govuk-table__header--non-bold">
@@ -30,10 +39,14 @@ export function Organization(props: IOrganizationProperties): ReactElement {
           href={props.linkTo('admin.organizations.view', {
             organizationGUID: props.guid,
           })}
+          aria-label={linkAriaLabel}
           className="govuk-link"
         >
           <span className="govuk-visually-hidden">Organisation name:</span> {props.name}
         </a>
+        {props.suspended &&
+          <span className="govuk-tag govuk-tag--grey pull-right">Suspended</span>
+        }
       </th>
       <td className="govuk-table__cell">
         {props.billable ? 'Billable' : 'Trial'}
@@ -50,6 +63,7 @@ export function OrganizationsPage(
       key={org.metadata.guid}
       guid={org.metadata.guid}
       name={org.entity.name}
+      suspended={org.entity.status == 'suspended'}
       linkTo={props.linkTo}
       billable={
         props.quotas[org.entity.quota_definition_guid].entity.name !== 'default'

--- a/src/components/spaces/controllers.tsx
+++ b/src/components/spaces/controllers.tsx
@@ -402,9 +402,16 @@ export async function listSpaces(
     ),
   };
 
+  let title: string;
+  if (summarisedOrganization.entity.status == "suspended") {
+    title = `Suspended Organisation ${summarisedOrganization.entity.name} Overview`
+  } else {
+    title = `Organisation ${summarisedOrganization.entity.name} Overview`
+  }
+
   const template = new Template(
     ctx.viewContext,
-    `Organisation ${summarisedOrganization.entity.name} Overview`,
+    title,
   );
   template.breadcrumbs = [
     { href: ctx.linkTo('admin.organizations'), text: 'Organisations' },

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -177,10 +177,16 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
   return (
     <>
       <h1 className="govuk-heading-l">
+        {props.organization.entity.status == "suspended" &&
+          <strong className="govuk-tag govuk-tag--grey">
+            <span className="govuk-visually-hidden">Status: </span>Suspended
+          </strong>
+        }
         <span className="govuk-caption-l">
           <span className="govuk-visually-hidden">Organisation</span>{' '}
-          {props.organization.entity.name}</span>{' '}
-          Overview
+          {props.organization.entity.name}
+        </span>{' '}
+        Overview
       </h1>
 
       <div className="govuk-grid-row">

--- a/src/layouts/_elements.scss
+++ b/src/layouts/_elements.scss
@@ -23,3 +23,7 @@ ul, ol {
 .tick-symbol {
   color: govuk-colour("green");
 }
+
+.pull-right {
+  float: right;
+}

--- a/src/lib/cf/types.ts
+++ b/src/lib/cf/types.ts
@@ -148,6 +148,10 @@ export type OrganizationUserRoleEndpoints =
   | 'auditors'
   | 'billing_managers';
 
+export type OrganizationStatus =
+  | 'active'
+  | 'suspended'
+
 export interface IOrganizationRequest {
   readonly name: string;
   readonly quota_definition_guid: string;
@@ -176,7 +180,7 @@ export interface IOrganization {
     readonly quota_definition_url: string;
     readonly space_quota_definitions_url: string;
     readonly spaces_url: string;
-    readonly status: string;
+    readonly status: OrganizationStatus;
     readonly users_url: string;
   };
   readonly metadata: IMetadata;

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -39,6 +39,7 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
   app.get('/v2/organizations', (_, res) => res.send(JSON.stringify(
     wrapResources(
       lodash.merge(defaultOrg(), { entity: { name: 'an-org' } }),
+      lodash.merge(defaultOrg(), { entity: { name: 'a-suspended-org', status: 'suspended' }})
     ),
   )));
   app.get('/v3/organizations', (_, res) => res.send(JSON.stringify(

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -33,13 +33,18 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
 
   app.get('/v2/info', (_, res) => res.send(info));
 
-  app.get('/v2/organizations/:guid',        (_, res) => res.send(JSON.stringify(defaultOrg())));
+  app.get('/v2/organizations/suspended-guid', (_, res) => res.send(
+    JSON.stringify(
+      lodash.merge(defaultOrg(), { metadata: { guid: 'suspended-guid' }, entity: { name: 'a-suspended-org', status: 'suspended' }})
+    )
+  ));
+  app.get('/v2/organizations/:guid', (_, res) => res.send(JSON.stringify(defaultOrg())));
   app.get('/v2/organizations/:guid/spaces', (_, res) => res.send(testData.spaces));
 
   app.get('/v2/organizations', (_, res) => res.send(JSON.stringify(
     wrapResources(
       lodash.merge(defaultOrg(), { entity: { name: 'an-org' } }),
-      lodash.merge(defaultOrg(), { entity: { name: 'a-suspended-org', status: 'suspended' }})
+      lodash.merge(defaultOrg(), { metadata: { guid: 'suspended-guid' }, entity: { name: 'a-suspended-org', status: 'suspended' }})
     ),
   )));
   app.get('/v3/organizations', (_, res) => res.send(JSON.stringify(


### PR DESCRIPTION
What
----
Org in CloudFoundry have two states: `active` and `suspended`. The former is the default state.

We expect to start moving orgs to the `suspended` state when we want to shut them down. Currently it is only possible to know an org is suspended by using the API directly. This PR marks suspended orgs in the UI.

![image](https://user-images.githubusercontent.com/1747386/92723187-a04c8200-f360-11ea-92a2-0fd4288e0f5d.png)

![image](https://user-images.githubusercontent.com/1747386/92723214-ab9fad80-f360-11ea-8d45-0a081be7fd6e.png)


How to review
-------------
Deploy it, and suspend an org

```
cf curl -X PATCH -d '{"suspended": true}' -H "Content-Type: application/json" "/v3/organizations/$(cf org ORG_NAME --guid)"
```

Who can review
---------------
Anyone