### PR TITLE
Fix accounts usage for autoscaler

### DIFF
--- a/src/components/application-events/controllers.tsx
+++ b/src/components/application-events/controllers.tsx
@@ -1,5 +1,6 @@
 import lodash from 'lodash';
 import React from 'react';
+import { validate as uuidValidate } from 'uuid';
 
 import { Template } from '../../layouts';
 import { AccountsClient, IAccountsUser } from '../../lib/accounts';
@@ -36,7 +37,9 @@ export async function viewApplicationEvent(
   ]);
 
   const eventActorGUID: string | undefined =
-    event.actor.type === 'user' ? event.actor.guid : undefined;
+    event.actor.type === 'user' && uuidValidate(event.actor.guid)
+      ? event.actor.guid
+      : undefined;
 
   const eventActor: IAccountsUser | undefined = eventActorGUID
     ? await accountsClient.getUser(eventActorGUID)
@@ -111,6 +114,7 @@ export async function viewApplicationEvents(
     .chain(events)
     .filter(e => e.actor.type === 'user')
     .map(e => e.actor.guid)
+    .filter(guid => uuidValidate(guid))
     .uniq()
     .value();
 

--- a/src/components/service-events/controllers.tsx
+++ b/src/components/service-events/controllers.tsx
@@ -1,5 +1,6 @@
 import lodash from 'lodash';
 import React from 'react';
+import { validate as uuidValidate } from 'uuid';
 
 import { Template } from '../../layouts';
 import { AccountsClient, IAccountsUser } from '../../lib/accounts';
@@ -54,7 +55,9 @@ export async function viewServiceEvent(
   };
 
   const eventActorGUID: string | undefined =
-    event.actor.type === 'user' ? event.actor.guid : undefined;
+    event.actor.type === 'user' && uuidValidate(event.actor.guid)
+      ? event.actor.guid
+      : undefined;
 
   const eventActor: IAccountsUser | null | undefined = eventActorGUID
     ? await accountsClient.getUser(eventActorGUID)
@@ -148,6 +151,7 @@ export async function viewServiceEvents(
     .filter(e => e.actor.type === 'user')
     .map(e => e.actor.guid)
     .uniq()
+    .filter(guid => uuidValidate(guid))
     .value();
 
   if (userActorGUIDs.length > 0) {

--- a/src/components/spaces/controllers.tsx
+++ b/src/components/spaces/controllers.tsx
@@ -1,5 +1,6 @@
 import lodash from 'lodash';
 import React from 'react';
+import { validate as uuidValidate } from 'uuid';
 
 import { Template } from '../../layouts';
 import { AccountsClient, IAccountsUser } from '../../lib/accounts';
@@ -94,7 +95,9 @@ export async function viewSpaceEvent(
   ]);
 
   const eventActorGUID: string | undefined =
-    event.actor.type === 'user' ? event.actor.guid : undefined;
+    event.actor.type === 'user' && uuidValidate(event.actor.guid)
+      ? event.actor.guid
+      : undefined;
 
   const eventActor: IAccountsUser | null | undefined = eventActorGUID
     ? await accountsClient.getUser(eventActorGUID)
@@ -160,11 +163,13 @@ export async function viewSpaceEvents(
     .chain(events)
     .filter(e => e.actor.type === 'user')
     .map(e => e.actor.guid)
+    .filter(guid => uuidValidate(guid))
     .value();
   const userTargetGUIDs = lodash
     .chain(events)
     .filter(e => e.target.type === 'user')
     .map(e => e.target.guid)
+    .filter(guid => uuidValidate(guid))
     .value();
   const userGUIDs = lodash.uniq(userActorGUIDs.concat(userTargetGUIDs));
 

--- a/src/lib/cf/test-data/audit-event.ts
+++ b/src/lib/cf/test-data/audit-event.ts
@@ -1,6 +1,7 @@
 import { IAuditEvent } from '../types';
 
 export const eventGUID = 'a595fe2f-01ff-4965-a50c-290258ab8582';
+export const autoscalerEventGUID = '7252659b-cb77-4f46-bbd8-6c023fe17de2';
 
 export const actorGUID = 'd144abe3-3d7b-40d4-b63f-2584798d3ee5';
 export const actorName = 'admin';
@@ -52,7 +53,7 @@ export const auditEvent = (): IAuditEvent =>
 
 export const auditEventForAutoscaler = (): IAuditEvent =>
   JSON.parse(`{
-  "guid": "${eventGUID}",
+  "guid": "${autoscalerEventGUID}",
   "created_at": "2020-09-18T05:12:33Z",
   "updated_at": "2020-09-18T05:12:33Z",
   "type": "audit.app.update",
@@ -79,7 +80,7 @@ export const auditEventForAutoscaler = (): IAuditEvent =>
   },
   "links": {
     "self": {
-      "href": "https://api.example.org//v3/audit_events/${eventGUID}"
+      "href": "https://api.example.org//v3/audit_events/${autoscalerEventGUID}"
     }
   }
 }`);

--- a/src/lib/cf/test-data/audit-event.ts
+++ b/src/lib/cf/test-data/audit-event.ts
@@ -49,3 +49,37 @@ export const auditEvent = (): IAuditEvent =>
     }
   }
 }`);
+
+export const auditEventForAutoscaler = (): IAuditEvent =>
+  JSON.parse(`{
+  "guid": "${eventGUID}",
+  "created_at": "2020-09-18T05:12:33Z",
+  "updated_at": "2020-09-18T05:12:33Z",
+  "type": "audit.app.update",
+  "actor": {
+    "guid": "app_autoscaler",
+    "type": "user",
+    "name": ""
+  },
+  "target": {
+    "guid": "${targetGUID}",
+    "type": "app",
+    "name": "${targetName}"
+  },
+  "data": {
+    "request": {
+       "instances": 3
+    }
+  },
+  "space": {
+    "guid": "${spaceGUID}"
+  },
+  "organization": {
+    "guid": "${orgGUID}"
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org//v3/audit_events/${eventGUID}"
+    }
+  }
+}`);

--- a/stub-api/stub-cf.ts
+++ b/stub-api/stub-cf.ts
@@ -3,7 +3,7 @@ import lodash from 'lodash';
 
 import * as testData from '../src/lib/cf/cf.test.data';
 import { app as defaultApp } from '../src/lib/cf/test-data/app';
-import { auditEvent as defaultAuditEvent } from '../src/lib/cf/test-data/audit-event';
+import { auditEvent as defaultAuditEvent, auditEventForAutoscaler, autoscalerEventGUID } from '../src/lib/cf/test-data/audit-event';
 import { org as defaultOrg, v3Org as defaultV3Org } from '../src/lib/cf/test-data/org';
 import { wrapResources, wrapV3Resources } from '../src/lib/cf/test-data/wrap-resources';
 
@@ -79,12 +79,17 @@ function mockCF(app: express.Application, config: IStubServerPorts): express.App
   app.get('/v2/stacks'                               , (_, res) => res.send(testData.stacks));
   app.get('/v2/stacks/:guid'                         , (_, res) => res.send(testData.stack));
 
-  app.get('/v3/audit_events/:guid' , (_, res) => res.send(JSON.stringify(defaultAuditEvent())));
+  app.get(`/v3/audit_events/${autoscalerEventGUID}` , (_, res) => {
+    res.send(JSON.stringify(auditEventForAutoscaler()));
+  });
+  app.get('/v3/audit_events/:guid' , (_, res) => {
+    res.send(JSON.stringify(defaultAuditEvent()));
+  });
   app.get('/v3/audit_events'       , (req, res) => {
     const page = parseInt(req.param('page', '1'), 10);
 
     const predefinedResources = [
-      [lodash.merge(defaultAuditEvent(), { type: 'first-page' }), defaultAuditEvent()],
+      [lodash.merge(defaultAuditEvent(), { type: 'first-page' }), auditEventForAutoscaler()],
       [lodash.merge(defaultAuditEvent(), { type: 'middle-page' }), defaultAuditEvent()],
       [lodash.merge(defaultAuditEvent(), { type: 'last-page' }), defaultAuditEvent()],
     ];


### PR DESCRIPTION
What
----

The app and space audit event pages are erroring when they include audit events from the [autoscaler](https://github.com/cloudfoundry/app-autoscaler). This is happening because we never anticipated this sort of actor field on an audit event:

```
    "actor": {
      "type": "user",
      "guid": "app_autoscaler",
      "name": ""
    },
```

We assumed that anything with `type: user` would have a UUID for a GUID. This makes complete sense, but it isn't the case for the autoscaler.

The autoscaler uses a UAA Client named `app_autoscaler`. It is reported with `type: user` even though it's a UAA Client, not a UAA user. The UUID is set to the name of the client, not a GUID.

Our views already had logic to cope with this problem. They fall back to printing out `<code>{{event.actor.guid}}</code>`. But the controllers try to convert GUIDs to validated user emails using https://github.com/alphagov/paas-accounts, and that code did not guard against this problem.

This PR changes the controllers so they only ask https://github.com/alphagov/paas-accounts about actors whose UUID is a valid GUID.

How to review
-------------

* <s>Deploy to a dev env</s> I used a modified stub API to test this
* [x] Check this works fine with normal events
* [x] Look at events on the autoscaler's test app
* [x] Look at events on the space containing the autoscaler's test app

Who can review
---------------

Not @46bit 