### PR TITLE
add backing service metrics  for number of sqs messages sent/recv

### DIFF
--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -435,12 +435,11 @@ export async function downloadServiceMetrics(
         rangeStop,
       );
 
-      headers = ['Service', 'Instance', 'Time', 'Value'];
+      headers = ['Service', 'Time', 'Value'];
       contents = values(sqsMetricSeries[params.metric])
         .map(metric =>
           metric.metrics.map(series => [
             serviceLabel,
-            metric.label,
             moment(series.date).format('YYYY-MM-DD[T]HH:mm'),
             composeValue(series.value, params.units),
           ]),

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -251,6 +251,7 @@ export async function viewServiceMetrics(
         period,
         rangeStart,
         rangeStop,
+        servicePlan!.entity.name,
       );
 
       metrics = sqsMetrics(
@@ -422,6 +423,7 @@ export async function downloadServiceMetrics(
 
   switch (serviceLabel) {
     case 'aws-sqs-queue':
+      const servicePlan = await cf.servicePlan(service.entity.service_plan_guid);
       const sqsMetricSeries = await new SQSMetricDataGetter(
         new cw.CloudWatchClient({
           endpoint: ctx.app.awsCloudwatchEndpoint,
@@ -433,6 +435,7 @@ export async function downloadServiceMetrics(
         period,
         rangeStart,
         rangeStop,
+        servicePlan.entity.name,
       );
 
       headers = ['Service', 'Time', 'Value'];

--- a/src/components/service-metrics/metrics.tsx
+++ b/src/components/service-metrics/metrics.tsx
@@ -704,3 +704,44 @@ export function elasticSearchMetrics(
     },
   ];
 }
+
+export function sqsMetrics(
+  series: ISeries,
+  summaries: ISummaries,
+  downloadLink: string,
+): ReadonlyArray<IMetricProperties> {
+  return [
+    {
+      id: 'messages-sent',
+      format: 'number',
+      title: 'Number of messages sent',
+      description: `The number of messages added to the queue by your applications`,
+      chart: drawLineGraph(
+        'number of messages sent',
+        'Messages',
+        numberLabel,
+        series.mNumberOfMessagesSent,
+      ),
+      units: 'Number',
+      metric: 'mNumberOfMessagesSent',
+      summaries: summaries.mNumberOfMessagesSent,
+      downloadLink,
+    },
+    {
+      id: 'messages-recv',
+      format: 'number',
+      title: 'Number of messages received',
+      description: `The number of messages consumed from the queue by your applications`,
+      chart: drawLineGraph(
+        'number of messages received',
+        'Messages',
+        numberLabel,
+        series.mNumberOfMessagesReceived,
+      ),
+      units: 'Number',
+      metric: 'mNumberOfMessagesReceived',
+      summaries: summaries.mNumberOfMessagesReceived,
+      downloadLink,
+    },
+  ];
+}

--- a/src/lib/metric-data-getters/index.ts
+++ b/src/lib/metric-data-getters/index.ts
@@ -2,3 +2,4 @@ export * from './cloudfront';
 export * from './elasticache';
 export * from './elasticsearch';
 export * from './rds';
+export * from './sqs';

--- a/src/lib/metric-data-getters/sqs.ts
+++ b/src/lib/metric-data-getters/sqs.ts
@@ -1,0 +1,79 @@
+import * as cw from '@aws-sdk/client-cloudwatch-node';
+import _ from 'lodash';
+import moment from 'moment';
+
+
+import { IMetricDataGetter, IMetricSerie, MetricName } from '../metrics';
+
+import { CloudWatchMetricDataGetter, ICloudWatchMetric } from './cloudwatch';
+
+const sqsMetricPropertiesById: { [key in MetricName]: ICloudWatchMetric } = {
+  mNumberOfMessagesReceived: {
+    name: 'NumberOfMessagesReceived',
+    stat: 'Average',
+  },
+  mNumberOfMessagesSent: {
+    name: 'NumberOfMessagesSent',
+    stat: 'Average',
+  },
+};
+
+export const sqsMetricNames = Object.keys(sqsMetricPropertiesById);
+
+export class SQSMetricDataGetter extends CloudWatchMetricDataGetter
+  implements IMetricDataGetter {
+
+  constructor(private readonly cloudwatchClient: cw.CloudWatchClient) {
+    super();
+  }
+
+  public getSQSQueueName(guid: string): string {
+    return `paas-sqs-broker-${guid}-pri`;
+  }
+
+  public async getData(
+    metricNames: ReadonlyArray<MetricName>,
+    guid: string,
+    period: moment.Duration,
+    rangeStart: moment.Moment,
+    rangeStop: moment.Moment,
+  ): Promise<{ [key in MetricName]: ReadonlyArray<IMetricSerie> }> {
+
+    const metricDataInputs = [
+      {
+        MetricDataQueries: metricNames.map(metricId => ({
+          Id: metricId,
+          MetricStat: {
+            Metric: {
+              Dimensions: [{
+                Name: 'QueueName',
+                Value: this.getSQSQueueName(guid),
+              }],
+              MetricName: sqsMetricPropertiesById[metricId].name,
+              Namespace: 'AWS/SQS',
+            },
+            Period: period.asSeconds(),
+            Stat: sqsMetricPropertiesById[metricId].stat,
+          },
+        })),
+        StartTime: rangeStart.toDate(),
+        EndTime: rangeStop.toDate(),
+      },
+    ];
+
+    const responses = await Promise.all(
+      metricDataInputs.map(async input =>
+        await this.cloudwatchClient.send(new cw.GetMetricDataCommand(input)),
+      ),
+    );
+
+    const results = _.flatMap(
+      responses,
+      response => response.MetricDataResults!,
+    );
+
+    return Promise.resolve(
+      this.addPlaceholderData(results, period, rangeStart, rangeStop),
+    );
+  }
+}

--- a/src/lib/metric-data-getters/sqs.ts
+++ b/src/lib/metric-data-getters/sqs.ts
@@ -27,8 +27,13 @@ export class SQSMetricDataGetter extends CloudWatchMetricDataGetter
     super();
   }
 
-  public getSQSQueueName(guid: string): string {
-    return `paas-sqs-broker-${guid}-pri`;
+  public getSQSQueueName(guid: string, servicePlanName?: string): string {
+    /* istanbul ignore next: ext doesn't need own test */
+    const ext = servicePlanName && servicePlanName == 'fifo'
+      ? '.fifo'
+      : '';
+
+      return `paas-sqs-broker-${guid}-pri${ext}`;
   }
 
   public async getData(
@@ -37,6 +42,7 @@ export class SQSMetricDataGetter extends CloudWatchMetricDataGetter
     period: moment.Duration,
     rangeStart: moment.Moment,
     rangeStop: moment.Moment,
+    servicePlanName?: string,
   ): Promise<{ [key in MetricName]: ReadonlyArray<IMetricSerie> }> {
 
     const metricDataInputs = [
@@ -47,7 +53,7 @@ export class SQSMetricDataGetter extends CloudWatchMetricDataGetter
             Metric: {
               Dimensions: [{
                 Name: 'QueueName',
-                Value: this.getSQSQueueName(guid),
+                Value: this.getSQSQueueName(guid, servicePlanName),
               }],
               MetricName: sqsMetricPropertiesById[metricId].name,
               Namespace: 'AWS/SQS',


### PR DESCRIPTION
## What

display charts for number of messages sent/recv for sqs backing services

this is not all the metrics available, it was an initial pass to get the ball rolling and ensure everything is in place to add metrics as specific needs arise.

currently only checks the "primary" queue (ignore the "secondary" queue that is often configured as a dead-letter queue).

## How to review

If you have an `aws-sqs-queue` service instance  you should be able visit the metrics tab and see charts for NumberOfMessagesSent and NumberOfMessagesReceived

## Who can review

Not @chrisfarms 
