### PR TITLE
Update marketplace service docs text logic

### DIFF
--- a/src/components/marketplace/views.tsx
+++ b/src/components/marketplace/views.tsx
@@ -177,6 +177,10 @@ function documentationTitle(service: string, url: string): string {
       return `GOV.UK PaaS ${service} documentation`;
     case 'aws.amazon.com':
     case 'docs.aws.amazon.com':
+        switch(true){
+          case u.pathname.toLowerCase().includes('elasticache'):
+            return `AWS ElastiCache ${service} documentation`;
+        }
       return `AWS RDS ${service} documentation`;
     case 'help.aiven.io':
       return `Aiven ${service} documentation`;


### PR DESCRIPTION
Original: #1105

What
----

Our user pointed out that on
https://admin.london.cloud.service.gov.uk/marketplace/754c7e96-bc62-45ca-8fe7-a5064d922588
it should say ElastiCache instead of RDS.

![Screenshot 2020-11-06 at 14 59 21](https://user-images.githubusercontent.com/3758555/98384423-a8196180-2045-11eb-8c04-8ba8dd69d613.png)


Our url text logic was only checking for hostname which is docs.aws.amazon.com for both AWS ElastiCache Redis and AWS RDS Postgres.

Updated logic checks for both hostname and pathname to return the correct link text.

How to review
-------------

deploy to a dev env as this doesn't work locally

Who can review
---------------

not @kr8n3r 
