### PR TITLE
[#178944607] calculator: add aws-sqs-queue services

### DIFF
--- a/src/components/calculator/controllers.test.tsx
+++ b/src/components/calculator/controllers.test.tsx
@@ -85,6 +85,11 @@ describe('calculator test suite', () => {
             name: 'aws-s3-bucket default',
             plan_guid: 'f4d4b95a-f55e-4593-8d54-3364c25798c9',
           },
+          {
+            ...defaultPricingPlan,
+            name: 'aws-sqs-queue standard',
+            plan_guid: 'f4d4b95a-f55e-4593-8d54-3364c25798c9',
+          },
         ]),
       );
 
@@ -97,6 +102,7 @@ describe('calculator test suite', () => {
     expect(response.body).toMatch(/\bRedis\b/);
     expect(response.body).toMatch(/\bElasticsearch\b/);
     expect(response.body).toMatch(/\bAmazon S3\b/);
+    expect(response.body).toMatch(/\bAmazon SQS\b/);
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);

--- a/src/components/calculator/controllers.tsx
+++ b/src/components/calculator/controllers.tsx
@@ -1,5 +1,5 @@
 import { endOfMonth, format, startOfMonth } from 'date-fns';
-import { sum } from 'lodash';
+import { isMatch, sum } from 'lodash';
 import React from 'react';
 import * as uuid from 'uuid';
 
@@ -151,17 +151,19 @@ function toVersionedPricingPlans(plan: IPricingPlan): IVersionedPricingPlan {
 
 function safelistServices(p: IPricingPlan): boolean {
   const safelist = [
-    'app',
-    'postgres',
-    'mysql',
-    'redis',
-    'elasticsearch',
-    'aws-s3-bucket',
-    'aws-sqs-queue',
-    'influxdb',
+    {serviceName: 'app'},
+    {serviceName: 'postgres'},
+    {serviceName: 'mysql'},
+    {serviceName: 'redis'},
+    {serviceName: 'elasticsearch'},
+    {serviceName: 'aws-s3-bucket'},
+    {serviceName: 'influxdb'},
+    // both sqs queue types are priced the same and a meaningless plan
+    // selector is weird and ugly
+    {serviceName: 'aws-sqs-queue', planName: 'standard'},
   ];
 
-  return safelist.some(name => name === p.serviceName);
+  return safelist.some(query => isMatch(p, query));
 }
 
 function filterComposeIOServices(p: IPricingPlan): boolean {

--- a/src/components/calculator/controllers.tsx
+++ b/src/components/calculator/controllers.tsx
@@ -157,6 +157,7 @@ function safelistServices(p: IPricingPlan): boolean {
     'redis',
     'elasticsearch',
     'aws-s3-bucket',
+    'aws-sqs-queue',
     'influxdb',
   ];
 

--- a/src/components/calculator/views.tsx
+++ b/src/components/calculator/views.tsx
@@ -84,6 +84,7 @@ function niceServiceName(planName: string): string {
   const niceServiceNames: {readonly [key: string]: string} = {
     'app': 'Compute',
     'aws-s3-bucket': 'Amazon S3',
+    'aws-sqs-queue': 'Amazon SQS',
     'elasticsearch': 'Elasticsearch',
     'influxdb': 'InfluxDB',
     'mysql': 'MySQL',


### PR DESCRIPTION
What
----

Made calculator aware of SQS pricing.

One thing is that of course it insists on listing the two different variants of SQS (standard & fifo), though it has no effect on pricing. A little ugly, but how much do we care? Would probably take some hackery to omit plan selection for specific offerings.

<img width="1245" alt="Screenshot 2021-07-30 at 14 58 58" src="https://user-images.githubusercontent.com/807447/127667493-2901a1e4-3d4c-4bfb-afc7-a9b4803c6fa9.png">

How to review
-------------

You'll probably first have to deploy `paas-cf/ris-sqs-pricing-178944646` (https://github.com/alphagov/paas-cf/pull/2713) to a dev paas, then hack the create-cloudfoundry pipeline to use this branch for deployment and do a deploy of that.

Alternatively look @ dev01 before the day is out (2021-07-30).

Who can review
---------------

Anyone technically capable to try it or irresponsible enough to just trust me.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
