### PR TITLE
Implement GA event tracking

### DIFF
--- a/src/components/statements/views.tsx
+++ b/src/components/statements/views.tsx
@@ -169,6 +169,10 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
                   className="govuk-button"
                   data-module="govuk-button"
                   data-prevent-double-click="true"
+                  data-track-click="true" 
+                  data-track-category="Click"
+                  data-track-action="Button"
+                  data-track-label="Billing filter"
                 >
                   Filter <span className="govuk-visually-hidden">with selected options</span>
                 </button>
@@ -291,6 +295,10 @@ export function StatementsPage(props: IStatementsPageProperties): ReactElement {
               })}
               className="govuk-link"
               download
+              data-track-click="true" 
+              data-track-category="Click"
+              data-track-action="Link"
+              data-track-label="Billing download"
             >
               Download a spreadsheet of these items [CSV] <span className="govuk-visually-hidden">as a comma-separated values file</span>
             </a>

--- a/src/frontend/javascript/event-tracking.js
+++ b/src/frontend/javascript/event-tracking.js
@@ -1,0 +1,110 @@
+function EventTracking () {
+  this.$bodyElement = document.querySelector('body')
+  this.$mainHeading = this.$bodyElement.querySelector('h1')
+ }
+
+EventTracking.prototype.init = function() {
+
+  this.$bodyElement.addEventListener('click', this.handleClickEvent.bind(this))
+  this.checkForErrorPage(this.$mainHeading)
+}
+
+EventTracking.prototype.handleClickEvent = function (e) {
+  var target = e.target,
+      isLink = e.target.nodeName === 'A',
+      // external link: starts with http(s) or mailto and does not contain a "service.gov" in url
+      externalLinkRegex = /^(?=.*(http|mailto))(?:(?!cloud\.service\.gov\.uk).)*$/g,
+      isExternalLink = isLink && externalLinkRegex.test(target.getAttribute('href')),
+      // we have data tracking attributes on some elements
+      isManuallyTargetedElement = target.hasAttribute('data-track-click') 
+        && target.getAttribute('data-track-click').indexOf('true') > -1
+
+  // therem ight be an edge case where a manually tagretted link could also be an external link
+  // and we only wan't to fire one function in such a case
+  // hence the logic below
+  if (isExternalLink && isManuallyTargetedElement) {
+    this.trackTargettedLinkClick(target)
+  }
+  
+  if (!isExternalLink && isManuallyTargetedElement) {
+    this.trackTargettedLinkClick(target)
+  }
+
+  if (isExternalLink && !isManuallyTargetedElement) {
+    this.trackExternalLinkClick(target)
+  }
+}
+
+EventTracking.prototype.trackTargettedLinkClick = function (element) {
+  var eventParams = {},
+    category = element.getAttribute('data-track-category'),
+    action = element.getAttribute('data-track-action'),
+    label = element.getAttribute('data-track-label')
+
+  if (label) {
+    eventParams.event_label = label
+  }
+
+  if (category) {
+    eventParams.event_category = category
+  }
+  
+  this.sendEvent(action, eventParams)
+}
+
+EventTracking.prototype.trackExternalLinkClick = function (element) {
+
+  var eventParams = {},
+      action = element.textContent
+
+  eventParams.event_category = 'External Link Clicked'
+  eventParams.event_label = element.getAttribute('href')
+  
+  this.sendEvent(action, eventParams)
+}
+
+EventTracking.prototype.errorPageEvent = function (errorStatusCode) {
+
+  var eventParams = {},
+      action = errorStatusCode
+
+  eventParams.event_category = 'Error'
+  
+  this.sendEvent(action, eventParams)
+}
+
+EventTracking.prototype.sendEvent = function (action, options) {
+  window.dataLayer = window.dataLayer || []
+  var gtag = function () {
+    dataLayer.push(arguments)
+  }
+
+  gtag('event', action, options)
+}
+
+EventTracking.prototype.checkForErrorPage = function(identifier) {
+  // GA needs strings for status code as event labels
+  var errorPagesArray = [
+    {
+      title: 'Page not authorised',
+      statusCode: '403'
+    },
+    {
+      title: 'Page not found',
+      statusCode: '404'
+    },
+    {
+      title: 'Sorry an error occurred',
+      statusCode: '500'
+    }
+  ]
+  if (!identifier) return
+  
+  var errorPageData  = errorPagesArray.filter(function(o){
+    return o.title === identifier.textContent; 
+  });
+  
+  errorPageData[0] ? this.errorPageEvent(errorPageData[0].statusCode) : null;
+}
+
+export default EventTracking

--- a/src/frontend/javascript/event-tracking.js
+++ b/src/frontend/javascript/event-tracking.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 function EventTracking () {
   this.$bodyElement = document.querySelector('body')
   this.$mainHeading = this.$bodyElement.querySelector('h1')

--- a/src/frontend/javascript/event-tracking.test.js
+++ b/src/frontend/javascript/event-tracking.test.js
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import EventTracking from './event-tracking'
+
+const eventTracking = new EventTracking()
+
+describe("link event tracking", () => {
+  beforeEach(() => {
+    global.dataLayer = []
+    eventTracking.init()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it("if a link has data tracking attributes, those values should be used in push to dataLayer", () => {
+
+    document.body.innerHTML = `
+    <a href="/test"
+      data-testid="data-attribute-tracking"
+      data-track-click="true" 
+      data-track-category="Test category 1" 
+      data-track-action="Test action 1" 
+      data-track-label="Test label 1">
+        Link with data tracking attributes
+    </a>
+    `
+    document.querySelector('[data-testid="data-attribute-tracking"').click()
+    
+    expect(global.dataLayer[0]).toEqual(
+      expect.objectContaining({
+        '0': 'event',
+        '1': 'Test action 1',
+        '2': { event_label: 'Test label 1', event_category: 'Test category 1' }
+      })
+    )
+  })
+
+  it("if a link has data tracking attributes but is also an external link, data attribute values should be used in push to dataLayer", () => {
+
+    document.body.innerHTML = `
+    <a href="https://example.com"
+      data-testid="external-with-data-attribute-tracking"
+      data-track-click="true" 
+      data-track-category="Test category 2" 
+      data-track-action="Test action 2" 
+      data-track-label="Test label 2">
+        External link with data tracking attributes
+    </a>
+    `
+
+    document.querySelector('[data-testid="external-with-data-attribute-tracking"]').click()
+
+    expect(global.dataLayer[0]).toEqual(
+      expect.objectContaining({
+        '0': 'event',
+        '1': 'Test action 2',
+        '2': { event_label: 'Test label 2', event_category: 'Test category 2' }
+      })
+    )
+  })
+
+  it("if a link is an external link only, values set in 'trackExternalLinkClick' function should be used in push to dataLayer", () => {
+
+    document.body.innerHTML = `<a href="https://www.example.com" data-testid="external">External link</a>`
+
+    document.querySelector('[data-testid="external"]').click()
+
+    expect(global.dataLayer[0]).toEqual(
+      expect.objectContaining({
+        '0': 'event',
+        '1': 'External link',
+        '2': { event_category: 'External Link Clicked', event_label: 'https://www.example.com' }
+      })
+    )
+  })
+})
+
+describe("page events", () => {
+  it("if a page is a 403 page, values set in the 'errorPageEvent' function should be used in push to dataLayer", () => {
+    document.body.innerHTML = `
+      <h1>Page not authorised</h1>
+    `
+    global.dataLayer = []
+    const eventTracking = new EventTracking()
+    eventTracking.init()
+    
+    expect(global.dataLayer[0]).toEqual(
+      expect.objectContaining({
+        '0': 'event',
+        '1': '403',
+        '2': { event_category: 'Error' }
+      })
+    )
+  })
+
+  it("if a page is a 404 page, values set in the 'errorPageEvent' function should be used in push to dataLayer", () => {
+    document.body.innerHTML = `
+      <h1>Sorry an error occurred</h1>
+    `
+    global.dataLayer = []
+    const eventTracking = new EventTracking()
+    eventTracking.init()
+    
+    expect(global.dataLayer[0]).toEqual(
+      expect.objectContaining({
+        '0': 'event',
+        '1': '500',
+        '2': { event_category: 'Error' }
+      })
+    )
+  })
+  it("if a page is a 4500 page, values set in the 'errorPageEvent' function should be used in push to dataLayer", () => {
+    document.body.innerHTML = `
+      <h1>Page not found</h1>
+    `
+    global.dataLayer = []
+    const eventTracking = new EventTracking()
+    eventTracking.init()
+    
+    expect(global.dataLayer[0]).toEqual(
+      expect.objectContaining({
+        '0': 'event',
+        '1': '404',
+        '2': { event_category: 'Error' }
+      })
+    )
+  })
+})

--- a/src/frontend/javascript/init.js
+++ b/src/frontend/javascript/init.js
@@ -1,11 +1,13 @@
 import Tooltip from './tooltip';
 import Cookies from './cookie-functions'
-
+import EventTracking from './event-tracking'
 
 var cookies = new Cookies()
+var eventTracking = new EventTracking()
 
 if (cookies.hasConsentForAnalytics()) {
   cookies.initAnalytics()
+  eventTracking.init()
 }
 
 var $cookieBanner = document.querySelector('[data-module="cookie-banner"]')

--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -100,17 +100,38 @@ export function Header(props: IHeaderProperties): ReactElement {
               aria-label="Top Level Navigation"
             >
               <li className="govuk-header__navigation-item">
-                <a className="govuk-header__link" href="/support">
+                <a
+                  className="govuk-header__link" 
+                  href="/support"
+                  data-track-click="true"
+                  data-track-category="Navigation"
+                  data-track-action="Top Menu"
+                  data-track-label="Support"
+                >
                   Support
                 </a>
               </li>
               <li className="govuk-header__navigation-item">
-                <a className="govuk-header__link" href="/marketplace">
+                <a
+                  className="govuk-header__link"
+                  href="/marketplace"
+                  data-track-click="true"
+                  data-track-category="Navigation"
+                  data-track-action="Top Menu"
+                  data-track-label="Marketplace"
+                >
                   Marketplace
                 </a>
               </li>
               {props.authenticated ? <li className="govuk-header__navigation-item">
-                <a className="govuk-header__link" href="/">
+                <a
+                  className="govuk-header__link" 
+                  href="/"
+                  data-track-click="true"
+                  data-track-category="Navigation"
+                  data-track-action="Top Menu"
+                  data-track-label="Organisations"
+                >
                   Organisations
                 </a>
               </li> : undefined}
@@ -118,6 +139,10 @@ export function Header(props: IHeaderProperties): ReactElement {
                 <a
                   className="govuk-header__link"
                   href="https://docs.cloud.service.gov.uk"
+                  data-track-click="true"
+                  data-track-category="Navigation"
+                  data-track-action="Top Menu"
+                  data-track-label="Documentation"
                 >
                   Documentation
                 </a>
@@ -125,12 +150,25 @@ export function Header(props: IHeaderProperties): ReactElement {
               {props.isPlatformAdmin ? platformLink : undefined}
               {props.authenticated
                 ? <li className="govuk-header__navigation-item">
-                    <a className="govuk-header__link" href="/auth/logout">
+                    <a 
+                      className="govuk-header__link" 
+                      href="/auth/logout"
+                      data-track-click="true"
+                      data-track-category="Navigation"
+                      data-track-action="Top Menu"
+                      data-track-label="Sign out"
+                    >
                       Sign out
                     </a>
                   </li>
                 : <li className="govuk-header__navigation-item">
-                    <a className="govuk-header__link" href="/">
+                    <a 
+                      className="govuk-header__link" 
+                      href="/"
+                      data-track-click="true"
+                      data-track-category="Navigation"
+                      data-track-action="Top Menu"
+                      data-track-label="Sign in">
                       Sign In
                     </a>
                   </li>}
@@ -140,6 +178,10 @@ export function Header(props: IHeaderProperties): ReactElement {
                   title="Switch to a different region"
                   className={`govuk-header__link govuk-tag app-region-tag app-region-tag--${props.location.toLowerCase()}`}
                   aria-label={`Current region: ${props.location.toLowerCase()}. Switch to a different region.`}
+                  data-track-click="true"
+                  data-track-category="Navigation"
+                  data-track-action="Top Menu"
+                  data-track-label="Switch to a different region ?add region name?"
                 >
                   <span className="app-region-tag__text">Region:</span> {props.location}
                 </a>


### PR DESCRIPTION
What
----

To measure engagement for users that have accepted cookies we want to
record certain events with either specific labels for targeted elements
or more generic for larger groups .

This script introduces functions to send events for:

- targeted elements with data attributes
- external links to non *.cloud.service subdomains and email links
- error pages (403, 404, 500)

For targeted elements values for the event are read from the data
attributes.

For external links, values are partially set and partially read from
the target element.

For error pages, values are set.

This is an [adapted version of product page work](https://github.com/alphagov/paas-product-pages/pull/120)

How to review
-------------
- best to review commit by commit
- can test this with the Omnibug extension on https://admin.dev02.dev.cloudpipeline.digital for 
    top nav, external links, error page and billing page download and filter

Who can review
---------------

not @kr8n3r 
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
