### PR TITLE
Fix metrics filters glitch

### DIFF
--- a/src/components/service-metrics/service-metrics.scss
+++ b/src/components/service-metrics/service-metrics.scss
@@ -2,3 +2,8 @@
   border-bottom: 1px solid $govuk-border-colour;
   margin-bottom: 10px;
 }
+
+.metrics-filters {
+  @include govuk-responsive-padding(6);
+  background-color: govuk-colour("light-grey");
+}

--- a/src/components/service-metrics/views.tsx
+++ b/src/components/service-metrics/views.tsx
@@ -214,7 +214,7 @@ function Metric(props: IMetricProperties): ReactElement {
 
 function RangePicker(props: IRangePickerProperties): ReactElement {
   return (
-    <div className="paas-statement-filters">
+    <div className="metrics-filters">
       <h2 className="govuk-heading-m">Change time period</h2>
       <h3 className="govuk-heading-s">Chose a predefined period</h3>
         <ol className="govuk-list">


### PR DESCRIPTION
What
----

It turns out that the same CSS classname was used on the metrics filters that is used on billing statement filters.

Work in https://github.com/alphagov/paas-admin/pull/1336 broke.

New CSS class has now been added to the metrics filter.

### Before
![Screenshot 2021-04-15 at 11 55 31](https://user-images.githubusercontent.com/3758555/114861632-686d5780-9de5-11eb-89a3-bee012ee2cd4.png)


### After

![Screenshot 2021-04-15 at 12 22 28](https://user-images.githubusercontent.com/3758555/114861516-4673d500-9de5-11eb-9619-463c5d17972e.png)

How to review
-------------

- run locally
- check metrics page
- check billing page to double check

Who can review
---------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
