### PR TITLE
Replace ES6 with ES5 in cookie functions

### DIFF
--- a/src/frontend/javascript/cookie-functions.js
+++ b/src/frontend/javascript/cookie-functions.js
@@ -46,12 +46,16 @@ Cookies.prototype.initCookieBanner = function ($module) {
 
   this.$acceptCookiesLink = this.$module.querySelector('button[data-accept-cookies=true]');
   if (this.$acceptCookiesLink) {
-    this.$acceptCookiesLink.addEventListener('click', () => this.$module.setBannerCookieConsent(true));
+    this.$acceptCookiesLink.addEventListener('click', function() {
+      this.$module.setBannerCookieConsent(true);
+    }.bind(this));
   }
 
   this.$rejectCookiesLink = this.$module.querySelector('button[data-accept-cookies=false]');
   if (this.$rejectCookiesLink) {
-    this.$rejectCookiesLink.addEventListener('click', () => this.$module.setBannerCookieConsent(false));
+    this.$rejectCookiesLink.addEventListener('click', function() {
+      this.$module.setBannerCookieConsent(false);
+    }.bind(this));
   }
 
   this.showCookieBanner()


### PR DESCRIPTION
What
----

No arrow functions allowed in client-side JS

How to review
-------------

- set `this.cookieDomain` to empty string for localhost test in cookie-functions.js
- start the app
- save a cookie preference
- check if have cookies stored (chrome: Option + ⌘ + J (on macOS), or Shift + CTRL + J (on Windows/Linux) - Application tab

Who can review
---------------
not @kr8n3r 
