### PR TITLE
Link to our channel on cross-gov Slack instance

### DIFF
--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -218,6 +218,13 @@ export function Footer({ authenticated }: IFooterProperties): ReactElement {
                   Static IPs
                 </a>
               </li> : null}
+              <li className="govuk-footer__list-item">
+                <a 
+                  className="govuk-footer__link" 
+                  href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-paas">
+                    Chat to us on Slack
+                </a>
+              </li>
             </ul>
           </div>
           <div className="govuk-footer__section">


### PR DESCRIPTION
What
----

Link to our channel on cross-gov Slack instance to be consistent with Pay and Notify.

How to review
-------------

- run locally
- click on the footer link. if signed into slack it should open the govuk-paas channel

Who can review
---------------

not @kr8n3r 
