### PR TITLE
Update link text to non-HTML documents

### DIFF
--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -134,7 +134,7 @@ export function OrganizationsPage(
               href="https://packages.cloudfoundry.org/stable?release=redhat64&source=github"
               className="govuk-link"
             >
-              Download the RedHat version <span className="govuk-visually-hidden">installer [RPM] file</span>
+              Download the RedHat version [RPM] <span className="govuk-visually-hidden">installer file</span>
             </a>
           </p>
           <p className="govuk-body">
@@ -142,7 +142,7 @@ export function OrganizationsPage(
               href="https://packages.cloudfoundry.org/stable?release=debian64&source=github"
               className="govuk-link"
             >
-              Download the Debian version <span className="govuk-visually-hidden">installer [DEB] file</span>
+              Download the Debian version [DEB] <span className="govuk-visually-hidden">installer file</span>
             </a>
           </p>
         </div>
@@ -154,7 +154,7 @@ export function OrganizationsPage(
               href="https://packages.cloudfoundry.org/stable?release=macosx64&source=github"
               className="govuk-link"
             >
-              Download the macOS version <span className="govuk-visually-hidden">installer [PKG] file</span>
+              Download the macOS version [PKG] <span className="govuk-visually-hidden">installer file</span>
             </a>
           </p>
         </div>
@@ -166,7 +166,7 @@ export function OrganizationsPage(
               href="https://packages.cloudfoundry.org/stable?release=windows64&source=github"
               className="govuk-link"
             >
-              Download the Windows version <span className="govuk-visually-hidden">installer [ZIP] file</span>
+              Download the Windows version [ZIP] <span className="govuk-visually-hidden">installer file</span>
             </a>
           </p>
         </div>

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -296,7 +296,7 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
               className="govuk-link"
               download
             >
-              Download a spreadsheet of these items <span className="govuk-visually-hidden">as a comma-separated values [CSV] file</span>
+              Download a spreadsheet of these items [CSV] <span className="govuk-visually-hidden">as a comma-separated values file</span>
             </a>
           </p>
         </div>


### PR DESCRIPTION
What
----

Although a file type had been proved via a hidden text for screen reader users, sighted users are unable to identify the download links file type.

WCAG Reference:
2.4.4 Link Purpose – in context
Understanding Link Purpose (In Context) (Level A)

3.2.5 Change on Request
(Level AAA)

How to review
-------------

- checkout branch, run locally
- visit /organisations and billing page
- check link text makes sense

Who can review
---------------

not @kr8n3r 
