### PR TITLE
Add link to the accessibility statement

### DIFF
--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -195,14 +195,6 @@ export function Footer(): ReactElement {
               <li className="govuk-footer__inline-list-item">
                 <a
                   className="govuk-footer__link"
-                  href="https://www.gov.uk/government/organisations/government-digital-service"
-                >
-                  Built by the Government Digital Service
-                </a>
-              </li>
-              <li className="govuk-footer__inline-list-item">
-                <a
-                  className="govuk-footer__link"
                   href="https://www.cloud.service.gov.uk/privacy-notice"
                 >
                   Privacy notice
@@ -214,6 +206,14 @@ export function Footer(): ReactElement {
                   href="https://www.cloud.service.gov.uk/terms-of-use"
                 >
                   Terms of use
+                </a>
+              </li>
+              <li className="govuk-footer__inline-list-item">
+                <a
+                  className="govuk-footer__link"
+                  href="https://www.cloud.service.gov.uk/accessibility-statement"
+                >
+                  Accessibility statement
                 </a>
               </li>
               <li className="govuk-footer__inline-list-item">
@@ -233,7 +233,9 @@ export function Footer(): ReactElement {
                 </a>
               </li>
             </ul>
-
+            <div className="govuk-footer__meta-custom">
+              Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service" className="govuk-footer__link">Government Digital Service</a>
+            </div>
             <svg
               role="presentation"
               focusable="false"


### PR DESCRIPTION
**Needs https://github.com/alphagov/paas-product-pages/pull/82**

What
----

Add link to the accessibility statement and update footer links

Visual change
-------------

### Before
<img width="1250" alt="Screenshot 2020-09-21 at 10 33 49" src="https://user-images.githubusercontent.com/3758555/93752176-2cc73200-fbf6-11ea-84a5-821c6be2f193.png">


### After
<img width="1248" alt="Screenshot 2020-09-21 at 10 33 30" src="https://user-images.githubusercontent.com/3758555/93752165-28027e00-fbf6-11ea-8ca9-7bccf00ccfe9.png">


Who can review
---------------

not @kr8n3r 
