### PR TITLE
Fix authentication cell markup on team members page

### DIFF
--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -714,9 +714,13 @@ export function OrganizationUsersPage(
                 <th className="govuk-table__header name" scope="col">
                   Email address
                 </th>
-                <th className="govuk-table__header authentication" scope="col">
-                  {props.privileged ? 'Authentication' : ''}
-                </th>
+                {props.privileged ? (
+                  <th className="govuk-table__header authentication" scope="col">
+                    Authentication
+                  </th>
+                ) : (
+                  <></>
+                )}
                 <th className="govuk-table__header is-org-manager" scope="col">
                   Org manager
                 </th>
@@ -749,25 +753,15 @@ export function OrganizationUsersPage(
                       props.users[guid].username
                     )}
                   </th>
-                  <td className="govuk-table__cell">
-                    {props.privileged ? (
-                      props.userOriginMapping[guid] === 'uaa' ? (
-                        <a
-                          href={props.linkTo('admin.organizations.users.edit', {
-                            organizationGUID: props.organizationGUID,
-                            userGUID: guid,
-                          })}
-                          className="govuk-link"
-                        >
-                          <span className="govuk-visually-hidden">Authentication method:</span> Password
-                        </a>
-                      ) : (
-                        capitalize(props.userOriginMapping[guid])
-                      )
-                    ) : (
-                      <NoTick />
-                    )}
-                  </td>
+                  {props.privileged ? (
+                    <td className="govuk-table__cell">
+                      <span className="govuk-visually-hidden">Authentication method:</span> {
+                        props.userOriginMapping[guid] === 'uaa' ? 'Password' : capitalize(props.userOriginMapping[guid])
+                      }
+                    </td>
+                  ) : (
+                    <></>
+                  )}
                   <td className="govuk-table__cell">
                     {props.users[guid].orgRoles.includes('org_manager') ? (
                       <Tick />


### PR DESCRIPTION
What
----

Previously, users with "password" authentication got a visually hidden
"Authentication method:" span and a confusing link (to the same place as
the "Email address" cell one column to the left). Users with "Google" or
"Admin-google" don't get the link, and also don't get the visually
hidden span (which is probably an a11y issue).

Users where `props.privileged` was falsey got a table with an empty
column heading ("" instead of "Authentication") containing a bunch of
<NoTick />s (which are visually hidden, but readable by screen readers).
This changes the logic to skip the entire column (both the heading and
the cells) if the user isn't privileged enough to see the
Authentication.


How to review
-------------

Run locally, check the markup on the team members page is better.

Who can review
---------------

PaaSians

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
