### PR TITLE
Add suspended org tests and improve test coverage

### DIFF
--- a/src/components/organizations/controllers.test.tsx
+++ b/src/components/organizations/controllers.test.tsx
@@ -38,7 +38,7 @@ const organizations = JSON.stringify(
 const tokenKey = 'secret';
 
 function extractOrganizations(responseBody: string): ReadonlyArray<string> {
-  const re = /(.-(trial-)?org-name(-\d)?)/g;
+  const re = /(Organisation\sname:)\s(.-(trial-)?org-name(-\d)?)/g;
   const matches = [];
   // :scream:
   // eslint-disable-next-line no-constant-condition
@@ -89,11 +89,11 @@ describe('organizations test suite', () => {
 
     const matches = extractOrganizations(response.body as string);
     expect(matches.length).toBe(5);
-    expect(matches[0]).toBe('a-org-name-4');
-    expect(matches[1]).toBe('a-trial-org-name');
-    expect(matches[2]).toBe('b-org-name-3');
-    expect(matches[3]).toBe('c-org-name-1');
-    expect(matches[4]).toBe('d-org-name-2');
+    expect(matches[0]).toContain('a-org-name-4');
+    expect(matches[1]).toContain('a-trial-org-name');
+    expect(matches[2]).toContain('b-org-name-3');
+    expect(matches[3]).toContain('c-org-name-1');
+    expect(matches[4]).toContain('d-org-name-2');
   });
 
   it('should report the org quotas for both trial and billable orgs', async () => {

--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -413,4 +413,32 @@ describe(SpacesPage, () => {
       `There is 1 space in ${organization.entity.name}.`,
     );
   });
+
+  it('should highlight suspended state in main heading', () => {
+
+    const suspendedOrganization = ({
+      metadata: { guid: 'ORG_GUID' },
+      entity: { name: 'org-name', status: 'suspended' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: {
+        entity: { name: 'default', memory_limit: (5 * GIBIBYTE) / MEBIBYTE },
+      },
+    } as unknown) as IEnhancedOrganization;
+
+    const markup = shallow(
+      <SpacesPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        isAdmin={false}
+        isManager={false}
+        isBillingManager={false}
+        organization={suspendedOrganization}
+        spaces={[space, { ...space, quota: undefined }]}
+        users={[null]}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+
+    expect($('h1').text()).toContain('Status: Suspended');
+  })
+
 });

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -35,8 +35,8 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
 
   app.get('/v2/organizations/suspended-guid', (_, res) => res.send(
     JSON.stringify(
-      lodash.merge(defaultOrg(), { metadata: { guid: 'suspended-guid' }, entity: { name: 'a-suspended-org', status: 'suspended' }})
-    )
+      lodash.merge(defaultOrg(), { metadata: { guid: 'suspended-guid' }, entity: { name: 'a-suspended-org', status: 'suspended' }}),
+    ),
   ));
   app.get('/v2/organizations/:guid', (_, res) => res.send(JSON.stringify(defaultOrg())));
   app.get('/v2/organizations/:guid/spaces', (_, res) => res.send(testData.spaces));
@@ -44,7 +44,7 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
   app.get('/v2/organizations', (_, res) => res.send(JSON.stringify(
     wrapResources(
       lodash.merge(defaultOrg(), { entity: { name: 'an-org' } }),
-      lodash.merge(defaultOrg(), { metadata: { guid: 'suspended-guid' }, entity: { name: 'a-suspended-org', status: 'suspended' }})
+      lodash.merge(defaultOrg(), { metadata: { guid: 'suspended-guid' }, entity: { name: 'a-suspended-org', status: 'suspended' }}),
     ),
   )));
   app.get('/v3/organizations', (_, res) => res.send(JSON.stringify(


### PR DESCRIPTION
What
----

Added tests for https://github.com/alphagov/paas-admin/pull/1060

- Test for line 180 in /spaces/views.tsx
- Test for line 407 in /spaces/controllers.tsx 
- Update test for counting number of organisations on the org page
- Fix linting


Who can review
---------------
not @kr8n3r 
