### PR TITLE
Update user deletion "are you sure" page

### DIFF
--- a/src/components/org-users/controllers.tsx
+++ b/src/components/org-users/controllers.tsx
@@ -1046,7 +1046,6 @@ export async function confirmDeletion(
   if (!user) {
     throw new NotFoundError('User not found');
   }
-
   const template = new Template(ctx.viewContext, 'Confirm user deletion');
   template.breadcrumbs = fromOrg(ctx, organization, [
     {
@@ -1064,6 +1063,7 @@ export async function confirmDeletion(
         csrf={ctx.viewContext.csrf}
         linkTo={ctx.linkTo}
         organizationGUID={organization.metadata.guid}
+        organizationName={organization.entity.name}
         user={user}
       />,
     ),

--- a/src/components/org-users/views.test.tsx
+++ b/src/components/org-users/views.test.tsx
@@ -294,6 +294,7 @@ describe(DeleteConfirmationPage, () => {
       <DeleteConfirmationPage
         csrf="CSRF_TOKEN"
         linkTo={route => `__LINKS_TO__${route}`}
+        organizationName="ORG_NAME"
         organizationGUID="ORG_GUID"
         user={user}
       />,
@@ -302,7 +303,8 @@ describe(DeleteConfirmationPage, () => {
     expect($('h2').text()).toContain(
       'Are you sure you\'d like to remove the following user?',
     );
-    expect($('p').text()).toContain('user-name');
+    expect($('.govuk-summary-list').text()).toContain('user-name');
+    expect($('.govuk-summary-list').text()).toContain('ORG_NAME');
   });
 });
 

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -16,6 +16,7 @@ interface IDeleteConfirmationPageProperties {
   readonly csrf: string;
   readonly linkTo: RouteLinker;
   readonly organizationGUID: string;
+  readonly organizationName: string;
   readonly user: IOrganizationUserRoles;
 }
 
@@ -364,7 +365,24 @@ export function DeleteConfirmationPage(
             Are you sure you&apos;d like to remove the following user?
           </h2>
 
-          <p className="govuk-heading-m">{props.user.entity.username}</p>
+          <dl className="govuk-summary-list">
+            <div className="govuk-summary-list__row">
+              <dt className="govuk-summary-list__key">
+                User
+              </dt>
+              <dd className="govuk-summary-list__value">
+                {props.user.entity.username}
+              </dd>
+            </div>
+            <div className="govuk-summary-list__row">
+              <dt className="govuk-summary-list__key">
+                Organisation
+              </dt>
+              <dd className="govuk-summary-list__value">
+                {props.organizationName}
+              </dd>
+            </div>
+          </dl>
 
           <button
             className="govuk-button govuk-button--warning"


### PR DESCRIPTION
What
----

Based on user feedback we're adding the name of the organisation from which the user is being removed from, for more clarity.

_Users can either use email or SSO so we unable to additionally show the email as well in the latter case._ NEEDS changes

How to review
-------------

- checkout branch
- run locally
- visit http://0.0.0.0:3000/organisations/a7aff246-5f5b-4cf8-87d8-f316053e4a20/users/99022be6-feb8-4f78-96f3-7d11f4d476f1/delete to view the change
- review code

Visual changes
---------------

### Before
<img width="792" alt="Screenshot 2020-10-07 at 16 59 52" src="https://user-images.githubusercontent.com/3758555/95356408-8a2dd500-08be-11eb-9697-27fda60bc3c8.png">


### After
<img width="844" alt="Screenshot 2020-10-07 at 16 56 23" src="https://user-images.githubusercontent.com/3758555/95356309-708c8d80-08be-11eb-83b8-5a3643547076.png">

