### PR TITLE
Move from momentjs to datefs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7396,6 +7396,11 @@
         "whatwg-url": "^7.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "d3-scale": "^3.2.1",
     "d3-selection": "^1.4.2",
     "d3-shape": "^2.0.0",
+    "date-fns": "^2.16.1",
     "express": "^4.17.1",
     "express-pino-logger": "^5.0.0",
     "express-static-gzip": "^2.0.7",

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -1,5 +1,5 @@
 import { forIn } from 'lodash';
-import moment from 'moment';
+import {format, Duration } from 'date-fns';
 import React, { ReactElement, ReactNode } from 'react';
 
 import { bytesToHuman, DATE_TIME } from '../../layouts';
@@ -41,7 +41,7 @@ interface IRangePickerProperties {
   readonly rangeStop: Date;
   readonly linkTo: RouteLinker;
   readonly service: IServiceInstance;
-  readonly period: moment.Duration;
+  readonly period: Duration;
   readonly persistancePeriod?: string;
 }
 
@@ -59,7 +59,7 @@ interface IMetricPageProperties extends IPageProperties {
   readonly rangeStart: Date;
   readonly rangeStop: Date;
   readonly serviceLabel: string;
-  readonly period: moment.Duration;
+  readonly period: Duration;
   readonly metrics: ReadonlyArray<IMetricProperties>;
 }
 
@@ -280,7 +280,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
-                      defaultValue={moment(props.rangeStart).format('DD')}
+                      defaultValue={format(props.rangeStart, 'dd')}
                     />
                   </div>
                 </div>
@@ -296,7 +296,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
-                      defaultValue={moment(props.rangeStart).format('MM')}
+                      defaultValue={format(props.rangeStart, 'MM')}
                       />
                   </div>
                 </div>
@@ -312,7 +312,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
-                      defaultValue={moment(props.rangeStart).format('YYYY')}
+                      defaultValue={format(props.rangeStart, 'yyyy')}
                       />
                   </div>
                 </div>
@@ -340,7 +340,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
-                      defaultValue={moment(props.rangeStart).format('HH')}
+                      defaultValue={format(props.rangeStart, 'HH')}
                     />
                   </div>
                 </div>
@@ -356,7 +356,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
-                      defaultValue={moment(props.rangeStart).format('mm')} 
+                      defaultValue={format(props.rangeStart, 'mm')}
                     />
                   </div>
                 </div>
@@ -385,7 +385,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
-                      defaultValue={moment(props.rangeStop).format('DD')}
+                      defaultValue={format(props.rangeStart, 'dd')}
                       />
                   </div>
                 </div>
@@ -401,7 +401,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                     type="text"
                     pattern="[0-9]*"
                     inputMode="numeric"
-                    defaultValue={moment(props.rangeStop).format('MM')}
+                    defaultValue={format(props.rangeStart, 'MM')}
                   />
                   </div>
                 </div>
@@ -417,7 +417,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
-                      defaultValue={moment(props.rangeStop).format('YYYY')}
+                      defaultValue={format(props.rangeStart, 'yyyy')}
                     />
                   </div>
                 </div>
@@ -445,7 +445,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric"
-                      defaultValue={moment(props.rangeStop).format('HH')}
+                      defaultValue={format(props.rangeStart, 'HH')}
                     />
                   </div>
                 </div>
@@ -461,7 +461,7 @@ function RangePicker(props: IRangePickerProperties): ReactElement {
                       type="text"
                       pattern="[0-9]*"
                       inputMode="numeric" 
-                      defaultValue={moment(props.rangeStop).format('mm')}
+                      defaultValue={format(props.rangeStart, 'mm')}
                       />
                     </div>
                 </div>
@@ -521,8 +521,8 @@ export function UnsupportedServiceMetricsPage(
 
 export function MetricPage(props: IMetricPageProperties): ReactElement {
   const title = `Metrics <span class="govuk-visually-hidden">
-    between ${' '}${moment(props.rangeStart).format(DATE_TIME)}${' '}
-    and${' '}${moment(props.rangeStop).format(DATE_TIME)}
+    between ${' '}${format(props.rangeStart, DATE_TIME)}${' '}
+    and${' '}${format(props.rangeStop, DATE_TIME)}
   </span>`;
   return (
     <ServiceTab
@@ -548,9 +548,9 @@ export function MetricPage(props: IMetricPageProperties): ReactElement {
             <hr className="govuk-section-break govuk-section-break--m" />
             <p className="govuk-body">
               Showing metrics between{' '}
-              <strong>{moment(props.rangeStart).format(DATE_TIME)}</strong>{' '}
+              <strong>{format(props.rangeStart, DATE_TIME)}</strong>{' '}
               and{' '}
-              <strong>{moment(props.rangeStop).format(DATE_TIME)}</strong>
+              <strong>{format(props.rangeStop, DATE_TIME)}</strong>
             </p>
 
             <p className="govuk-body">

--- a/src/layouts/constants.ts
+++ b/src/layouts/constants.ts
@@ -1,6 +1,6 @@
 export const DATE = 'MMMM Do YYYY';
 export const TIME = 'HH:mm';
-export const DATE_TIME = 'h:mma, D MMMM YYYY';
+export const DATE_TIME = 'h:mma, d MMMM yyyy';
 
 export const KIBIBYTE = 1024;
 export const MEBIBYTE = KIBIBYTE * 1024;


### PR DESCRIPTION
Original: #1096

What
----

Moment.js is now in [maintenance mode only](https://momentjs.com/docs/#/-project-status/) so we can take time to move away from it.

[date-fns](https://github.com/date-fns/date-fns) is a much smaller replacement. We utilise some things that are not available natively in javascript so cannot use that.
[See the comparison table](https://github.com/you-dont-need/You-Dont-Need-Momentjs#feature-parity)

How to review
-------------

Describe the steps required to test the changes.

Who can review
---------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
