### PR TITLE
Drop IE8 support

### DIFF
--- a/src/layouts/govuk.screen.ie8.scss
+++ b/src/layouts/govuk.screen.ie8.scss
@@ -1,6 +1,0 @@
-// By setting $govuk-is-ie8 to true, we create a version of the stylesheet that
-// targets IE8 – e.g. conditionally including or excluding styles, and
-// rasterizing media queries.
-$govuk-is-ie8: true;
-
-@import "govuk.screen";

--- a/src/layouts/template.tsx
+++ b/src/layouts/template.tsx
@@ -4,7 +4,6 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { IViewContext } from '../components/app';
 import { Breadcrumbs, IBreadcrumbsItem } from '../components/breadcrumbs';
 
-import govukIE8Styles from './govuk.screen.ie8.scss';
 import govukStyles from './govuk.screen.scss';
 import {
   CookieBanner,
@@ -65,17 +64,7 @@ export class Template {
 
           <meta name="x-user-identity-origin" content="${this.ctx.origin || ''}" />
 
-          <!--[if !IE 8]><!-->
-            <link href="${govukStyles}" media="all" rel="stylesheet" />
-          <!--<![endif]-->
-
-          <!--[if IE 8]>
-            <link href="${govukIE8Styles}" media="all" rel="stylesheet" />
-          <![endif]-->
-
-          <!--[if lt IE 9]>
-            <script src="/html5-shiv/html5shiv.js"></script>
-          <![endif]-->
+          <link href="${govukStyles}" media="all" rel="stylesheet" />
 
           <meta property="og:image" content="${assetURL}/images/govuk-opengraph-image.png" />
         </head>


### PR DESCRIPTION
What
----

We have next to nothing number of IE8 users and we we're really full-in on supporting it.

This removes the separate IE8 stylesheet and references to html5 shiv (which we weren't serving anyway)

End result will be marginally worse experience for and IE8 user.

How to review
-------------

- run locally
- check page still loads fine in modern browsers

Who can review
---------------

anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
