### PR TITLE
add permissions-policy to all express-served pages

### DIFF
--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -87,6 +87,12 @@ describe('app test suite', () => {
     );
   });
 
+  it('should server a null cohort permissions policy header', async () => {
+    const app = init(config);
+    const response = await request(app).get('/healthcheck');
+    expect(response.header['permissions-policy']).toEqual('interest-cohort=()');
+  });
+
   it('should redirect to oauth provider for auth', async () => {
     const app = init(config);
     const response = await request(app).get(

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -86,6 +86,11 @@ export interface IOIDCConfig {
 export default function(config: IAppConfig): express.Express {
   const app = express();
 
+  app.use((req, res, next) => {
+      res.append('Permissions-Policy', 'interest-cohort=()');
+      next();
+  });
+
   app.use(
     pinoMiddleware({
       logger: config.logger,


### PR DESCRIPTION

What
----
Added a zeroed-out permissions-policy header to all express-served pages (ie, all pages)

Why: To disable FLoC as per https://github.com/alphagov/govuk-rfcs/blob/main/rfc-142-add-interest-cohort-permssion-policy-header.md

How to review
-------------

Run the server locally and observe the new `permissions-policy` header being set.
If on chrome, observe `document.interestCohort()` to be `()`

Who can review
---------------

Any developer

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨