### PR TITLE
Run tests on GitHub Actions instead of our own CI

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,25 @@
+---
+name: pr-tests
+on: pull_request
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-18.04
+
+    env:
+      NODE_ENV: development
+      TEST_TIMEOUT: 60000
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
What
----

The tests we run don't require any special resources or permissions, and in the
past they've got stopped the PR being merged when they should have. Moving to
GitHub Actions ought to make the whole thing a bit more reliable.

How to review
-------------

See the Actions tab here, and ensure the tests passed.

Who can review
---------------
Anyone but me