### PR TITLE
use service/app specific command for CLI example

### DIFF
--- a/src/components/applications/views.tsx
+++ b/src/components/applications/views.tsx
@@ -222,9 +222,7 @@ export function ApplicationPage(
             </tbody>
           </table>
           </div>
-          <CommandLineAlternative context="for all of your apps">
-            cf apps
-          </CommandLineAlternative>
+          <CommandLineAlternative>{`cf app ${props.application.entity.name}`}</CommandLineAlternative>
         </div>
       </div>
     </ApplicationTab>

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -208,9 +208,8 @@ export function ServicePage(props: IServicePageProperties): ReactElement {
           </table>
           </div>
 
-          <CommandLineAlternative context="for all of your services">
-            cf services
-          </CommandLineAlternative>
+          <CommandLineAlternative>{`cf service ${props.service.entity.name}`}</CommandLineAlternative>
+
         </div>
       </div>
     </ServiceTab>


### PR DESCRIPTION
What
----

Use Service/App specific command in CLI example. This is because:
1) As this is an app/service specific page it makes more sense to show the specific command
2) The call to action says _"You can also view this information in the Cloud Foundry command line interface by running:"_ and this is simply not true, the information on the `cf apps`/`cf services` summary does not contain all the fields in this view.

How to review
-------------

Go to Application and Service pages. Commands should be app/service specific
e.g.
![Screenshot 2021-01-28 at 15 59 42](https://user-images.githubusercontent.com/1764158/106164494-effddf80-6181-11eb-9b4a-37c38dcaf1b6.png)

Who can review
---------------

not me
