### PR TITLE
Don't ship CSS sourceMaps in production

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -86,7 +86,7 @@ let cfg = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
+              sourceMap: NODE_ENV === 'production' ? false : true,
               url: false,
             },
           },


### PR DESCRIPTION
What
----

Seems like OptimizeCssnanoPlugin sourceMap has no effect as maps are already added by the css-loader.

Checking for NODE_ENV there allows us to remove sourcemaps from prod css and reduce screen.css by 100KB

![Screenshot 2021-02-26 233229](https://user-images.githubusercontent.com/3758555/109366482-72fe7c80-788b-11eb-8561-85e99309432f.jpg)


How to review
-------------

- check out main branch, set NODE_ENV=production and run `npm run -s build`. Check CSS file sizes.
- check out this branch, set NODE_ENV=production and run `npm run -s build`. Check and compare CSS file sizes.

Who can review
---------------

not @kr8n3r
