### PR TITLE
Use fake AWS credentials when using the stub API

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -1,5 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http';
 
+import awsTypes from '@aws-sdk/types';
 import compression from 'compression';
 import cookieSession from 'cookie-session';
 import csrf from 'csurf';
@@ -59,6 +60,7 @@ export interface IAppConfig {
   readonly awsRegion: string;
   readonly awsCloudwatchEndpoint?: string;
   readonly awsResourceTaggingAPIEndpoint?: string;
+  readonly awsCredentials?: awsTypes.Credentials;
   readonly adminFee: number;
   readonly prometheusEndpoint: string;
   readonly prometheusUsername: string;

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -244,6 +244,7 @@ export async function viewServiceMetrics(
         new cw.CloudWatchClient({
           endpoint: ctx.app.awsCloudwatchEndpoint,
           region: ctx.app.awsRegion,
+          credentials: ctx.app.awsCredentials,
         }),
       ).getData(
         sqsMetricNames,
@@ -265,10 +266,12 @@ export async function viewServiceMetrics(
         new cw.CloudWatchClient({
           endpoint: ctx.app.awsCloudwatchEndpoint,
           region: 'us-east-1',
+          credentials: ctx.app.awsCredentials,
         }),
         new rg.ResourceGroupsTaggingAPIClient({
           endpoint: ctx.app.awsResourceTaggingAPIEndpoint,
           region: 'us-east-1',
+          credentials: ctx.app.awsCredentials,
         }),
       ).getData(
         cloudfrontMetricNames,
@@ -290,6 +293,7 @@ export async function viewServiceMetrics(
         new cw.CloudWatchClient({
           endpoint: ctx.app.awsCloudwatchEndpoint,
           region: ctx.app.awsRegion,
+          credentials: ctx.app.awsCredentials,
         }),
       ).getData(
         rdsMetricNames,
@@ -310,6 +314,7 @@ export async function viewServiceMetrics(
         new cw.CloudWatchClient({
           endpoint: ctx.app.awsCloudwatchEndpoint,
           region: ctx.app.awsRegion,
+          credentials: ctx.app.awsCredentials,
         }),
       ).getData(
         elasticacheMetricNames,

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,10 @@ async function main() {
     awsCloudwatchEndpoint: process.env.AWS_CLOUDWATCH_ENDPOINT,
     awsRegion,
     awsResourceTaggingAPIEndpoint: process.env.AWS_RESOURCE_TAGGING_API_ENDPOINT,
+    awsCredentials: !process.env.ENABLE_FAKE_AWS_CREDENTIALS? undefined : {
+      accessKeyId: "FAKE_ACCESS_KEY_ID",
+      secretAccessKey: "FAKE_SECRET_ACCESS_KEY",
+    },
     billingAPI: expectEnvVariable('BILLING_URL'),
     cloudFoundryAPI,
     domainName: expectEnvVariable('DOMAIN_NAME'),

--- a/stub-api/stub-apis-env.sh
+++ b/stub-api/stub-apis-env.sh
@@ -32,5 +32,4 @@ export MS_TENANT_ID=tenantid
 export GOOGLE_CLIENT_ID=googleclientid
 export GOOGLE_CLIENT_SECRET=googleclientsecret
 
-export AWS_ACCESS_KEY_ID=some-key-id
-export AWS_SECRET_ACCESS_KEY=some-secret-key
+export ENABLE_FAKE_AWS_CREDENTIALS=true


### PR DESCRIPTION
What
----

When using the stub API, we have fake responses to AWS API calls, but we still create instances of the client types in code. When this happens, the clients look for AWS credentials in all the normal places.

Sometimes, developers don't have AWS credentials set, or otherwise don't have the `default` profile in place. Since we don't actually NEED the AWS credentials, we should set fakes explicitly when using the stub API. That will stop the AWS clients from searching for credentials.

The error you can get without this change is:

```
stack":"Error: Profile default could not be found or parsed in shared credentials file.\n    at new ProviderError (/Users/andyhunt/code/paas-admin/node_modules/@aws-sdk/property-provider/src/ProviderError.ts:14:5)
```

How to review
-------------
1. Checkout `master`
2. Disable your `default` AWS profile if you have one
3. Run with the stub api
4. Go to [the service metrics page](http://0.0.0.0:3000/organisations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/services/0d632575-bb06-4ea5-bb19-a451a9644d92/metrics?rangeStart=2020-10-05T12%3A52&rangeStop=2020-10-06T12%3A52)
5. Check you get the error
6. Checkout this branch
7. Repeat steps 3, 4
8. See you don't get an error anymore

Who can review
---------------
Anyone