### PR TITLE
Fix local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     },
     "globals": {
       "ts-jest": {
-        "tsConfig": "tsconfig.json",
+        "tsconfig": "tsconfig.json",
         "diagnostics": false
       }
     },

--- a/stub-api/stub-accounts.ts
+++ b/stub-api/stub-accounts.ts
@@ -47,7 +47,7 @@ return;
 return;
     }
 
-    const uuidsAsList: ReadonlyArray<string> = uuids.split(',');
+    const uuidsAsList: ReadonlyArray<string> = (uuids as string).split(',');
     const uuidsThatExist = uuidsAsList.filter(id => userIds.indexOf(id) >= 0);
 
     res.send(JSON.stringify({

--- a/stub-api/stub-prometheus.ts
+++ b/stub-api/stub-prometheus.ts
@@ -12,9 +12,10 @@ function mockPrometheus(
   app.get(
     /query_range/,
     (req, res) => {
-      const historicTime = parseInt(req.query.start, 10);
-      const instantTime = parseInt(req.query.end, 10);
-      const step = parseInt(req.query.step, 10);
+      console.log(req.query.start)
+      const historicTime = parseInt(req.query.start as string, 10);
+      const instantTime = parseInt(req.query.end as string, 10);
+      const step = parseInt(req.query.step as string, 10);
 
       const length = Math.ceil(((instantTime - historicTime)) / step);
 


### PR DESCRIPTION
What
----

Tighter rules result in a failed start up mocks with `npm run start:stub:api`
This resolves it and addresses the ts-jest warning as well.

How to review
-------------

- run `npm run start:stub-api` in `main` branch 
it should fail to start

- run `npm run start:stub-api` in this branch
It should start fine 

Who can review
---------------

not @kr8n3r 
