### PR TITLE
Strip PII data

### DIFF
--- a/src/frontend/javascript/cookie-functions.js
+++ b/src/frontend/javascript/cookie-functions.js
@@ -145,7 +145,7 @@ Cookies.prototype.setupGtm = function () {
 
   var config = {
     cookie_expires: this.cookieDuration * 24 * 60 * 60,
-    page_path: this.stripUuids(),
+    page_path: this.PIIfy(window.location.pathname),
     // Paas-admin gets a relatively small number	
     // of visits daily, so the default site speed	
     // sample rate of 1% gives us too few data points.	
@@ -178,10 +178,19 @@ Cookies.prototype.loadGtmScript = function () {
   document.documentElement.firstChild.appendChild(gtmScriptTag)
 }
 
-Cookies.prototype.stripUuids = function () {
-  return window.location.pathname.replace(
-    /[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}/g, '…'
-  )
+Cookies.prototype.PIIfy = function (string) {
+
+  var strippedString
+  var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
+  var UUID_PATTERN = /[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}/g
+  strippedString = string
+    .replace(
+      UUID_PATTERN, '…'
+    ).replace(
+      EMAIL_PATTERN, '[email]'
+    )
+
+  return strippedString
 }
 
 export default Cookies

--- a/src/frontend/javascript/cookie-functions.test.js
+++ b/src/frontend/javascript/cookie-functions.test.js
@@ -127,6 +127,18 @@ describe("Cookies", () => {
       expect(document.documentElement.innerHTML).toContain(`https://www.googletagmanager.com/gtag/js?id=${cookies.trackingId}`);
       expect(global.dataLayer[1]).toContain(cookies.trackingId);
     });
+
+    it(`string is stripped of email address`, () => {
+      const input = '/users/test.user@test.com';
+      const result = cookies.PIIfy(input)
+      expect(result).toBe('/users/[email]');
+    });
+
+    it(`string is stripped of uuid`, () => {
+      const input = '/organisations/2b6275d6-6c39-484d-b6e1-71a05b3fab65';
+      const result = cookies.PIIfy(input)
+      expect(result).toBe('/organisations/…');
+    });
   });
 
 });


### PR DESCRIPTION
What
----

We need to strip more personally identifiable information (PII) that gets sent to GA as part of the url.
We already striped UUIDs but found out that on the `/platform-admin/user` search url plays back the email search for.

This updates the function to additionally remove the email address from  user search in platform admin


How to review
-------------

- review code

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
