### PR TITLE
removed Date() test

### DIFF
--- a/src/components/performance/controllers.test.tsx
+++ b/src/components/performance/controllers.test.tsx
@@ -270,19 +270,6 @@ describe(exportMaxPerMonthDataValues,() => {
  });
 });
 
-describe(formatDate,() => {
-  it('should by default output month name and year from given timestamp', () => {
-    const input = '2020-02-24T16:32:03.000Z';
-    const output = formatDate(new Date(input));
-    expect(output).toContain('February 2020');
-  });
-  it('should output date string based on provided format options from given timestamp', () => {
-    const input = '2020-02-24T16:32:03.000Z';
-    const output = formatDate(new Date(input),{ weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
-    expect(output).toContain('Monday, February 24, 2020');
-  });
-});
-
 describe(combineMetrics,() => {
   it('should combine two array of objects into one array with trial and billable values', () => {
     const input1 = {


### PR DESCRIPTION
What
----

We shouldn't test features of the language, right?

I'm removing this because the test actually is LOCALE-dependant, and fails on my en-GB machine.



How to review
-------------

test with `npm test`

Who can review
---------------

javascipt devs
