### PR TITLE
Always format date given by prometheus

### DIFF
--- a/src/components/performance/controllers.tsx
+++ b/src/components/performance/controllers.tsx
@@ -10,7 +10,7 @@ import { IContext } from '../app';
 import { IScrapedData, period } from './scraper';
 import { MetricPage } from './views';
 
-export function formatDate(input:Date, options?: Record<string, unknown>): string {
+export function formatDate(input: Date, options?: Record<string, unknown>): string {
   const opts = typeof options === 'undefined' ? { month: 'long', year: 'numeric' } : options;
 
   return new Intl.DateTimeFormat('en-GB', opts).format(new Date(input));
@@ -29,7 +29,7 @@ function extractData(data: ReadonlyArray<IMetricSerie> | undefined): ReadonlyArr
 export function exportMaxPerMonthDataValues(data: IMetricSerie): ReadonlyArray<IMetric> {
   const metrics = data.metrics;
 
-return [...metrics.concat() // so that we con't modify the original array
+  return [...metrics.concat() // so that we con't modify the original array
     // 1. sort by value property so we get highest entry in each month to the highest index in array
     .sort((a, b) => b.value - a.value)
     // 2. remove any duplicates for given month, as we've already brought the needed values to the top of array

--- a/src/components/performance/scraper.ts
+++ b/src/components/performance/scraper.ts
@@ -13,7 +13,6 @@ export const period: Duration = { weeks: 1 };
 export const timeAgo = sub(new Date(), { years: 1 });
 
 const delay = async (ms: number): Promise<object> => await new Promise(resolve => setTimeout(resolve, ms));
-const durationToSeconds = (duration: Duration): number => millisecondsToSeconds(milliseconds(duration));
 
 interface IConfig {
   readonly pingdom: {
@@ -105,7 +104,7 @@ export async function scrape(cfg: IConfig, logger: Logger): Promise<IScrapedData
   logger.info('Obtaining organizations data...');
   const organizations = await prometheus.getSeries(
     queries.organizations,
-    durationToSeconds(period),
+    millisecondsToSeconds(milliseconds(period)),
     timeAgo,
     now,
   );
@@ -119,7 +118,7 @@ export async function scrape(cfg: IConfig, logger: Logger): Promise<IScrapedData
   logger.info('Obtaining applications data...');
   const applicationCount = await prometheus.getSeries(
     queries.applicationCount,
-    durationToSeconds(period),
+    millisecondsToSeconds(milliseconds(period)),
     timeAgo,
     now,
   );
@@ -133,7 +132,7 @@ export async function scrape(cfg: IConfig, logger: Logger): Promise<IScrapedData
   logger.info('Obtaining services data...');
   const serviceCount = await prometheus.getSeries(
     queries.serviceCount,
-    durationToSeconds(period),
+    millisecondsToSeconds(milliseconds(period)),
     timeAgo,
     now,
   );

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -1,4 +1,4 @@
-import { add, Duration, formatISO, sub } from 'date-fns';
+import { add, Duration, getUnixTime, sub } from 'date-fns';
 
 import roundDown from '../moment/round';
 
@@ -66,7 +66,7 @@ export function getGappyRandomData(): {
     ) {
       // do nothing - empty piece of the graph
     } else {
-      const timestamp = formatISO(add(startTime, { minutes: i }));
+      const timestamp = getUnixTime(add(startTime, { minutes: i }));
 
       let value = 0;
       if (values.length === 0) {
@@ -76,7 +76,7 @@ export function getGappyRandomData(): {
         value = value > 0 ? value : 0;
       }
 
-      timestamps.push(timestamp);
+      timestamps.push(`${timestamp}`);
       values.push(value);
     }
   }

--- a/src/lib/prom/prom.test.ts
+++ b/src/lib/prom/prom.test.ts
@@ -1,4 +1,4 @@
-import { sub } from 'date-fns';
+import { getUnixTime, sub } from 'date-fns';
 import nock from 'nock';
 import pino from 'pino';
 
@@ -101,6 +101,7 @@ describe('lib/prom test suite', () => {
   });
 
   it('should getSeries successfully', async () => {
+    const now = new Date();
     nockPrometheus.get(/api.v1.query_range\??/).reply(200, {
       data: {
         result: [
@@ -110,23 +111,19 @@ describe('lib/prom test suite', () => {
             },
             values: [
               [
-                (new Date())
-                  .getTime() / 1000,
+                getUnixTime(now),
                 `${Math.random() * 100}`,
               ],
               [
-                (new Date())
-                  .getTime() / 1000,
+                getUnixTime(now),
                 `${Math.random() * 100}`,
               ],
               [
-                (new Date())
-                  .getTime() / 1000,
+                getUnixTime(now),
                 `${Math.random() * 100}`,
               ],
               [
-                (new Date())
-                  .getTime() / 1000,
+                getUnixTime(now),
                 `${Math.random() * 100}`,
               ],
             ],
@@ -137,23 +134,19 @@ describe('lib/prom test suite', () => {
             },
             values: [
               [
-                (new Date())
-                  .getTime() / 1000,
+                getUnixTime(now),
                 `${Math.random() * 100}`,
               ],
               [
-                (new Date())
-                  .getTime() / 1000,
+                getUnixTime(now),
                 `${Math.random() * 100}`,
               ],
               [
-                (new Date())
-                  .getTime() / 1000,
+                getUnixTime(now),
                 `${Math.random() * 100}`,
               ],
               [
-                (new Date())
-                  .getTime() / 1000,
+                getUnixTime(now),
                 `${Math.random() * 100}`,
               ],
             ],
@@ -179,6 +172,8 @@ describe('lib/prom test suite', () => {
     expect(series).toBeDefined();
     expect(series!.length).toEqual(2);
     expect(series![0].metrics.length).toEqual(4);
+    expect(getUnixTime(series![0].metrics[0].date)).toEqual(getUnixTime(now));
+    expect(getUnixTime(series![0].metrics[1].date)).toEqual(getUnixTime(now));
   });
 
   it('should fail to getSeries when invalid query has been provided', async () => {

--- a/src/lib/prom/prom.ts
+++ b/src/lib/prom/prom.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosResponse } from 'axios';
+import { fromUnixTime } from 'date-fns';
 import { BaseLogger } from 'pino';
 
 import { intercept } from '../axios-logger/axios';
@@ -98,7 +99,7 @@ export default class PromClient {
       return {
         label: series.metric.instance,
         metrics: metrics.map(metric => {
-          const date = new Date(metric[0]);
+          const date = fromUnixTime(metric[0]);
           const value = parseFloat(metric[1] as string);
 
           return { date, value };


### PR DESCRIPTION
What
----

Prometheus is returning the date in various different formats. For
instance, once it comes back as ISO string, the other as a UNIX
timestamp. This is causing problems with `Date` object where as moment
has been magically figuring this out.

How to review
-------------

- Deploy to staging environment
- See if performance dashboard is now behaving

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
