### PR TITLE
Correct cloudfoundry marketplace command

### DIFF
--- a/src/components/marketplace/views.tsx
+++ b/src/components/marketplace/views.tsx
@@ -428,7 +428,7 @@ export function MarketplaceItemPage(props: IMarketplaceItemPageProperties): Reac
           versions={props.versions}
         />
 
-        <CommandLineAlternative>{`cf marketplace -s ${props.service.name}`}</CommandLineAlternative>
+        <CommandLineAlternative>{`cf marketplace -e ${props.service.name}`}</CommandLineAlternative>
       </div>
     </div>
   );


### PR DESCRIPTION
Original: #1120

Usage for `cf marketplace` is `cf marketplace [-e SERVICE_OFFERING] [-b SERVICE_BROKER] [--no-plans]`. The flag for specifying a service is `-e`, not `-s`

What
----
Super simple change to the command line alternative on the marketplace page, just fixing the flag used.

How to review
-------------
Usage can be verified by running `cf marketplace -help`

Who can review
---------------
N/A
