### PR TITLE
Correct link text for AWS service documentation

### DIFF
--- a/src/components/marketplace/views.tsx
+++ b/src/components/marketplace/views.tsx
@@ -177,7 +177,7 @@ function documentationTitle(service: string, url: string): string {
       return `GOV.UK PaaS ${service} documentation`;
     case 'aws.amazon.com':
     case 'docs.aws.amazon.com':
-      return `AWS RDS ${service} documentation`;
+      return `AWS service documentation`;
     case 'help.aiven.io':
       return `Aiven ${service} documentation`;
     default:


### PR DESCRIPTION

What
----
We were giving the title "AWS RDS ${service} documentation" to every link to AWS docs. 
This resulted in the Redis docs being labelled "AWS RDS Redis documentation".

This commit makes the link text a bit more generic, so that it can apply to all links to AWS docs.


How to review
-------------
See if you agree with the text

Who can review
---------------
Anyone
