### PR TITLE
Make it clearer that event times are in UTC

### DIFF
--- a/src/components/events/views.tsx
+++ b/src/components/events/views.tsx
@@ -78,7 +78,7 @@ export function Event(props: IEventProperties): ReactElement {
   return (
     <dl className="govuk-summary-list">
       <EventSummaryItem title="Date">
-        {moment(props.event.updated_at).format(DATE_TIME)}
+        {moment(props.event.updated_at).format(DATE_TIME)} (UTC)
       </EventSummaryItem>
       <EventSummaryItem title="Actor">
         {props.actor?.email || props.event.actor.name || (
@@ -103,7 +103,7 @@ export function TargetedEvent(props: IEventProperties): ReactElement {
   return (
     <dl className="govuk-summary-list">
       <EventSummaryItem title="Date">
-        {moment(props.event.updated_at).format(DATE_TIME)}
+        {moment(props.event.updated_at).format(DATE_TIME)} (UTC)
       </EventSummaryItem>
       <EventSummaryItem title="Actor">
         {props.actor?.email || props.event.actor.name || (


### PR DESCRIPTION
What
----

Raised by the user, as they didn't know if it was BST or UTC.

While we say that events are it UTC, we display a humanly readable time that may look like BST.

### Before
![Screenshot 2021-05-11 at 09 11 28](https://user-images.githubusercontent.com/3758555/117782061-2fd06a80-b239-11eb-8f54-e6a46c6b35aa.png)


### After
![Screenshot 2021-05-11 at 09 11 06](https://user-images.githubusercontent.com/3758555/117782087-35c64b80-b239-11eb-9980-6a09cdd9582c.png)


How to review
-------------

- test locally on application and backing services event details page
- agree/disagree with the change

Who can review
---------------

no @kr8n3r 
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
