### PR TITLE
Use tabs to show trial and billable organisations on the admin organisation report

### DIFF
--- a/src/components/reports/views.test.tsx
+++ b/src/components/reports/views.test.tsx
@@ -223,6 +223,46 @@ describe(OrganizationsReport, () => {
 
     expect($('table tbody tr td:first-of-type span.govuk-tag').length).toEqual(1);
   })
+
+  it('should not show a table of trial organisations if there are no organisations', () => {
+    const markup = shallow(
+      <OrganizationsReport
+        linkTo={route => `__LINKS_TO__${route}`}
+        organizations={org}
+        trialOrgs={[]}
+        billableOrgs={billableOrg}
+        orgQuotaMapping={{
+          'quota-guid': orgQuota,
+          'billable-quota-guid': billableQuota,
+        }}
+        orgTrialExpirys={{ 'org-guid': new Date('2019-01-30') }}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('#trial-accounts .govuk-table').length).toEqual(0);
+    expect($('#billable-accounts .govuk-table').length).toEqual(1);
+    
+  })
+
+  it('should not show a table of billable organisations if there are no organisations', () => {
+    const markup = shallow(
+      <OrganizationsReport
+        linkTo={route => `__LINKS_TO__${route}`}
+        organizations={org}
+        trialOrgs={org}
+        billableOrgs={[]}
+        orgQuotaMapping={{
+          'quota-guid': orgQuota,
+          'billable-quota-guid': billableQuota,
+        }}
+        orgTrialExpirys={{ 'org-guid': new Date('2019-01-30') }}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('#billable-accounts .govuk-table').length).toEqual(0);
+    expect($('#trial-accounts .govuk-table').length).toEqual(1);
+    
+  })
 });
 
 describe(CostReport, () => {

--- a/src/components/reports/views.tsx
+++ b/src/components/reports/views.tsx
@@ -143,7 +143,8 @@ export function OrganizationsReport(
             {props.trialOrgs.length} trial{' '}
             {props.trialOrgs.length === 1 ? 'organisation' : 'organisations'}.
           </p>
-
+          {props.trialOrgs.length > 0 ?
+          <>
           <p className="govuk-body">Sorted by age; oldest first.</p>
 
           <div className="scrollable-table-container">
@@ -201,6 +202,8 @@ export function OrganizationsReport(
             </tbody>
           </table>
           </div>
+          </> : <></>
+          }
         </div>
         <div className="govuk-tabs__panel" id="billable-accounts">
           <h2 className="govuk-heading-m">Billable accounts</h2>
@@ -210,7 +213,8 @@ export function OrganizationsReport(
             {props.billableOrgs.length} billable{' '}
             {props.billableOrgs.length === 1 ? 'organisation' : 'organisations'}.
           </p>
-
+          {props.billableOrgs.length > 0 ?
+          <>
           <p className="govuk-body">Sorted by age; newest first.</p>
 
           <div className="scrollable-table-container">
@@ -260,6 +264,8 @@ export function OrganizationsReport(
           </tbody>
         </table>
         </div>
+          </> : <></>
+          }
         </div>
       </div>
     </>

--- a/src/components/reports/views.tsx
+++ b/src/components/reports/views.tsx
@@ -119,129 +119,148 @@ export function OrganizationsReport(
         {props.organizations.length}{' '}
         {props.organizations.length === 1 ? 'organisation' : 'organisations'}.
       </p>
+      <div className="govuk-tabs" data-module="govuk-tabs">
+        <h2 className="govuk-tabs__title">
+          Contents
+        </h2>
+        <ul className="govuk-tabs__list">
+          <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
+            <a className="govuk-tabs__tab" href="#trial-accounts">
+              Trial accounts
+            </a>
+          </li>
+          <li className="govuk-tabs__list-item">
+            <a className="govuk-tabs__tab" href="#billable-accounts">
+              Billable accounts
+            </a>
+          </li>
+        </ul>
+        <div className="govuk-tabs__panel" id="trial-accounts">
+          <h2 className="govuk-heading-m">Trial accounts</h2>
 
-      <h2 className="govuk-heading-m">Trial accounts</h2>
+          <p className="govuk-body">
+            There {props.trialOrgs.length === 1 ? 'is' : 'are'}{' '}
+            {props.trialOrgs.length} trial{' '}
+            {props.trialOrgs.length === 1 ? 'organisation' : 'organisations'}.
+          </p>
 
-      <p className="govuk-body">
-        There {props.trialOrgs.length === 1 ? 'is' : 'are'}{' '}
-        {props.trialOrgs.length} trial{' '}
-        {props.trialOrgs.length === 1 ? 'organisation' : 'organisations'}.
-      </p>
+          <p className="govuk-body">Sorted by age; oldest first.</p>
 
-      <p className="govuk-body">Sorted by age; oldest first.</p>
+          <div className="scrollable-table-container">
+            <table className="govuk-table">
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th className="govuk-table__header">Organisation</th>
+                <th className="govuk-table__header">Owner</th>
+                <th className="govuk-table__header">Quota</th>
+                <th className="govuk-table__header">Creation date</th>
+                <th className="govuk-table__header">Status</th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {props.trialOrgs.map(organization => (
+                <tr key={organization.guid} className="govuk-table__row">
+                  <td className="govuk-table__cell">
+                    <a
+                      href={props.linkTo('admin.organizations.view', {
+                        organizationGUID: organization.guid,
+                      })}
+                      className="govuk-link"
+                      aria-label={`Organisation name: ${organization.name}${organization.suspended? ', status: suspended':''}`}
+                    >
+                      {organization.name}
+                    </a>
 
-      <div className="scrollable-table-container">
-        <table className="govuk-table">
-        <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
-            <th className="govuk-table__header">Organisation</th>
-            <th className="govuk-table__header">Owner</th>
-            <th className="govuk-table__header">Quota</th>
-            <th className="govuk-table__header">Creation date</th>
-            <th className="govuk-table__header">Status</th>
-          </tr>
-        </thead>
-        <tbody className="govuk-table__body">
-          {props.trialOrgs.map(organization => (
-            <tr key={organization.guid} className="govuk-table__row">
-              <td className="govuk-table__cell">
-                <a
-                  href={props.linkTo('admin.organizations.view', {
-                    organizationGUID: organization.guid,
-                  })}
-                  className="govuk-link"
-                  aria-label={`Organisation name: ${organization.name}${organization.suspended? ', status: suspended':''}`}
-                >
-                  {organization.name}
-                </a>
+                    {organization.suspended &&
+                      <span className="govuk-tag govuk-tag--grey pull-right">Suspended</span>
+                    }
+                  </td>
+                  <td className="govuk-table__cell">
+                    {organization.metadata.annotations.owner === undefined
+                      ? 'Unknown'
+                      : organization.metadata.annotations.owner}
+                  </td>
+                  <td className="govuk-table__cell">
+                    {
+                      props.orgQuotaMapping[
+                        organization.relationships.quota.data.guid
+                      ].entity.name
+                    }
+                  </td>
+                  <td className="govuk-table__cell">
+                    {moment(organization.created_at).format(DATE)}
+                  </td>
+                  <td className="govuk-table__cell">
+                    {new Date() > props.orgTrialExpirys[organization.guid]
+                      ? 'Expired'
+                      : 'Expires'}{' '}
+                    {moment(props.orgTrialExpirys[organization.guid]).fromNow()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          </div>
+        </div>
+        <div className="govuk-tabs__panel" id="billable-accounts">
+          <h2 className="govuk-heading-m">Billable accounts</h2>
 
-                {organization.suspended &&
-                  <span className="govuk-tag govuk-tag--grey pull-right">Suspended</span>
-                }
-              </td>
-              <td className="govuk-table__cell">
-                {organization.metadata.annotations.owner === undefined
-                  ? 'Unknown'
-                  : organization.metadata.annotations.owner}
-              </td>
-              <td className="govuk-table__cell">
-                {
-                  props.orgQuotaMapping[
-                    organization.relationships.quota.data.guid
-                  ].entity.name
-                }
-              </td>
-              <td className="govuk-table__cell">
-                {moment(organization.created_at).format(DATE)}
-              </td>
-              <td className="govuk-table__cell">
-                {new Date() > props.orgTrialExpirys[organization.guid]
-                  ? 'Expired'
-                  : 'Expires'}{' '}
-                {moment(props.orgTrialExpirys[organization.guid]).fromNow()}
-              </td>
+          <p className="govuk-body">
+            There {props.billableOrgs.length === 1 ? 'is' : 'are'}{' '}
+            {props.billableOrgs.length} billable{' '}
+            {props.billableOrgs.length === 1 ? 'organisation' : 'organisations'}.
+          </p>
+
+          <p className="govuk-body">Sorted by age; newest first.</p>
+
+          <div className="scrollable-table-container">
+          <table className="govuk-table">
+          <thead className="govuk-table__head">
+            <tr className="govuk-table__row">
+              <th className="govuk-table__header">Organisation</th>
+              <th className="govuk-table__header">Owner</th>
+              <th className="govuk-table__header">Quota</th>
+              <th className="govuk-table__header">Creation date</th>
+              <th className="govuk-table__header">Time since creation</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-      </div>
-
-      <h2 className="govuk-heading-m">Billable accounts</h2>
-
-      <p className="govuk-body">
-        There {props.billableOrgs.length === 1 ? 'is' : 'are'}{' '}
-        {props.billableOrgs.length} billable{' '}
-        {props.billableOrgs.length === 1 ? 'organisation' : 'organisations'}.
-      </p>
-
-      <p className="govuk-body">Sorted by age; newest first.</p>
-
-      <div className="scrollable-table-container">
-        <table className="govuk-table">
-        <thead className="govuk-table__head">
-          <tr className="govuk-table__row">
-            <th className="govuk-table__header">Organisation</th>
-            <th className="govuk-table__header">Owner</th>
-            <th className="govuk-table__header">Quota</th>
-            <th className="govuk-table__header">Creation date</th>
-            <th className="govuk-table__header">Time since creation</th>
-          </tr>
-        </thead>
-        <tbody className="govuk-table__body">
-          {props.billableOrgs.map(organization => (
-            <tr key={organization.guid} className="govuk-table__row">
-              <td className="govuk-table__cell">
-                <a
-                  href={props.linkTo('admin.organizations.view', {
-                    organizationGUID: organization.guid,
-                  })}
-                  className="govuk-link"
-                >
-                  {organization.name}
-                </a>
-              </td>
-              <td className="govuk-table__cell">
-                {organization.metadata.annotations.owner === undefined
-                  ? 'Unknown'
-                  : organization.metadata.annotations.owner}
-              </td>
-              <td className="govuk-table__cell">
-                {
-                  props.orgQuotaMapping[
-                    organization.relationships.quota.data.guid
-                  ].entity.name
-                }
-              </td>
-              <td className="govuk-table__cell">
-                {moment(organization.created_at).format(DATE)}
-              </td>
-              <td className="govuk-table__cell">
-                Created {moment(organization.created_at).fromNow()}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="govuk-table__body">
+            {props.billableOrgs.map(organization => (
+              <tr key={organization.guid} className="govuk-table__row">
+                <td className="govuk-table__cell">
+                  <a
+                    href={props.linkTo('admin.organizations.view', {
+                      organizationGUID: organization.guid,
+                    })}
+                    className="govuk-link"
+                  >
+                    {organization.name}
+                  </a>
+                </td>
+                <td className="govuk-table__cell">
+                  {organization.metadata.annotations.owner === undefined
+                    ? 'Unknown'
+                    : organization.metadata.annotations.owner}
+                </td>
+                <td className="govuk-table__cell">
+                  {
+                    props.orgQuotaMapping[
+                      organization.relationships.quota.data.guid
+                    ].entity.name
+                  }
+                </td>
+                <td className="govuk-table__cell">
+                  {moment(organization.created_at).format(DATE)}
+                </td>
+                <td className="govuk-table__cell">
+                  Created {moment(organization.created_at).fromNow()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        </div>
+        </div>
       </div>
     </>
   );

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -77,7 +77,7 @@ export function ServiceTab(props: IServiceTabProperties): ReactElement {
         {props.pageTitle}
       </h1>
 
-      <div className="govuk-tabs" data-module="govuk-tabs">
+      <div className="govuk-tabs">
         <h2 className="govuk-tabs__title">Contents</h2>
 
         <ul className="govuk-tabs__list">

--- a/src/frontend/javascript/init.js
+++ b/src/frontend/javascript/init.js
@@ -44,3 +44,11 @@ if ($tooltips) {
     new Tooltip($tooltips[i]).init();
   };
 }
+
+var $tabs = document.querySelectorAll('[data-module="govuk-tabs"]');
+var GOVUKTabs = window.GOVUKFrontend.Tabs;
+if ($tabs) {
+  for (var i = 0; i < $tabs.length; i++) {
+    new GOVUKTabs($tabs[i]).init();
+  };
+}


### PR DESCRIPTION
What
----

Move the display of trial and billable organisations into tabs layout - true, arrow key navigable tabs as per [Design system](https://design-system.service.gov.uk/components/tabs/)

On Production the list of both is long this makes it easier to only view either.

Additionally, we now only show a table of organisations actually exist.

How to review
-------------

- deploy or run locally
- visit /reports/organisations
- check that tab work as expected (as per DS)

Who can review
---------------

not @kr8n3r 

Visual change
-----------

### Before
<img width="1287" alt="Screenshot 2020-09-20 at 08 13 39" src="https://user-images.githubusercontent.com/3758555/93705903-3a5aba00-fb19-11ea-9df9-684ec52d0d6b.png">


### After
<img width="1242" alt="Screenshot 2020-09-20 at 08 10 16" src="https://user-images.githubusercontent.com/3758555/93705876-0089b380-fb19-11ea-9b05-c1298715c9b0.png">
<img width="1225" alt="Screenshot 2020-09-20 at 08 10 23" src="https://user-images.githubusercontent.com/3758555/93705877-02ec0d80-fb19-11ea-946c-cf6fce4ba9b7.png">

