### PR TITLE
Update statement page layout

### DIFF
--- a/src/components/statements/_statements.scss
+++ b/src/components/statements/_statements.scss
@@ -5,18 +5,17 @@
   }
 }
 
-.text-right {
-  text-align: right;
-}
-
-.paas-text-regular {
-  font-weight: 500;
-}
-
-.paas-exchange-rate {
-  border: 10px solid govuk-colour("light-grey");
+.cost-summary {
   background-color: govuk-colour("light-grey");
-  padding: 10px;
+  @include govuk-responsive-margin(6, "top");
+  @include govuk-responsive-margin(6, "bottom");
+  @include govuk-responsive-padding(6, "top");
+  @include govuk-responsive-padding(2, "bottom");
+  @include govuk-responsive-padding(6, "left");
+  @include govuk-responsive-padding(6, "right");
+}
+
+.cost-summary-table {
   border-collapse: separate;
   margin-bottom: govuk-spacing(4);
 
@@ -26,10 +25,6 @@
     padding-bottom: 0;
     padding-top: 0;
   }
-}
-
-.paas-month-price-demphasised {
-  font-weight: normal;
 }
 
 .paas-table-billing-statement {
@@ -64,15 +59,6 @@
       border-top-color: currentColor;
     }
   }
-}
-
-.paas-month-total-information {
-   @include govuk-font($size: 16);
-   color: govuk-colour("dark-grey");
-}
-
-.paas-month-price {
-  text-align: right;
 }
 
 .paas-table-notification {

--- a/src/components/statements/_statements.scss
+++ b/src/components/statements/_statements.scss
@@ -1,12 +1,7 @@
-@mixin hidden {
-  position: absolute !important;
-  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-  clip: rect(1px, 1px, 1px, 1px);
-}
-
 .paas-statement-range {
   button {
-    margin-bottom: 5px;
+    margin-bottom: 2px;
+    width: 100%;
   }
 }
 
@@ -80,37 +75,26 @@
   text-align: right;
 }
 
-.paas-hidden-table-header {
-  @include hidden;
-}
-
 .paas-table-notification {
   @include govuk-font($size: 24);
   padding: 25px 0;
   text-align: center;
 }
 
-.paas-statement-filter {
-  width: 23%;
-
-  .govuk-button {
-    width: 100%;
-  }
-}
-
 .paas-statement-filters {
   @include govuk-responsive-padding(6);
   background-color: govuk-colour("light-grey");
-  border-collapse: separate;
-
-  .govuk-table__header,
-  .govuk-table__cell {
-    border-bottom: 0;
-    padding-bottom: 0;
-    padding-top: .32632em
+  @include govuk-media-query($from:tablet) {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: govuk-spacing(3); // safari 10.1 - 11.1 and FF 52-60
+    column-gap: govuk-spacing(3);
+    align-items: end;
   }
-
-  .govuk-table__header {
-    @include govuk-font($size: 16, $weight: bold);
+  @include govuk-media-query($from:desktop) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  > div {
+    margin-bottom: govuk-spacing(3);
   }
 }

--- a/src/components/statements/views.test.tsx
+++ b/src/components/statements/views.test.tsx
@@ -71,14 +71,14 @@ describe(StatementsPage, () => {
     expect($('input[name="_csrf"]').prop('value')).toEqual('qwert');
     expect($('input[name="sort"]').prop('value')).toEqual('name');
     expect($('input[name="order"]').prop('value')).toEqual('asc');
-    expect($('th').text()).toContain(
+    expect($('.cost-summary-table tbody tr:first-child th').text()).toContain(
       'Total cost for January in space-name space with service-name services',
     );
-    expect($('th').text()).toContain('£302.62');
-    expect($('th').text()).toContain('£363.15');
-    expect($('td').text()).toContain('£27.51');
-    expect($('td').text()).toContain('£33.01');
-    expect($('tr').text()).toContain('Exchange rate: £1 to $1.25');
+    expect($('.cost-summary-table tbody tr:first-child td').eq(0).text()).toContain('£302.62');
+    expect($('.cost-summary-table tbody tr:first-child td').eq(1).text()).toContain('£363.15');
+    expect($('.cost-summary-table tbody tr:nth-child(2) td').eq(0).text()).toContain('£27.51');
+    expect($('.cost-summary-table tbody tr:nth-child(2) td').eq(1).text()).toContain('£33.01');
+    expect($('.exchange-rate').text()).toContain('Exchange rate: £1 to $1.25');
     expect($('.paas-table-billing-statement caption').text()).toContain(
       'Cost itemisation for January in space-name space with service-name services sorted by name column in ascending order',
     );

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -181,88 +181,107 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
         </div>
 
         <div className="govuk-grid-column-full">
-          <div className="scrollable-table-container">
-            <table className="govuk-table paas-exchange-rate">
-            <caption className="govuk-visually-hidden">
-              Summary of total cost inclusive of 10% admin fee, shown with and without VAT
-            </caption>
-            <tr className="govuk-table__row">
-              <th className="govuk-table__header" scope="row">
-                Total cost for {props.currentMonth}{' '}
-                {props.filterSpace?.guid !== 'none' ? (
-                  <span className="paas-text-regular">
-                    in <strong>{props.filterSpace?.name.toLowerCase()}</strong>{' '}
-                    space
-                  </span>
-                ) : (
-                  <></>
-                )}{' '}
-                {props.filterService?.guid !== 'none' ? (
-                  <span className="paas-text-regular">
-                    with{' '}
-                    <strong>{props.filterService?.name.toLowerCase()}</strong>{' '}
-                    services
-                  </span>
+          <div className="scrollable-table-container cost-summary">
+            <table className="govuk-table cost-summary-table">
+              <caption className="govuk-visually-hidden">
+                Summary of total cost inclusive of 10% admin fee, shown with and without VAT at
+                exchange rate:
+                {props.usdCurrencyRates.length === 1 ? (
+                  `${' '}£1 to $${1.0 / props.usdCurrencyRates[0].rate.toFixed(2)}`
                 ) : (
                   <></>
                 )}
-              </th>
-              <th className="paas-month-price paas-month-price-demphasised">
-                £
-                {(
-                  props.totals.exVAT +
-                  props.totals.exVAT * props.adminFee
-                ).toFixed(2)}
-              </th>
-              <th className="paas-month-price">
-                £
-                {(
-                  props.totals.incVAT +
-                  props.totals.incVAT * props.adminFee
-                ).toFixed(2)}
-              </th>
-            </tr>
-            <tr>
-              <td className="govuk-table__cell">
-                <small>Included 10% admin fee:</small>
-              </td>
-              <td className="paas-month-price">
-                <small>
-                  £{(props.totals.exVAT * props.adminFee).toFixed(2)}
-                </small>
-              </td>
-              <td className="paas-month-price">
-                <small>
-                  £{(props.totals.incVAT * props.adminFee).toFixed(2)}
-                </small>
-              </td>
-            </tr>
-            <tr className="paas-month-total-information">
+                {props.usdCurrencyRates.length > 1 ? (
+                  props.usdCurrencyRates.map(usdCurrencyRate => (
+                      `{' '}£1 to $${(1.0 / usdCurrencyRate.rate).toFixed(2)} from${' '}
+                      ${moment(usdCurrencyRate.validFrom).format(DATE)}`
+                  ))
+                ) : (
+                  <></>
+                )}
+              </caption>
+              <thead className="govuk-table__head">
+                <tr className="govuk-table__row">
+                  <th scope="col" className="govuk-table__header govuk-visually-hidden">Item</th>
+                  <th scope="col" className="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular govuk-!-font-size-16">
+                    excluding VAT
+                  </th>
+                  <th scope="col" className="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular govuk-!-font-size-16">
+                    including VAT at 20%
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="govuk-table__body">
+                <tr className="govuk-table__row">
+                  <th className="govuk-table__header" scope="row">
+                    Total cost for {props.currentMonth}{' '}
+                    {props.filterSpace?.guid !== 'none' ? (
+                      <span className="govuk-!-font-weight-regular">
+                        in <strong>{props.filterSpace?.name.toLowerCase()}</strong>{' '}
+                        space
+                      </span>
+                    ) : (
+                      <></>
+                    )}{' '}
+                    {props.filterService?.guid !== 'none' ? (
+                      <span className="govuk-!-font-weight-regular">
+                        with{' '}
+                        <strong>{props.filterService?.name.toLowerCase()}</strong>{' '}
+                        services
+                      </span>
+                    ) : (
+                      <></>
+                    )}
+                  </th>
+                  <td className="govuk-table__cell govuk-table__cell--numeric">
+                    £
+                    {(
+                      props.totals.exVAT +
+                      props.totals.exVAT * props.adminFee
+                    ).toFixed(2)}
+                  </td>
+                  <td className="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">
+                    £
+                    {(
+                      props.totals.incVAT +
+                      props.totals.incVAT * props.adminFee
+                    ).toFixed(2)}
+                  </td>
+                </tr>
+                <tr className="govuk-table__row">
+                  <th className="govuk-table__header" scope="row">
+                    <span className="govuk-body-s govuk-!-font-weight-regular">Included 10% admin fee:</span>
+                  </th>
+                  <td className="govuk-table__cell govuk-table__cell--numeric">
+                    <small>
+                      £{(props.totals.exVAT * props.adminFee).toFixed(2)}
+                    </small>
+                  </td>
+                  <td className="govuk-table__cell govuk-table__cell--numeric">
+                    <small>
+                      £{(props.totals.incVAT * props.adminFee).toFixed(2)}
+                    </small>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
               {props.usdCurrencyRates.length === 1 ? (
-                <td className="govuk-table__cell">
-                  Exchange rate: £1 to $
-                  {1.0 / props.usdCurrencyRates[0].rate.toFixed(2)}
-                </td>
+                <p className="govuk-body-s exchange-rate">
+                  Exchange rate: £1 to ${1.0 / props.usdCurrencyRates[0].rate.toFixed(2)}
+                </p>
               ) : (
                 <></>
               )}
               {props.usdCurrencyRates.length > 1 ? (
-                <td className="govuk-table__cell">
-                  Exchange rate:{' '}
-                  {props.usdCurrencyRates.map((usdCurrencyRate, index) => (
-                    <span key={index}>
-                      £1 to ${(1.0 / usdCurrencyRate.rate).toFixed(2)} from{' '}
-                      {moment(usdCurrencyRate.validFrom).format(DATE)}
-                    </span>
-                  ))}
-                </td>
+                props.usdCurrencyRates.map((usdCurrencyRate, index) => (
+                  <p key={index} className="govuk-body-s exchange-rate">
+                    Exchange rate: £1 to ${(1.0 / usdCurrencyRate.rate).toFixed(2)} from{' '}
+                    {moment(usdCurrencyRate.validFrom).format(DATE)}
+                  </p>
+                ))
               ) : (
                 <></>
               )}
-              <td className="paas-month-price">ex VAT</td>
-              <td className="paas-month-price">inc VAT at 20%</td>
-            </tr>
-          </table>
           </div>
           <p>
             <a

--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -101,101 +101,78 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
             className="paas-statement-range"
           >
             <input type="hidden" name="_csrf" value={props.csrf} />
-            <div className="scrollable-table-container">
-              <table className="govuk-table paas-statement-filters">
-              <tbody className="govuk-table__body">
-                <tr className="govuk-table__row">
-                  <th className="govuk-table__header" scope="column">
-                    Month
-                  </th>
-                  <th className="govuk-table__header" scope="column">
-                    Spaces
-                  </th>
-                  <th className="govuk-table__header" scope="column">
-                    Services and apps
-                  </th>
-                  <th
-                    className="govuk-table__header paas-hidden-table-header"
-                    scope="column"
-                  >
-                    Filter
-                  </th>
-                </tr>
-                <tr>
-                  <td className="govuk-table__cell">
-                    <label className="govuk-label govuk-visually-hidden" htmlFor="rangeStart">
-                      Select month to filter by
-                    </label>
-                    <select
-                      className="govuk-select govuk-!-width-full"
-                      id="rangeStart"
-                      name="rangeStart"
+            <div className="paas-statement-filters">
+              <div>
+                <label className="govuk-label govuk-label--s govuk-!-font-size-16" htmlFor="rangeStart">
+                  <span className="govuk-visually-hidden">Filter by</span> Month
+                </label>
+                <select
+                  className="govuk-select govuk-!-width-full"
+                  id="rangeStart"
+                  name="rangeStart"
+                >
+                  {Object.keys(props.listOfPastYearMonths).map(
+                    (key, index) => (
+                      <option
+                        key={index}
+                        value={key}
+                        selected={props.filterMonth === key}
+                      >
+                        {props.listOfPastYearMonths[key]}
+                      </option>
+                    ),
+                  )}
+                </select>
+              </div>
+              <div>
+                <label className="govuk-label govuk-label--s govuk-!-font-size-16" htmlFor="space">
+                  <span className="govuk-visually-hidden">Filter by</span> Spaces
+                </label>
+                <select
+                  className="govuk-select govuk-!-width-full"
+                  id="space"
+                  name="space"
+                >
+                  {props.spaces.map(space => (
+                    <option
+                      key={space.guid}
+                      value={space.guid}
+                      selected={props.filterSpace?.guid === space.guid}
                     >
-                      {Object.keys(props.listOfPastYearMonths).map(
-                        (key, index) => (
-                          <option
-                            key={index}
-                            value={key}
-                            selected={props.filterMonth === key}
-                          >
-                            {props.listOfPastYearMonths[key]}
-                          </option>
-                        ),
-                      )}
-                    </select>
-                  </td>
-                  <td className="govuk-table__cell">
-                    <label className="govuk-label govuk-visually-hidden" htmlFor="space">
-                      Select a space to filter by
-                    </label>
-                    <select
-                      className="govuk-select govuk-!-width-full"
-                      id="space"
-                      name="space"
+                      {space.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="govuk-label govuk-label--s govuk-!-font-size-16" htmlFor="service">
+                  <span className="govuk-visually-hidden">Filter by</span> Services and apps
+                </label>
+                <select
+                  className="govuk-select govuk-!-width-full"
+                  id="service"
+                  name="service"
+                >
+                  {props.plans.map(plan => (
+                    <option
+                      key={plan.guid}
+                      value={plan.guid}
+                      selected={props.filterService?.guid === plan.guid}
                     >
-                      {props.spaces.map(space => (
-                        <option
-                          key={space.guid}
-                          value={space.guid}
-                          selected={props.filterSpace?.guid === space.guid}
-                        >
-                          {space.name}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
-                  <td className="govuk-table__cell">
-                    <label className="govuk-label govuk-visually-hidden" htmlFor="service">
-                      Select services and apps to filter by
-                    </label>
-                    <select
-                      className="govuk-select govuk-!-width-full"
-                      id="service"
-                      name="service"
-                    >
-                      {props.plans.map(plan => (
-                        <option
-                          key={plan.guid}
-                          value={plan.guid}
-                          selected={props.filterService?.guid === plan.guid}
-                        >
-                          {plan.name}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
-                  <td className="govuk-table__cell paas-statement-filter">
-                    <button
-                      className="govuk-button"
-                      data-module="govuk-button"
-                      data-prevent-double-click="true"
-                    >
-                      Filter <span className="govuk-visually-hidden">with selected options</span>
-                    </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      {plan.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <button
+                  className="govuk-button"
+                  data-module="govuk-button"
+                  data-prevent-double-click="true"
+                >
+                  Filter <span className="govuk-visually-hidden">with selected options</span>
+                </button>
+              </div>
             </div>
 
             <input type="hidden" name="sort" value={props.orderBy} />


### PR DESCRIPTION
What
----

Replace the use of tables for layout in the filters section with CSS Grid , update the cost summary table with proper markup and cleanup CSS styles

Visual changes
----

### Before

https://user-images.githubusercontent.com/3758555/112801269-96723e00-9068-11eb-80f2-ed485eb8e4fd.mov


### After


https://user-images.githubusercontent.com/3758555/114675806-9167ec80-9d00-11eb-82db-261c345950ea.mov



## Browsers that don't support the modern CSS Grid syntax
![non modern css grid supporting browser layout](https://user-images.githubusercontent.com/3758555/114672060-a2aefa00-9cfc-11eb-938a-8dcccfac2dce.png)



How to review
-------------

- [compare markup changes with whitespace removed](https://github.com/alphagov/paas-admin/pull/1336/files?diff=split&w=1)
- run locally and check statement page in browser
- review code changes


Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
