### PR TITLE
Update AWS-SDK packages

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm test
+      - name: Test - Unit
+        run: npm run test:unit
+
+      - name: Lint
+        run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "paas-admin",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-cloudwatch-node": "^0.1.0-preview.2",
-        "@aws-sdk/client-resource-groups-tagging-api-node": "0.1.0-preview.2",
+        "@aws-sdk/client-cloudwatch": "^3.31.0",
+        "@aws-sdk/client-resource-groups-tagging-api": "^3.31.0",
+        "@aws-sdk/types": "^3.29.0",
         "@babel/preset-env": "^7.15.6",
         "@babel/preset-react": "^7.14.5",
         "aws-sdk": "^2.989.0",
@@ -133,744 +135,1886 @@
         "npm": ">=7.x.x"
       }
     },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-0.1.0-preview.7.tgz",
-      "integrity": "sha512-UpAa0PQ4u1UdDYPU9ajO/vzfmSn3rTMjXQjlsd0Ue4oK/A2lffNN28+egMVuS+Ivs96pv1HAfA4t4tPw+U6wjA==",
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^1.11.1"
       }
     },
-    "node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-sdk/client-cloudwatch-node": {
-      "version": "0.1.0-preview.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-node/-/client-cloudwatch-node-0.1.0-preview.2.tgz",
-      "integrity": "sha512-DGr3hGdJbwwSDV7xx2c3GscsI+VQE/fyOTdgxdsrKbjKPzSL2eG9yQHy5xyiVRppJJVcLNZ2QFvTyaIhJUZ/lw==",
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.1.tgz",
+      "integrity": "sha512-nS4vdan97It6HcweV58WXtjPbPSc0JXd3sAwlw3Ou5Mc3WllSycAS32Tv2LRn8butNQoU9AE3jEQAOgiMdNC1Q==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "^0.1.0-preview.5",
-        "@aws-sdk/core-handler": "^0.1.0-preview.5",
-        "@aws-sdk/credential-provider-node": "^0.1.0-preview.6",
-        "@aws-sdk/hash-node": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-content-length": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-header-default": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-serializer": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-stack": "^0.1.0-preview.6",
-        "@aws-sdk/node-http-handler": "^0.1.0-preview.6",
-        "@aws-sdk/protocol-query": "^0.1.0-preview.6",
-        "@aws-sdk/query-builder": "^0.1.0-preview.5",
-        "@aws-sdk/query-error-unmarshaller": "^0.1.0-preview.6",
-        "@aws-sdk/region-provider": "^0.1.0-preview.5",
-        "@aws-sdk/retry-middleware": "^0.1.0-preview.5",
-        "@aws-sdk/signature-v4": "^0.1.0-preview.6",
-        "@aws-sdk/signing-middleware": "^0.1.0-preview.6",
-        "@aws-sdk/stream-collector-node": "^0.1.0-preview.5",
-        "@aws-sdk/types": "^0.1.0-preview.5",
-        "@aws-sdk/url-parser-node": "^0.1.0-preview.5",
-        "@aws-sdk/util-base64-node": "^0.1.0-preview.3",
-        "@aws-sdk/util-body-length-node": "^0.1.0-preview.4",
-        "@aws-sdk/util-user-agent-node": "^0.1.0-preview.6",
-        "@aws-sdk/util-utf8-node": "^0.1.0-preview.3",
-        "@aws-sdk/xml-body-parser": "^0.1.0-preview.6",
-        "tslib": "^1.8.0"
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
       }
     },
-    "node_modules/@aws-sdk/client-cloudwatch-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-sdk/client-resource-groups-tagging-api-node": {
-      "version": "0.1.0-preview.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-resource-groups-tagging-api-node/-/client-resource-groups-tagging-api-node-0.1.0-preview.2.tgz",
-      "integrity": "sha512-ZRZ6bOfuCoSzy+iQ3GmD7ukyIMKdN6k0p8HIMyVvnaZHsV/GBEdzAYucGojAGLYIBtb9IVVCA5i9ADPxRrSqiQ==",
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "^0.1.0-preview.5",
-        "@aws-sdk/core-handler": "^0.1.0-preview.5",
-        "@aws-sdk/credential-provider-node": "^0.1.0-preview.6",
-        "@aws-sdk/hash-node": "^0.1.0-preview.5",
-        "@aws-sdk/json-builder": "^0.1.0-preview.5",
-        "@aws-sdk/json-error-unmarshaller": "^0.1.0-preview.6",
-        "@aws-sdk/json-parser": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-content-length": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-header-default": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-serializer": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-stack": "^0.1.0-preview.6",
-        "@aws-sdk/node-http-handler": "^0.1.0-preview.6",
-        "@aws-sdk/protocol-json-rpc": "^0.1.0-preview.6",
-        "@aws-sdk/region-provider": "^0.1.0-preview.5",
-        "@aws-sdk/retry-middleware": "^0.1.0-preview.5",
-        "@aws-sdk/signature-v4": "^0.1.0-preview.6",
-        "@aws-sdk/signing-middleware": "^0.1.0-preview.6",
-        "@aws-sdk/stream-collector-node": "^0.1.0-preview.5",
-        "@aws-sdk/types": "^0.1.0-preview.5",
-        "@aws-sdk/url-parser-node": "^0.1.0-preview.5",
-        "@aws-sdk/util-base64-node": "^0.1.0-preview.3",
-        "@aws-sdk/util-body-length-node": "^0.1.0-preview.4",
-        "@aws-sdk/util-user-agent-node": "^0.1.0-preview.6",
-        "@aws-sdk/util-utf8-node": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
       }
     },
-    "node_modules/@aws-sdk/client-resource-groups-tagging-api-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-0.1.0-preview.7.tgz",
-      "integrity": "sha512-clP/NFkGyIJzCPPZ9y9vc4rQD2O8euuEVtYDlHNPfe+791uo43I1/qhw20v31mPY1OH0dScf5Jn/n4Ed9YO1VA==",
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^1.11.1"
       }
     },
-    "node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-sdk/core-handler": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core-handler/-/core-handler-0.1.0-preview.7.tgz",
-      "integrity": "sha512-F+BAYmcPGbbK2w6Y9i4RgK9f8ojUuQKoZuFCxiYoujLGoak/p81gACTz3dQyV9/NiY46EvmdpyaGQeLtpfuriQ==",
+    "node_modules/@aws-sdk/client-cloudwatch": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.31.0.tgz",
+      "integrity": "sha512-8KLOqJiFSiDQsZYoPPYjmMn1oSRirEGwcKJXS1Az0wgHjeuvvVuuAlMnVy3URjyz+qs+FQCKUQWeURz8ZjYcfg==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/core-handler/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-0.1.0-preview.8.tgz",
-      "integrity": "sha512-wW2XRalzx8jAIsVSdOM4cDP3hgbvPy6UJhQwpn9N3kfb22G5FPEry6hlJKHAVzQ15tkTNd0C6SyRlXgC5zEzmA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-0.1.0-preview.7.tgz",
-      "integrity": "sha512-FgrXEUf9/6VL+YWwGGpzVC7+hHcb43+kUtez/HoVq7duCi8OpnCAdLuGFoJdWhi2K76Qf1i3z2+fUYcSQnjcoQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-0.1.0-preview.7.tgz",
-      "integrity": "sha512-iIVGZonHwy08RJgW9AZURKAbRTcBtwZw9wWSkO1YgtFVKYHH81E+C/k3o9ljCD9TK+XfvB2dv5alPkS71EufIQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "0.1.0-preview.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-0.1.0-preview.9.tgz",
-      "integrity": "sha512-l7AioIfRpNjgEe+8ikWUEFV8Z5eDMQTDl6BEG3y2O9K+rksSmYvIAkraOJjJmHPi/nTKgCXrWzoBpasYahuSvA==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^0.1.0-preview.8",
-        "@aws-sdk/credential-provider-imds": "^0.1.0-preview.7",
-        "@aws-sdk/credential-provider-ini": "^0.1.0-preview.7",
-        "@aws-sdk/credential-provider-process": "^0.1.0-preview.5",
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.31.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/credential-provider-node": "3.31.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.31.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "@aws-sdk/util-waiter": "3.29.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
       },
       "engines": {
-        "node": ">=8.10"
+        "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "0.1.0-preview.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-0.1.0-preview.5.tgz",
-      "integrity": "sha512-OIBmuaul/aF3w3oCc1zIw+jE5tlhacrhCD/LXf0DornF8Bfp4oaYA5qJ4Lttu/Q25s2qW5+YEuFlDsnqpIQUyw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+      "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
       "dependencies": {
-        "@aws-sdk/credential-provider-ini": "^0.1.0-preview.7",
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-0.1.0-preview.8.tgz",
-      "integrity": "sha512-tYBKE5ggAfw7oCLj3/jVJomruUMXhFOL+yH7xnKbgEjCi2m/jsSClCwjUbco2d5eFeC75t74RsFuyCREm9o+nw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+      "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/hash-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-0.1.0-preview.3.tgz",
-      "integrity": "sha512-8SM7kBGkwH6JCKA6K1w4Jrj+EABFOPQkbPvwaf6BILYiUMUbgJvjOPjNQE2MrvRxJz50WAcZDHnlwhstuwIRnw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.29.0.tgz",
+      "integrity": "sha512-FUhdZODjkUeTFNfH7EnqN9piQwBR1gg+8NUJt6Rn7G4rj5lN2n2ryAatowIlzIB+/oWDvpPj+yMIE+XGjQrMhg==",
       "dependencies": {
-        "tslib": "^1.8.0"
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/is-iterable": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-iterable/-/is-iterable-0.1.0-preview.3.tgz",
-      "integrity": "sha512-dmqXKd7BlAGAaOz1dvmBw5MeOy/94LOxIRv4i8I76JPyTJsxFKjzJIHeRMnQ/5WJ3/POhmb6ZjBW/GwS/upaFw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.29.0.tgz",
+      "integrity": "sha512-sjyJrJoLhP2ekx+Z3m5g+/YIWYtuKII9eXuTTwRhzBKTpqv0WQm1ilISdNcz691JueF5jHQs4bP6FWk55RUWEg==",
       "dependencies": {
-        "tslib": "^1.8.0"
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/is-iterable/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/json-builder": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/json-builder/-/json-builder-0.1.0-preview.7.tgz",
-      "integrity": "sha512-gGrViVpR688e/3zQEXi7xb7/q4Nrz5w9DclJi6f32OHBphDkpv1SpHvf2WgA0949daU4QVKkyh0F6K2NygZtgg==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.31.0.tgz",
+      "integrity": "sha512-t95Gix2fWLIxrM2c2QZfRgJ1aCY1zGSlhb1JBlzPwxVRay7iUKa9U2dPoPhbOTsD1abQMjE4AnpDt9Bj+AXgyA==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/is-iterable": "^0.1.0-preview.3",
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/credential-provider-env": "3.29.0",
+        "@aws-sdk/credential-provider-imds": "3.29.0",
+        "@aws-sdk/credential-provider-sso": "3.31.0",
+        "@aws-sdk/credential-provider-web-identity": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/json-builder/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/json-error-unmarshaller": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/json-error-unmarshaller/-/json-error-unmarshaller-0.1.0-preview.8.tgz",
-      "integrity": "sha512-yCua3FUxKIahjDugSdQMj8g+DNT+R5gViL2CYZ05kXaUla+Qml8UDV5bPr/z21FM91Oe2d532eORXixWnWCVOQ==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.31.0.tgz",
+      "integrity": "sha512-T5309Q/MPHmaKYX0gSo6dv8w1ll4wsXvAUDXFC3MMdL/WYBfYvJa9H5nB9D9bL0xmtsm9e3WtfAcvEkN8Qz1xg==",
       "dependencies": {
-        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7"
+        "@aws-sdk/credential-provider-env": "3.29.0",
+        "@aws-sdk/credential-provider-imds": "3.29.0",
+        "@aws-sdk/credential-provider-ini": "3.31.0",
+        "@aws-sdk/credential-provider-process": "3.29.0",
+        "@aws-sdk/credential-provider-sso": "3.31.0",
+        "@aws-sdk/credential-provider-web-identity": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/json-parser": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/json-parser/-/json-parser-0.1.0-preview.7.tgz",
-      "integrity": "sha512-EOcBUct4jkkUky+h3nw+jRo/eSREUFgqr0k9Cqcqsf6rSHN7+TCXT9tyo8CLpvDUPsbJj+Wmoylce04wU5HQkQ==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.29.0.tgz",
+      "integrity": "sha512-1dMq84uGh3zcu+/bGohibWYMSxcrjwaIAc4dBU/3+rkNzPPdRA83hzYS34EizQ61JQHnM3z/xX9SLMeaNRKaSA==",
       "dependencies": {
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/json-parser/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-0.1.0-preview.7.tgz",
-      "integrity": "sha512-6ZI+dY8VgWmKL48tBtFGFgllwdhKgqNztscLtYPmHl38zrz4sITJnyGwbYDGLW+xLIGDOQhyFd/6kWTqT9QyKQ==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/hash-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+      "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/middleware-header-default": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-0.1.0-preview.7.tgz",
-      "integrity": "sha512-hf7+YMiPnyzRKzmcZZ5v2NKkC6CKgo8nnckJ1A1OlvWYGq3hLMF1gKDMzdkEFjWJmDWv6AVNyHjw5qe4AV8LVA==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+      "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-header-default/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/middleware-serializer": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serializer/-/middleware-serializer-0.1.0-preview.7.tgz",
-      "integrity": "sha512-mc5xBnrdDM9k3a78cbTSw+VWTadpDQQBObSuAy4fCxrkPZa+APqRY+y9MMDQ0uWI80e6Ab1pt9wTx1/OM1uMWQ==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+      "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-serializer/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-0.1.0-preview.8.tgz",
-      "integrity": "sha512-dlcq80vQe5buIVlAyPjJE0uL21IPfr04j5catPIfQ9rBm4809pib7vJoUkjNrfCk+RTeeVgynVdSdUaxlF5oWw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+      "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-0.1.0-preview.8.tgz",
-      "integrity": "sha512-D3hISgch64L2rG8RQDi361ywoSgsyH/5Yj4ZF05ZCo8UZ8TjU1CtiLPKy1is0XLqojhLlDAQ65lNna44xoArcw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+      "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "^0.1.0-preview.7",
-        "@aws-sdk/querystring-builder": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/abort-controller": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.7.tgz",
-      "integrity": "sha512-8yKkR78XC3fvdd+ePohfLuZHKBL7e3k+t82JL775phiXO94WHiz/hlvm6tGhNz5zKzz72yLrJPCyoQAZLrxrTg==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/property-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/property-provider/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/protocol-json-rpc": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-json-rpc/-/protocol-json-rpc-0.1.0-preview.8.tgz",
-      "integrity": "sha512-HF7g/xE/mGLzaYqO5tDFqxFvHS4vbuLAmRsWnUKsNBzg+G9+r6XK+4+PrUKwEJT69lNXezUetjwuemqnycsStA==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+      "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/protocol-json-rpc/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/protocol-query": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-query/-/protocol-query-0.1.0-preview.8.tgz",
-      "integrity": "sha512-O/y5XB1n9BoKYhxjN29cRvCAOXbrh3AhcdrsefcusWt5zv718TtLnTAPIpgfiCdAiCtB1Wywrmty6HgheuwY/A==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+      "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@types/node": "^10.0.0",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/protocol-query/node_modules/@types/node": {
-      "version": "10.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.2.tgz",
-      "integrity": "sha512-sAh60KDol+MpwOr1RTK0+HgBEYejKsxdpmrOS1Wts5bI03dLzq8F7T0sRXDKeaEK8iWDlGfdzxrzg6vx/c5pNA=="
-    },
-    "node_modules/@aws-sdk/protocol-query/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/protocol-timestamp": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-timestamp/-/protocol-timestamp-0.1.0-preview.7.tgz",
-      "integrity": "sha512-ObO202v456/S6Ckhlu844KBXN9toFTPt8zzrJpESzntVXIaidDECetd120/xToycYmICinvAYH9o1E2l6VlCRQ==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+      "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-hex-encoding": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/protocol-timestamp/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/query-builder": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/query-builder/-/query-builder-0.1.0-preview.7.tgz",
-      "integrity": "sha512-dKPHM2I+k3vQTJxL3b7vmi5qOXrNnbJzHAY+d0SHLinFM1CgSdQaAWIjO5lICkktiX65M6x7xCjVZbXwo8pfaw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+      "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/is-iterable": "^0.1.0-preview.3",
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/query-builder/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/query-error-unmarshaller": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/query-error-unmarshaller/-/query-error-unmarshaller-0.1.0-preview.8.tgz",
-      "integrity": "sha512-41lNT9delFhOss5H3eoi/2wYLYFuVqLXutRb5ZM5VvdhE4ZG+L8oE8HM0LSwQBttQFHaZcjdx3x3n9EVatSuCw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+      "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
       "dependencies": {
-        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/query-error-unmarshaller/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-0.1.0-preview.7.tgz",
-      "integrity": "sha512-U2d9CYTwnF4/Qc8XXFmCdRzcApTmwEXLyHUcjK2/GaOHKkHDAeIC94+cuP+H3nDjCjb3TdKV2xrl/wzuP0YBrg==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+      "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-uri-escape": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-0.1.0-preview.7.tgz",
-      "integrity": "sha512-r72E/wZYrhTXTK950Ld/L2Loso/HDqExQkIuCn1Pu8Rx0+uC3Y8fQTx+JZd5M5kOniCpGKdHWGc7y/bH/tjH4A==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+      "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/region-provider": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-provider/-/region-provider-0.1.0-preview.7.tgz",
-      "integrity": "sha512-n+LeuQYPYbCyfCboz9mmYqcPPKdmdd60KPbPeRqSdJYr9QZz9hWU962oCOl5EtLYIsUzy7Fm33APv6toEcAPVw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-provider/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/response-metadata-extractor": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/response-metadata-extractor/-/response-metadata-extractor-0.1.0-preview.8.tgz",
-      "integrity": "sha512-c5aJGYDiEwWqYpsROCqrmR60d0yeVdvRtzMptcpCI95BvIizS3hTc+PfuOq3Gcz7L+EQysbzQyqZutCJ/zLbew==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+      "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/response-metadata-extractor/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/retry-middleware": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/retry-middleware/-/retry-middleware-0.1.0-preview.7.tgz",
-      "integrity": "sha512-ULiq+dffOPurjyHm95PYWi1Cy27LQg9jPwLz5tiL7oIla/j9b5bcclZE3n0RtqbHDUvWJL5kxmYw0Kjrggr5iw==",
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+      "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
       "dependencies": {
-        "@aws-sdk/service-error-classification": "^0.1.0-preview.3",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/retry-middleware/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-0.1.0-preview.3.tgz",
-      "integrity": "sha512-3TXwADJL+HGOWyqdwx+pOdwr8L8LGbdxwHR0D05PP3skY+TP34F3ye2DJlyCll4S9vYzf9GlSbwJWviN9Sujrw=="
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-0.1.0-preview.3.tgz",
-      "integrity": "sha512-1wuV2YpZm+sW4AZa7CBD3A3b7+vSHX0DWBgGaENYdqC+MUEl6lD57ZOUGLryPq5xv/tQfy8BC7QT+qDNHElcuw==",
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-resource-groups-tagging-api/-/client-resource-groups-tagging-api-3.31.0.tgz",
+      "integrity": "sha512-BZb6iJby+Cl5cJTzZy7y0tZ6IImdFdCJLG7DSbjcA4/4OsBHJVNY9+q/kFO5E2HXX/fegoqwuPkQLudIjujH8A==",
       "dependencies": {
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.31.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/credential-provider-node": "3.31.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.31.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "0.1.0-preview.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-0.1.0-preview.9.tgz",
-      "integrity": "sha512-772F+4Z3VHMQUIpdXmcg4Ar6ATiDQ+tLXdUQX/jDvkXbQWXURjZLLL6X1ghFSlXKmOR0fRxmYZL0fG/M9PwssQ==",
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+      "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-hex-encoding": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/signing-middleware": {
-      "version": "0.1.0-preview.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signing-middleware/-/signing-middleware-0.1.0-preview.9.tgz",
-      "integrity": "sha512-XXrs0h5YTLgkviotIQSwYjAf0aTPKCFYPA0vYubTP1EY7fUGI3hLlFttaUh5/77h8b3RNYx/QFcRXodY5GAxWg==",
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+      "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "^0.1.0-preview.9",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/signing-middleware/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/stream-collector-node": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/stream-collector-node/-/stream-collector-node-0.1.0-preview.8.tgz",
-      "integrity": "sha512-p8cpGYqUy0pgOsephImE4yar3CJqhuVgPqhegRQXXYor3ZPkGloPymNys/1FmVb4RbzLrQ8WmpM+Fd0dUIu3PA==",
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.29.0.tgz",
+      "integrity": "sha512-FUhdZODjkUeTFNfH7EnqN9piQwBR1gg+8NUJt6Rn7G4rj5lN2n2ryAatowIlzIB+/oWDvpPj+yMIE+XGjQrMhg==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/stream-collector-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.29.0.tgz",
+      "integrity": "sha512-sjyJrJoLhP2ekx+Z3m5g+/YIWYtuKII9eXuTTwRhzBKTpqv0WQm1ilISdNcz691JueF5jHQs4bP6FWk55RUWEg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.31.0.tgz",
+      "integrity": "sha512-t95Gix2fWLIxrM2c2QZfRgJ1aCY1zGSlhb1JBlzPwxVRay7iUKa9U2dPoPhbOTsD1abQMjE4AnpDt9Bj+AXgyA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.29.0",
+        "@aws-sdk/credential-provider-imds": "3.29.0",
+        "@aws-sdk/credential-provider-sso": "3.31.0",
+        "@aws-sdk/credential-provider-web-identity": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.31.0.tgz",
+      "integrity": "sha512-T5309Q/MPHmaKYX0gSo6dv8w1ll4wsXvAUDXFC3MMdL/WYBfYvJa9H5nB9D9bL0xmtsm9e3WtfAcvEkN8Qz1xg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.29.0",
+        "@aws-sdk/credential-provider-imds": "3.29.0",
+        "@aws-sdk/credential-provider-ini": "3.31.0",
+        "@aws-sdk/credential-provider-process": "3.29.0",
+        "@aws-sdk/credential-provider-sso": "3.31.0",
+        "@aws-sdk/credential-provider-web-identity": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.29.0.tgz",
+      "integrity": "sha512-1dMq84uGh3zcu+/bGohibWYMSxcrjwaIAc4dBU/3+rkNzPPdRA83hzYS34EizQ61JQHnM3z/xX9SLMeaNRKaSA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/hash-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+      "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+      "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+      "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+      "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+      "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/property-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+      "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+      "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+      "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-hex-encoding": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+      "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+      "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+      "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+      "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+      "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-resource-groups-tagging-api/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+      "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.31.0.tgz",
+      "integrity": "sha512-fbquWlOS8+uotT2aZexK/3g85NYt2T5LpfWnk9mPV5HWfoevqTz9kwsZEW4DTnW9zibRl89vwXKolNpyszuZnw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.31.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+      "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+      "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/hash-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+      "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+      "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+      "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+      "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+      "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+      "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+      "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-hex-encoding": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+      "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+      "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+      "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+      "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+      "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+      "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.31.0.tgz",
+      "integrity": "sha512-XL8l88iUHPxfByFPp9a9eZV6Shb9QijHM+aGJPFU5zYvX3ruclfuBIs/3gLgqeX8rsmjt8AfeICxaP4BwJcaZA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/credential-provider-node": "3.31.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-sdk-sts": "3.30.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.31.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+      "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+      "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.29.0.tgz",
+      "integrity": "sha512-FUhdZODjkUeTFNfH7EnqN9piQwBR1gg+8NUJt6Rn7G4rj5lN2n2ryAatowIlzIB+/oWDvpPj+yMIE+XGjQrMhg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.29.0.tgz",
+      "integrity": "sha512-sjyJrJoLhP2ekx+Z3m5g+/YIWYtuKII9eXuTTwRhzBKTpqv0WQm1ilISdNcz691JueF5jHQs4bP6FWk55RUWEg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.31.0.tgz",
+      "integrity": "sha512-t95Gix2fWLIxrM2c2QZfRgJ1aCY1zGSlhb1JBlzPwxVRay7iUKa9U2dPoPhbOTsD1abQMjE4AnpDt9Bj+AXgyA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.29.0",
+        "@aws-sdk/credential-provider-imds": "3.29.0",
+        "@aws-sdk/credential-provider-sso": "3.31.0",
+        "@aws-sdk/credential-provider-web-identity": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.31.0.tgz",
+      "integrity": "sha512-T5309Q/MPHmaKYX0gSo6dv8w1ll4wsXvAUDXFC3MMdL/WYBfYvJa9H5nB9D9bL0xmtsm9e3WtfAcvEkN8Qz1xg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.29.0",
+        "@aws-sdk/credential-provider-imds": "3.29.0",
+        "@aws-sdk/credential-provider-ini": "3.31.0",
+        "@aws-sdk/credential-provider-process": "3.29.0",
+        "@aws-sdk/credential-provider-sso": "3.31.0",
+        "@aws-sdk/credential-provider-web-identity": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.29.0.tgz",
+      "integrity": "sha512-1dMq84uGh3zcu+/bGohibWYMSxcrjwaIAc4dBU/3+rkNzPPdRA83hzYS34EizQ61JQHnM3z/xX9SLMeaNRKaSA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/hash-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+      "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+      "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+      "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+      "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+      "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/property-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+      "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+      "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+      "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-hex-encoding": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+      "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+      "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+      "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+      "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+      "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+      "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.31.0.tgz",
+      "integrity": "sha512-x+xQvq8AFt+V1EpwRWa3Obsd1w2L7pQyP/P6O9Q5Enq6OwmdrM+i51jMD58QMRz4h+Ys5eaLLfi0wE0AjrUbng==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.31.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/property-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+      "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.29.0.tgz",
+      "integrity": "sha512-TwICG9y/iw08urlCymroQfRRJY++4JZwdhR0/2ycU+/Cgac6u4MfZsB1qD+u9+Q39/TqSz6QwtNhKLNdf0N23A==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/property-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.29.0.tgz",
+      "integrity": "sha512-rx+YlHFYzgGsCZMEvJBUdRsqfMGW4RY6J3USQvz63a32jVlMC3Kw9xINaXGhCEmOlUlzdeeIMQOZW5VxavLnjQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+      "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.29.0.tgz",
+      "integrity": "sha512-0TyZZbPs5SWCF2tT1DXccK5SUx7/bDJCVojgBuW3QRJn9ta3US/u5l7w8k6jwWFU3CQhLAWuG0TD7FhATiM2HQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.29.0.tgz",
+      "integrity": "sha512-aBifr86Owrhvy29cvZD17JzdoTtKMxzdjCkMA7ckNP+9Lg7kLI/6ws1yZ6BJlmcOnKxtNSnkvunGmJy8BU8EWQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.29.0.tgz",
+      "integrity": "sha512-0rLvuTvfaMWNb7+FApXAH0111FEp/AfG3fO7QkyVrXmHlTrNIJozilhkd0FwEMcQqqM9UK5lPLXwloH9Rkp9vw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.29.0.tgz",
+      "integrity": "sha512-yRQ48UIGPmK3/jWMJ2LC4trltFevMDEXyvtT6knwDnwXxmuwv7K6udk6TnGaUU5TlLVI1XdRQHaZY7xZH1KbGw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/service-error-classification": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.29.0.tgz",
+      "integrity": "sha512-VqOjXXTLTGbifzg3Fg2g/Ac6W3uzC3llPZjm/b0goM17KLWMGU7JKiem2l+CFyN4sxkver7InNlIUJCJAPB6+Q==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.30.0.tgz",
+      "integrity": "sha512-TZQQ0LA/rjYNgV+DbU0KvyHZaNhihrWf4IeJeKoez1vpvQmU58G5zAm0+rVHbzazJaOQuHYKKdPttOPxl/JAAg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+      "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/property-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+      "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-hex-encoding": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+      "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.29.0.tgz",
+      "integrity": "sha512-jN6zuaXg3k9HiWJZjBROiVJEdFaZrMikhyVdqYTT3hR+i08M/9UgVuX84HP/dALChZazOn9MPhvPWGvxrMOr9A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.30.0.tgz",
+      "integrity": "sha512-T/zGCijEGODmpbS/HlwnxT0Bn69FhZpBrVAjfofLUFzHteJ5Ab2q7AEt1dOdi3GrtTGStdwbfiZVeTxMKIjaTw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+      "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/property-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+      "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-hex-encoding": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+      "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.29.0.tgz",
+      "integrity": "sha512-AVbn9QEbqBgScaD3cxLv7/yi9Up10vYKy/AWIwgTrW0LxOuy9+Za2hdk5eZRP/QpqS/Ibz2/CqcmK1GQ/03kmg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.29.0.tgz",
+      "integrity": "sha512-ANRnPz4IT4FiSAc+9p0HqGSjL+cdzB2E68BFmbbGin0fZwhflX1BksjuUEibw8Emf8jvhvbUxdtAIUWctTYxOA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/property-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+      "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.29.0.tgz",
+      "integrity": "sha512-OIeJ7ukfgGkaIL0/NNM5sxIlfxtOqQN+KoaQ89YeLBlJPVoKnptAw+eWjjLwxLs+r/SbyZHXbBawP+sbzq0mSQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.31.0.tgz",
+      "integrity": "sha512-QZHOMM6npFyDEW8wrp8rLs+YGZIPRfuItlWHm6Upejp6a7s1ksb/1c44vNeqwnAeUJrdXfOX9QFkbh1+gZF21A==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+      "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-0.1.0-preview.7.tgz",
-      "integrity": "sha512-gpyU8N9XEs8diE4uW9B6/hjKDrB/c4a1GF4ICwkaGYpXrbJy9QLrEU8Hk4rC6P1l++YYyJKMl7RjMmTyBtNOzw=="
-    },
-    "node_modules/@aws-sdk/url-parser-node": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-node/-/url-parser-node-0.1.0-preview.8.tgz",
-      "integrity": "sha512-h8YwL+mLTBPNzryREkLChhtRSdz70tOR9y/UB6PATGKoJbMUFoTsDY1jbJ4WWBfdKjphZy9xVWTyxoCkP07tQQ==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.29.0.tgz",
+      "integrity": "sha512-8ilWQU5ZTdiRfblmmjl38+6JZKKM8EqA5Sbn8djgDLShCLeVJ2TsL2guzNi+WHcL7BHdv1pI/NNmTcgRUo6yOw==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/url-parser-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/util-base64-node": {
-      "version": "0.1.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-0.1.0-preview.4.tgz",
-      "integrity": "sha512-L9O3lMWB7y2xVIgg/nSJ7xZLVFmxMCk1maaup3CoL5USLqB7n7ngpf/WAH2LyhaGo8Og8TrAKt4BizpxbZU7wg==",
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.29.0.tgz",
+      "integrity": "sha512-385f+g4xeRym2S4bzF+Nc0MB8addAlCSb5hIUJu1JKH6FwFLrNRuixeaelGLyWr77xv25P0ruyXQAFf2ISxzKw==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/querystring-parser": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       }
     },
-    "node_modules/@aws-sdk/util-base64-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "0.1.0-preview.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-0.1.0-preview.5.tgz",
-      "integrity": "sha512-ZmqB7E/RizTe8ajxLyXdshoyzQg47CAkbnCK7yRE4A9N7XMEUgzyFVXuKT08DmbAwYSYWI5jaUwm3jpMKqG+bw==",
+    "node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.29.0.tgz",
+      "integrity": "sha512-v22PBXafAHw+wMaSGbq4B9wEsSYV2e0nZgGHZBNML3HPDiAYJqsQHiYEbiz8nzkmoayU0wrVFZ/XfKNXXcXGbw==",
       "dependencies": {
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-0.1.0-preview.3.tgz",
-      "integrity": "sha512-n78cUmI1SbluJgTgyqp24GgNQ3A5NUGB4rwRAoID7k7JpsiNJUWTXkijl3hxfNov2sEjMWvdQIGvAF6F/Q2mfw==",
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.29.0.tgz",
+      "integrity": "sha512-yMgn5vZ7laVO/497iPDjTdmia3sDdFBDq6k42EZxVTpkUcd8JS2nWJ+9ePuIMwqOgPjhhkOOXiidrbZaUQ+L6Q==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
       }
     },
-    "node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/util-error-constructor": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-error-constructor/-/util-error-constructor-0.1.0-preview.7.tgz",
-      "integrity": "sha512-sb8gruiOadl0YXG2yn0EMBkB/Oy/7y4mt8Wfl7G3crvWXcHtD7flbW7wjbFiMcQU91vi5sTaZ56hwvDA9lu0ug==",
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.29.0.tgz",
+      "integrity": "sha512-cKSwlDlZkcxuhSdoiq1TxleaBvveEgKA2Yo4TYP4DKVPHZuYZtbFv8r1driml1SaIKXg4GQpe+pJit3mxDRxAg==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
       }
     },
-    "node_modules/@aws-sdk/util-error-constructor/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-0.1.0-preview.3.tgz",
-      "integrity": "sha512-X/Qq5e2H4/EQ0WEwWUiSxGbFARk7IKZpa+E4pzQm49sxS2omVsvuphcr4yYJq4SZKEtuB2w2nHMr7NmGlWt4Xg==",
+    "node_modules/@aws-sdk/util-credentials": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.29.0.tgz",
+      "integrity": "sha512-xCWQizP5d6SwbwB2HmxpDqu0WYY7/E7pNrZ+7tSMrJxZlT8Zsd+lFaO23JVFMEBqjjBnpLBr+XkNZgOpD1BYwA==",
       "dependencies": {
-        "tslib": "^1.8.0"
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-0.1.0-preview.3.tgz",
-      "integrity": "sha512-axArIOq8+2PKjY9Fz+LKfCY127rjWQD50F1DAhCC0BV3mrG0OlhcQ8uKaNfMXVrveTqT+QYvrpTsrziHYjjTQw==",
+    "node_modules/@aws-sdk/util-credentials/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+      "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
       "dependencies": {
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "0.1.0-preview.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-0.1.0-preview.9.tgz",
-      "integrity": "sha512-V/1n0KAFvAIsguDXMJ9zvbJmv3j5dyOhjHKf6nhWYBR7hLYGdKA5HlZmQsoRCJf3B3whl6z1HSkmtTPOtY9Hlg==",
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.29.0.tgz",
+      "integrity": "sha512-gvcbl9UdTOvuCCzgbtTTsKnL1l/cnT/CFl0f6ZCQ6qubUTRCuL/aK8DvgWa1n9p/ddCiVKPLmHu/L1xtX4gc0A==",
       "dependencies": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "0.1.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-0.1.0-preview.4.tgz",
-      "integrity": "sha512-FxIWpC4LdKiJgJgiaLWMdZY/DbreSIRgVGO9cOlV5fI59KdN+2Aqb6sLnlp7yVbo2hiL0Hlcv7fcf4MEtELn0g==",
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.29.0.tgz",
+      "integrity": "sha512-se9WLQS3H36u8FUA3/DfnzH3LU77QBRpJN4FmQtcQHR3A5mR2tRty+eOrvIf2R4QtveMWXrQbvScTrca7ZFZug==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
       }
     },
-    "node_modules/@aws-sdk/util-utf8-node/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-    },
-    "node_modules/@aws-sdk/xml-body-parser": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-body-parser/-/xml-body-parser-0.1.0-preview.8.tgz",
-      "integrity": "sha512-qK9+ZT5c1pj30e8td4E04ly3JczgnKAwNdJp76eTJzHXzZewQhL7VlFg2TU5UVNc/3MWSgwQHcWEtcRaOtOEiw==",
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.29.0.tgz",
+      "integrity": "sha512-ZIHbBYByMq5vadQ1SZOQTHVtrkGAFiuypATYF5ST8YB3j7XKvflv+fiBX2xQ8xpqb28noEg6dNPnvqkQQ1n/aw==",
       "dependencies": {
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
       }
     },
-    "node_modules/@aws-sdk/xml-body-parser/node_modules/tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.29.0.tgz",
+      "integrity": "sha512-9qNsX+yRpX8xE0eW9qHZCy7W6+MFkYFR10umSPVl9gc5p+RViQwS0D2wVYmQblrqGK6VpK+wAb3faFf6KaDesg==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+      "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.14.5",
@@ -5479,6 +6623,11 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "node_modules/boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -9660,6 +10809,18 @@
       "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
       "dependencies": {
         "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastest-levenshtein": {
@@ -20097,829 +21258,1535 @@
     }
   },
   "dependencies": {
-    "@aws-sdk/abort-controller": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-0.1.0-preview.7.tgz",
-      "integrity": "sha512-UpAa0PQ4u1UdDYPU9ajO/vzfmSn3rTMjXQjlsd0Ue4oK/A2lffNN28+egMVuS+Ivs96pv1HAfA4t4tPw+U6wjA==",
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
-    "@aws-sdk/client-cloudwatch-node": {
-      "version": "0.1.0-preview.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-node/-/client-cloudwatch-node-0.1.0-preview.2.tgz",
-      "integrity": "sha512-DGr3hGdJbwwSDV7xx2c3GscsI+VQE/fyOTdgxdsrKbjKPzSL2eG9yQHy5xyiVRppJJVcLNZ2QFvTyaIhJUZ/lw==",
+    "@aws-crypto/sha256-browser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.1.tgz",
+      "integrity": "sha512-nS4vdan97It6HcweV58WXtjPbPSc0JXd3sAwlw3Ou5Mc3WllSycAS32Tv2LRn8butNQoU9AE3jEQAOgiMdNC1Q==",
       "requires": {
-        "@aws-sdk/config-resolver": "^0.1.0-preview.5",
-        "@aws-sdk/core-handler": "^0.1.0-preview.5",
-        "@aws-sdk/credential-provider-node": "^0.1.0-preview.6",
-        "@aws-sdk/hash-node": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-content-length": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-header-default": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-serializer": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-stack": "^0.1.0-preview.6",
-        "@aws-sdk/node-http-handler": "^0.1.0-preview.6",
-        "@aws-sdk/protocol-query": "^0.1.0-preview.6",
-        "@aws-sdk/query-builder": "^0.1.0-preview.5",
-        "@aws-sdk/query-error-unmarshaller": "^0.1.0-preview.6",
-        "@aws-sdk/region-provider": "^0.1.0-preview.5",
-        "@aws-sdk/retry-middleware": "^0.1.0-preview.5",
-        "@aws-sdk/signature-v4": "^0.1.0-preview.6",
-        "@aws-sdk/signing-middleware": "^0.1.0-preview.6",
-        "@aws-sdk/stream-collector-node": "^0.1.0-preview.5",
-        "@aws-sdk/types": "^0.1.0-preview.5",
-        "@aws-sdk/url-parser-node": "^0.1.0-preview.5",
-        "@aws-sdk/util-base64-node": "^0.1.0-preview.3",
-        "@aws-sdk/util-body-length-node": "^0.1.0-preview.4",
-        "@aws-sdk/util-user-agent-node": "^0.1.0-preview.6",
-        "@aws-sdk/util-utf8-node": "^0.1.0-preview.3",
-        "@aws-sdk/xml-body-parser": "^0.1.0-preview.6",
-        "tslib": "^1.8.0"
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
-    "@aws-sdk/client-resource-groups-tagging-api-node": {
-      "version": "0.1.0-preview.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-resource-groups-tagging-api-node/-/client-resource-groups-tagging-api-node-0.1.0-preview.2.tgz",
-      "integrity": "sha512-ZRZ6bOfuCoSzy+iQ3GmD7ukyIMKdN6k0p8HIMyVvnaZHsV/GBEdzAYucGojAGLYIBtb9IVVCA5i9ADPxRrSqiQ==",
+    "@aws-crypto/sha256-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
       "requires": {
-        "@aws-sdk/config-resolver": "^0.1.0-preview.5",
-        "@aws-sdk/core-handler": "^0.1.0-preview.5",
-        "@aws-sdk/credential-provider-node": "^0.1.0-preview.6",
-        "@aws-sdk/hash-node": "^0.1.0-preview.5",
-        "@aws-sdk/json-builder": "^0.1.0-preview.5",
-        "@aws-sdk/json-error-unmarshaller": "^0.1.0-preview.6",
-        "@aws-sdk/json-parser": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-content-length": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-header-default": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-serializer": "^0.1.0-preview.5",
-        "@aws-sdk/middleware-stack": "^0.1.0-preview.6",
-        "@aws-sdk/node-http-handler": "^0.1.0-preview.6",
-        "@aws-sdk/protocol-json-rpc": "^0.1.0-preview.6",
-        "@aws-sdk/region-provider": "^0.1.0-preview.5",
-        "@aws-sdk/retry-middleware": "^0.1.0-preview.5",
-        "@aws-sdk/signature-v4": "^0.1.0-preview.6",
-        "@aws-sdk/signing-middleware": "^0.1.0-preview.6",
-        "@aws-sdk/stream-collector-node": "^0.1.0-preview.5",
-        "@aws-sdk/types": "^0.1.0-preview.5",
-        "@aws-sdk/url-parser-node": "^0.1.0-preview.5",
-        "@aws-sdk/util-base64-node": "^0.1.0-preview.3",
-        "@aws-sdk/util-body-length-node": "^0.1.0-preview.4",
-        "@aws-sdk/util-user-agent-node": "^0.1.0-preview.6",
-        "@aws-sdk/util-utf8-node": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
-    "@aws-sdk/config-resolver": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-0.1.0-preview.7.tgz",
-      "integrity": "sha512-clP/NFkGyIJzCPPZ9y9vc4rQD2O8euuEVtYDlHNPfe+791uo43I1/qhw20v31mPY1OH0dScf5Jn/n4Ed9YO1VA==",
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
-    "@aws-sdk/core-handler": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core-handler/-/core-handler-0.1.0-preview.7.tgz",
-      "integrity": "sha512-F+BAYmcPGbbK2w6Y9i4RgK9f8ojUuQKoZuFCxiYoujLGoak/p81gACTz3dQyV9/NiY46EvmdpyaGQeLtpfuriQ==",
+    "@aws-sdk/client-cloudwatch": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.31.0.tgz",
+      "integrity": "sha512-8KLOqJiFSiDQsZYoPPYjmMn1oSRirEGwcKJXS1Az0wgHjeuvvVuuAlMnVy3URjyz+qs+FQCKUQWeURz8ZjYcfg==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.31.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/credential-provider-node": "3.31.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.31.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "@aws-sdk/util-waiter": "3.29.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-env": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-0.1.0-preview.8.tgz",
-      "integrity": "sha512-wW2XRalzx8jAIsVSdOM4cDP3hgbvPy6UJhQwpn9N3kfb22G5FPEry6hlJKHAVzQ15tkTNd0C6SyRlXgC5zEzmA==",
-      "requires": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-0.1.0-preview.7.tgz",
-      "integrity": "sha512-FgrXEUf9/6VL+YWwGGpzVC7+hHcb43+kUtez/HoVq7duCi8OpnCAdLuGFoJdWhi2K76Qf1i3z2+fUYcSQnjcoQ==",
-      "requires": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-ini": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-0.1.0-preview.7.tgz",
-      "integrity": "sha512-iIVGZonHwy08RJgW9AZURKAbRTcBtwZw9wWSkO1YgtFVKYHH81E+C/k3o9ljCD9TK+XfvB2dv5alPkS71EufIQ==",
-      "requires": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-node": {
-      "version": "0.1.0-preview.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-0.1.0-preview.9.tgz",
-      "integrity": "sha512-l7AioIfRpNjgEe+8ikWUEFV8Z5eDMQTDl6BEG3y2O9K+rksSmYvIAkraOJjJmHPi/nTKgCXrWzoBpasYahuSvA==",
-      "requires": {
-        "@aws-sdk/credential-provider-env": "^0.1.0-preview.8",
-        "@aws-sdk/credential-provider-imds": "^0.1.0-preview.7",
-        "@aws-sdk/credential-provider-ini": "^0.1.0-preview.7",
-        "@aws-sdk/credential-provider-process": "^0.1.0-preview.5",
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-process": {
-      "version": "0.1.0-preview.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-0.1.0-preview.5.tgz",
-      "integrity": "sha512-OIBmuaul/aF3w3oCc1zIw+jE5tlhacrhCD/LXf0DornF8Bfp4oaYA5qJ4Lttu/Q25s2qW5+YEuFlDsnqpIQUyw==",
-      "requires": {
-        "@aws-sdk/credential-provider-ini": "^0.1.0-preview.7",
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-0.1.0-preview.8.tgz",
-      "integrity": "sha512-tYBKE5ggAfw7oCLj3/jVJomruUMXhFOL+yH7xnKbgEjCi2m/jsSClCwjUbco2d5eFeC75t74RsFuyCREm9o+nw==",
-      "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-0.1.0-preview.3.tgz",
-      "integrity": "sha512-8SM7kBGkwH6JCKA6K1w4Jrj+EABFOPQkbPvwaf6BILYiUMUbgJvjOPjNQE2MrvRxJz50WAcZDHnlwhstuwIRnw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/is-iterable": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-iterable/-/is-iterable-0.1.0-preview.3.tgz",
-      "integrity": "sha512-dmqXKd7BlAGAaOz1dvmBw5MeOy/94LOxIRv4i8I76JPyTJsxFKjzJIHeRMnQ/5WJ3/POhmb6ZjBW/GwS/upaFw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/json-builder": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/json-builder/-/json-builder-0.1.0-preview.7.tgz",
-      "integrity": "sha512-gGrViVpR688e/3zQEXi7xb7/q4Nrz5w9DclJi6f32OHBphDkpv1SpHvf2WgA0949daU4QVKkyh0F6K2NygZtgg==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/is-iterable": "^0.1.0-preview.3",
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/json-error-unmarshaller": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/json-error-unmarshaller/-/json-error-unmarshaller-0.1.0-preview.8.tgz",
-      "integrity": "sha512-yCua3FUxKIahjDugSdQMj8g+DNT+R5gViL2CYZ05kXaUla+Qml8UDV5bPr/z21FM91Oe2d532eORXixWnWCVOQ==",
-      "requires": {
-        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7"
-      }
-    },
-    "@aws-sdk/json-parser": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/json-parser/-/json-parser-0.1.0-preview.7.tgz",
-      "integrity": "sha512-EOcBUct4jkkUky+h3nw+jRo/eSREUFgqr0k9Cqcqsf6rSHN7+TCXT9tyo8CLpvDUPsbJj+Wmoylce04wU5HQkQ==",
-      "requires": {
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-0.1.0-preview.7.tgz",
-      "integrity": "sha512-6ZI+dY8VgWmKL48tBtFGFgllwdhKgqNztscLtYPmHl38zrz4sITJnyGwbYDGLW+xLIGDOQhyFd/6kWTqT9QyKQ==",
-      "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-header-default": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-0.1.0-preview.7.tgz",
-      "integrity": "sha512-hf7+YMiPnyzRKzmcZZ5v2NKkC6CKgo8nnckJ1A1OlvWYGq3hLMF1gKDMzdkEFjWJmDWv6AVNyHjw5qe4AV8LVA==",
-      "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-serializer": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serializer/-/middleware-serializer-0.1.0-preview.7.tgz",
-      "integrity": "sha512-mc5xBnrdDM9k3a78cbTSw+VWTadpDQQBObSuAy4fCxrkPZa+APqRY+y9MMDQ0uWI80e6Ab1pt9wTx1/OM1uMWQ==",
-      "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-0.1.0-preview.8.tgz",
-      "integrity": "sha512-dlcq80vQe5buIVlAyPjJE0uL21IPfr04j5catPIfQ9rBm4809pib7vJoUkjNrfCk+RTeeVgynVdSdUaxlF5oWw==",
-      "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-0.1.0-preview.8.tgz",
-      "integrity": "sha512-D3hISgch64L2rG8RQDi361ywoSgsyH/5Yj4ZF05ZCo8UZ8TjU1CtiLPKy1is0XLqojhLlDAQ65lNna44xoArcw==",
-      "requires": {
-        "@aws-sdk/abort-controller": "^0.1.0-preview.7",
-        "@aws-sdk/querystring-builder": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.7.tgz",
-      "integrity": "sha512-8yKkR78XC3fvdd+ePohfLuZHKBL7e3k+t82JL775phiXO94WHiz/hlvm6tGhNz5zKzz72yLrJPCyoQAZLrxrTg==",
-      "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/protocol-json-rpc": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-json-rpc/-/protocol-json-rpc-0.1.0-preview.8.tgz",
-      "integrity": "sha512-HF7g/xE/mGLzaYqO5tDFqxFvHS4vbuLAmRsWnUKsNBzg+G9+r6XK+4+PrUKwEJT69lNXezUetjwuemqnycsStA==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/protocol-query": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-query/-/protocol-query-0.1.0-preview.8.tgz",
-      "integrity": "sha512-O/y5XB1n9BoKYhxjN29cRvCAOXbrh3AhcdrsefcusWt5zv718TtLnTAPIpgfiCdAiCtB1Wywrmty6HgheuwY/A==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@types/node": "^10.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.2.tgz",
-          "integrity": "sha512-sAh60KDol+MpwOr1RTK0+HgBEYejKsxdpmrOS1Wts5bI03dLzq8F7T0sRXDKeaEK8iWDlGfdzxrzg6vx/c5pNA=="
+        "@aws-sdk/abort-controller": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+          "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
         },
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/config-resolver": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+          "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.30.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.29.0.tgz",
+          "integrity": "sha512-FUhdZODjkUeTFNfH7EnqN9piQwBR1gg+8NUJt6Rn7G4rj5lN2n2ryAatowIlzIB+/oWDvpPj+yMIE+XGjQrMhg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.29.0.tgz",
+          "integrity": "sha512-sjyJrJoLhP2ekx+Z3m5g+/YIWYtuKII9eXuTTwRhzBKTpqv0WQm1ilISdNcz691JueF5jHQs4bP6FWk55RUWEg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/url-parser": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.31.0.tgz",
+          "integrity": "sha512-t95Gix2fWLIxrM2c2QZfRgJ1aCY1zGSlhb1JBlzPwxVRay7iUKa9U2dPoPhbOTsD1abQMjE4AnpDt9Bj+AXgyA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.29.0",
+            "@aws-sdk/credential-provider-imds": "3.29.0",
+            "@aws-sdk/credential-provider-sso": "3.31.0",
+            "@aws-sdk/credential-provider-web-identity": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.31.0.tgz",
+          "integrity": "sha512-T5309Q/MPHmaKYX0gSo6dv8w1ll4wsXvAUDXFC3MMdL/WYBfYvJa9H5nB9D9bL0xmtsm9e3WtfAcvEkN8Qz1xg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.29.0",
+            "@aws-sdk/credential-provider-imds": "3.29.0",
+            "@aws-sdk/credential-provider-ini": "3.31.0",
+            "@aws-sdk/credential-provider-process": "3.29.0",
+            "@aws-sdk/credential-provider-sso": "3.31.0",
+            "@aws-sdk/credential-provider-web-identity": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.29.0.tgz",
+          "integrity": "sha512-1dMq84uGh3zcu+/bGohibWYMSxcrjwaIAc4dBU/3+rkNzPPdRA83hzYS34EizQ61JQHnM3z/xX9SLMeaNRKaSA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+          "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+          "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+          "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+          "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+          "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.29.0",
+            "@aws-sdk/protocol-http": "3.29.0",
+            "@aws-sdk/querystring-builder": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+          "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+          "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+          "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+          "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-hex-encoding": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+          "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+          "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+          "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+          "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+          "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+          "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+          "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         }
       }
     },
-    "@aws-sdk/protocol-timestamp": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-timestamp/-/protocol-timestamp-0.1.0-preview.7.tgz",
-      "integrity": "sha512-ObO202v456/S6Ckhlu844KBXN9toFTPt8zzrJpESzntVXIaidDECetd120/xToycYmICinvAYH9o1E2l6VlCRQ==",
+    "@aws-sdk/client-resource-groups-tagging-api": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-resource-groups-tagging-api/-/client-resource-groups-tagging-api-3.31.0.tgz",
+      "integrity": "sha512-BZb6iJby+Cl5cJTzZy7y0tZ6IImdFdCJLG7DSbjcA4/4OsBHJVNY9+q/kFO5E2HXX/fegoqwuPkQLudIjujH8A==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.31.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/credential-provider-node": "3.31.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.31.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/abort-controller": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+          "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+          "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.30.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.29.0.tgz",
+          "integrity": "sha512-FUhdZODjkUeTFNfH7EnqN9piQwBR1gg+8NUJt6Rn7G4rj5lN2n2ryAatowIlzIB+/oWDvpPj+yMIE+XGjQrMhg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.29.0.tgz",
+          "integrity": "sha512-sjyJrJoLhP2ekx+Z3m5g+/YIWYtuKII9eXuTTwRhzBKTpqv0WQm1ilISdNcz691JueF5jHQs4bP6FWk55RUWEg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/url-parser": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.31.0.tgz",
+          "integrity": "sha512-t95Gix2fWLIxrM2c2QZfRgJ1aCY1zGSlhb1JBlzPwxVRay7iUKa9U2dPoPhbOTsD1abQMjE4AnpDt9Bj+AXgyA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.29.0",
+            "@aws-sdk/credential-provider-imds": "3.29.0",
+            "@aws-sdk/credential-provider-sso": "3.31.0",
+            "@aws-sdk/credential-provider-web-identity": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.31.0.tgz",
+          "integrity": "sha512-T5309Q/MPHmaKYX0gSo6dv8w1ll4wsXvAUDXFC3MMdL/WYBfYvJa9H5nB9D9bL0xmtsm9e3WtfAcvEkN8Qz1xg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.29.0",
+            "@aws-sdk/credential-provider-imds": "3.29.0",
+            "@aws-sdk/credential-provider-ini": "3.31.0",
+            "@aws-sdk/credential-provider-process": "3.29.0",
+            "@aws-sdk/credential-provider-sso": "3.31.0",
+            "@aws-sdk/credential-provider-web-identity": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.29.0.tgz",
+          "integrity": "sha512-1dMq84uGh3zcu+/bGohibWYMSxcrjwaIAc4dBU/3+rkNzPPdRA83hzYS34EizQ61JQHnM3z/xX9SLMeaNRKaSA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+          "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+          "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+          "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+          "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+          "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.29.0",
+            "@aws-sdk/protocol-http": "3.29.0",
+            "@aws-sdk/querystring-builder": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+          "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+          "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+          "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+          "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-hex-encoding": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+          "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+          "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+          "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+          "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+          "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+          "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+          "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/query-builder": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/query-builder/-/query-builder-0.1.0-preview.7.tgz",
-      "integrity": "sha512-dKPHM2I+k3vQTJxL3b7vmi5qOXrNnbJzHAY+d0SHLinFM1CgSdQaAWIjO5lICkktiX65M6x7xCjVZbXwo8pfaw==",
+    "@aws-sdk/client-sso": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.31.0.tgz",
+      "integrity": "sha512-fbquWlOS8+uotT2aZexK/3g85NYt2T5LpfWnk9mPV5HWfoevqTz9kwsZEW4DTnW9zibRl89vwXKolNpyszuZnw==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/is-iterable": "^0.1.0-preview.3",
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.31.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/abort-controller": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+          "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+          "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.30.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+          "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+          "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+          "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+          "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+          "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.29.0",
+            "@aws-sdk/protocol-http": "3.29.0",
+            "@aws-sdk/querystring-builder": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+          "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+          "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-hex-encoding": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+          "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+          "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+          "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+          "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+          "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+          "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+          "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/query-error-unmarshaller": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/query-error-unmarshaller/-/query-error-unmarshaller-0.1.0-preview.8.tgz",
-      "integrity": "sha512-41lNT9delFhOss5H3eoi/2wYLYFuVqLXutRb5ZM5VvdhE4ZG+L8oE8HM0LSwQBttQFHaZcjdx3x3n9EVatSuCw==",
+    "@aws-sdk/client-sts": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.31.0.tgz",
+      "integrity": "sha512-XL8l88iUHPxfByFPp9a9eZV6Shb9QijHM+aGJPFU5zYvX3ruclfuBIs/3gLgqeX8rsmjt8AfeICxaP4BwJcaZA==",
       "requires": {
-        "@aws-sdk/response-metadata-extractor": "^0.1.0-preview.8",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-error-constructor": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/credential-provider-node": "3.31.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-sdk-sts": "3.30.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.31.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/abort-controller": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+          "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+          "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.30.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.29.0.tgz",
+          "integrity": "sha512-FUhdZODjkUeTFNfH7EnqN9piQwBR1gg+8NUJt6Rn7G4rj5lN2n2ryAatowIlzIB+/oWDvpPj+yMIE+XGjQrMhg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.29.0.tgz",
+          "integrity": "sha512-sjyJrJoLhP2ekx+Z3m5g+/YIWYtuKII9eXuTTwRhzBKTpqv0WQm1ilISdNcz691JueF5jHQs4bP6FWk55RUWEg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/url-parser": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.31.0.tgz",
+          "integrity": "sha512-t95Gix2fWLIxrM2c2QZfRgJ1aCY1zGSlhb1JBlzPwxVRay7iUKa9U2dPoPhbOTsD1abQMjE4AnpDt9Bj+AXgyA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.29.0",
+            "@aws-sdk/credential-provider-imds": "3.29.0",
+            "@aws-sdk/credential-provider-sso": "3.31.0",
+            "@aws-sdk/credential-provider-web-identity": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.31.0.tgz",
+          "integrity": "sha512-T5309Q/MPHmaKYX0gSo6dv8w1ll4wsXvAUDXFC3MMdL/WYBfYvJa9H5nB9D9bL0xmtsm9e3WtfAcvEkN8Qz1xg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.29.0",
+            "@aws-sdk/credential-provider-imds": "3.29.0",
+            "@aws-sdk/credential-provider-ini": "3.31.0",
+            "@aws-sdk/credential-provider-process": "3.29.0",
+            "@aws-sdk/credential-provider-sso": "3.31.0",
+            "@aws-sdk/credential-provider-web-identity": "3.29.0",
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.29.0.tgz",
+          "integrity": "sha512-1dMq84uGh3zcu+/bGohibWYMSxcrjwaIAc4dBU/3+rkNzPPdRA83hzYS34EizQ61JQHnM3z/xX9SLMeaNRKaSA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.29.0",
+            "@aws-sdk/shared-ini-file-loader": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-credentials": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+          "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+          "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+          "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+          "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+          "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.29.0",
+            "@aws-sdk/protocol-http": "3.29.0",
+            "@aws-sdk/querystring-builder": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+          "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+          "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+          "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+          "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-hex-encoding": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+          "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+          "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+          "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+          "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+          "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+          "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+          "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         }
       }
     },
-    "@aws-sdk/querystring-builder": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-0.1.0-preview.7.tgz",
-      "integrity": "sha512-U2d9CYTwnF4/Qc8XXFmCdRzcApTmwEXLyHUcjK2/GaOHKkHDAeIC94+cuP+H3nDjCjb3TdKV2xrl/wzuP0YBrg==",
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.31.0.tgz",
+      "integrity": "sha512-x+xQvq8AFt+V1EpwRWa3Obsd1w2L7pQyP/P6O9Q5Enq6OwmdrM+i51jMD58QMRz4h+Ys5eaLLfi0wE0AjrUbng==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-uri-escape": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/client-sso": "3.31.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/property-provider": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+          "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+          "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/querystring-parser": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-0.1.0-preview.7.tgz",
-      "integrity": "sha512-r72E/wZYrhTXTK950Ld/L2Loso/HDqExQkIuCn1Pu8Rx0+uC3Y8fQTx+JZd5M5kOniCpGKdHWGc7y/bH/tjH4A==",
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.29.0.tgz",
+      "integrity": "sha512-TwICG9y/iw08urlCymroQfRRJY++4JZwdhR0/2ycU+/Cgac6u4MfZsB1qD+u9+Q39/TqSz6QwtNhKLNdf0N23A==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/property-provider": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+          "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/region-provider": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-provider/-/region-provider-0.1.0-preview.7.tgz",
-      "integrity": "sha512-n+LeuQYPYbCyfCboz9mmYqcPPKdmdd60KPbPeRqSdJYr9QZz9hWU962oCOl5EtLYIsUzy7Fm33APv6toEcAPVw==",
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.29.0.tgz",
+      "integrity": "sha512-rx+YlHFYzgGsCZMEvJBUdRsqfMGW4RY6J3USQvz63a32jVlMC3Kw9xINaXGhCEmOlUlzdeeIMQOZW5VxavLnjQ==",
       "requires": {
-        "@aws-sdk/property-provider": "^0.1.0-preview.7",
-        "@aws-sdk/shared-ini-file-loader": "^0.1.0-preview.3",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/querystring-builder": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+          "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+          "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/response-metadata-extractor": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/response-metadata-extractor/-/response-metadata-extractor-0.1.0-preview.8.tgz",
-      "integrity": "sha512-c5aJGYDiEwWqYpsROCqrmR60d0yeVdvRtzMptcpCI95BvIizS3hTc+PfuOq3Gcz7L+EQysbzQyqZutCJ/zLbew==",
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.29.0.tgz",
+      "integrity": "sha512-0TyZZbPs5SWCF2tT1DXccK5SUx7/bDJCVojgBuW3QRJn9ta3US/u5l7w8k6jwWFU3CQhLAWuG0TD7FhATiM2HQ==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.29.0.tgz",
+      "integrity": "sha512-aBifr86Owrhvy29cvZD17JzdoTtKMxzdjCkMA7ckNP+9Lg7kLI/6ws1yZ6BJlmcOnKxtNSnkvunGmJy8BU8EWQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.29.0.tgz",
+      "integrity": "sha512-0rLvuTvfaMWNb7+FApXAH0111FEp/AfG3fO7QkyVrXmHlTrNIJozilhkd0FwEMcQqqM9UK5lPLXwloH9Rkp9vw==",
+      "requires": {
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.29.0.tgz",
+      "integrity": "sha512-yRQ48UIGPmK3/jWMJ2LC4trltFevMDEXyvtT6knwDnwXxmuwv7K6udk6TnGaUU5TlLVI1XdRQHaZY7xZH1KbGw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/service-error-classification": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/service-error-classification": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.29.0.tgz",
+          "integrity": "sha512-VqOjXXTLTGbifzg3Fg2g/Ac6W3uzC3llPZjm/b0goM17KLWMGU7JKiem2l+CFyN4sxkver7InNlIUJCJAPB6+Q=="
         }
       }
     },
-    "@aws-sdk/retry-middleware": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/retry-middleware/-/retry-middleware-0.1.0-preview.7.tgz",
-      "integrity": "sha512-ULiq+dffOPurjyHm95PYWi1Cy27LQg9jPwLz5tiL7oIla/j9b5bcclZE3n0RtqbHDUvWJL5kxmYw0Kjrggr5iw==",
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.30.0.tgz",
+      "integrity": "sha512-TZQQ0LA/rjYNgV+DbU0KvyHZaNhihrWf4IeJeKoez1vpvQmU58G5zAm0+rVHbzazJaOQuHYKKdPttOPxl/JAAg==",
       "requires": {
-        "@aws-sdk/service-error-classification": "^0.1.0-preview.3",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+          "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+          "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+          "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-hex-encoding": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+          "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+          "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/service-error-classification": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-0.1.0-preview.3.tgz",
-      "integrity": "sha512-3TXwADJL+HGOWyqdwx+pOdwr8L8LGbdxwHR0D05PP3skY+TP34F3ye2DJlyCll4S9vYzf9GlSbwJWviN9Sujrw=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-0.1.0-preview.3.tgz",
-      "integrity": "sha512-1wuV2YpZm+sW4AZa7CBD3A3b7+vSHX0DWBgGaENYdqC+MUEl6lD57ZOUGLryPq5xv/tQfy8BC7QT+qDNHElcuw==",
+    "@aws-sdk/middleware-serde": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.29.0.tgz",
+      "integrity": "sha512-jN6zuaXg3k9HiWJZjBROiVJEdFaZrMikhyVdqYTT3hR+i08M/9UgVuX84HP/dALChZazOn9MPhvPWGvxrMOr9A==",
       "requires": {
-        "tslib": "^1.8.0"
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.30.0.tgz",
+      "integrity": "sha512-T/zGCijEGODmpbS/HlwnxT0Bn69FhZpBrVAjfofLUFzHteJ5Ab2q7AEt1dOdi3GrtTGStdwbfiZVeTxMKIjaTw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+          "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+          "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+          "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.29.0",
+            "@aws-sdk/types": "3.29.0",
+            "@aws-sdk/util-hex-encoding": "3.29.0",
+            "@aws-sdk/util-uri-escape": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+          "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+          "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/signature-v4": {
-      "version": "0.1.0-preview.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-0.1.0-preview.9.tgz",
-      "integrity": "sha512-772F+4Z3VHMQUIpdXmcg4Ar6ATiDQ+tLXdUQX/jDvkXbQWXURjZLLL6X1ghFSlXKmOR0fRxmYZL0fG/M9PwssQ==",
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.29.0.tgz",
+      "integrity": "sha512-AVbn9QEbqBgScaD3cxLv7/yi9Up10vYKy/AWIwgTrW0LxOuy9+Za2hdk5eZRP/QpqS/Ibz2/CqcmK1GQ/03kmg==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "@aws-sdk/util-hex-encoding": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.29.0.tgz",
+      "integrity": "sha512-ANRnPz4IT4FiSAc+9p0HqGSjL+cdzB2E68BFmbbGin0fZwhflX1BksjuUEibw8Emf8jvhvbUxdtAIUWctTYxOA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/property-provider": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+          "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+          "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/signing-middleware": {
-      "version": "0.1.0-preview.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signing-middleware/-/signing-middleware-0.1.0-preview.9.tgz",
-      "integrity": "sha512-XXrs0h5YTLgkviotIQSwYjAf0aTPKCFYPA0vYubTP1EY7fUGI3hLlFttaUh5/77h8b3RNYx/QFcRXodY5GAxWg==",
+    "@aws-sdk/protocol-http": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.29.0.tgz",
+      "integrity": "sha512-OIeJ7ukfgGkaIL0/NNM5sxIlfxtOqQN+KoaQ89YeLBlJPVoKnptAw+eWjjLwxLs+r/SbyZHXbBawP+sbzq0mSQ==",
       "requires": {
-        "@aws-sdk/signature-v4": "^0.1.0-preview.9",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       }
     },
-    "@aws-sdk/stream-collector-node": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/stream-collector-node/-/stream-collector-node-0.1.0-preview.8.tgz",
-      "integrity": "sha512-p8cpGYqUy0pgOsephImE4yar3CJqhuVgPqhegRQXXYor3ZPkGloPymNys/1FmVb4RbzLrQ8WmpM+Fd0dUIu3PA==",
+    "@aws-sdk/smithy-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.31.0.tgz",
+      "integrity": "sha512-QZHOMM6npFyDEW8wrp8rLs+YGZIPRfuItlWHm6Upejp6a7s1ksb/1c44vNeqwnAeUJrdXfOX9QFkbh1+gZF21A==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/middleware-stack": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+          "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
     "@aws-sdk/types": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-0.1.0-preview.7.tgz",
-      "integrity": "sha512-gpyU8N9XEs8diE4uW9B6/hjKDrB/c4a1GF4ICwkaGYpXrbJy9QLrEU8Hk4rC6P1l++YYyJKMl7RjMmTyBtNOzw=="
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.29.0.tgz",
+      "integrity": "sha512-8ilWQU5ZTdiRfblmmjl38+6JZKKM8EqA5Sbn8djgDLShCLeVJ2TsL2guzNi+WHcL7BHdv1pI/NNmTcgRUo6yOw=="
     },
-    "@aws-sdk/url-parser-node": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-node/-/url-parser-node-0.1.0-preview.8.tgz",
-      "integrity": "sha512-h8YwL+mLTBPNzryREkLChhtRSdz70tOR9y/UB6PATGKoJbMUFoTsDY1jbJ4WWBfdKjphZy9xVWTyxoCkP07tQQ==",
+    "@aws-sdk/url-parser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.29.0.tgz",
+      "integrity": "sha512-385f+g4xeRym2S4bzF+Nc0MB8addAlCSb5hIUJu1JKH6FwFLrNRuixeaelGLyWr77xv25P0ruyXQAFf2ISxzKw==",
       "requires": {
-        "@aws-sdk/querystring-parser": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
+        "@aws-sdk/querystring-parser": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/querystring-parser": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.29.0.tgz",
+          "integrity": "sha512-v22PBXafAHw+wMaSGbq4B9wEsSYV2e0nZgGHZBNML3HPDiAYJqsQHiYEbiz8nzkmoayU0wrVFZ/XfKNXXcXGbw==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/util-base64-node": {
-      "version": "0.1.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-0.1.0-preview.4.tgz",
-      "integrity": "sha512-L9O3lMWB7y2xVIgg/nSJ7xZLVFmxMCk1maaup3CoL5USLqB7n7ngpf/WAH2LyhaGo8Og8TrAKt4BizpxbZU7wg==",
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.29.0.tgz",
+      "integrity": "sha512-yMgn5vZ7laVO/497iPDjTdmia3sDdFBDq6k42EZxVTpkUcd8JS2nWJ+9ePuIMwqOgPjhhkOOXiidrbZaUQ+L6Q==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.29.0.tgz",
+      "integrity": "sha512-cKSwlDlZkcxuhSdoiq1TxleaBvveEgKA2Yo4TYP4DKVPHZuYZtbFv8r1driml1SaIKXg4GQpe+pJit3mxDRxAg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-credentials": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.29.0.tgz",
+      "integrity": "sha512-xCWQizP5d6SwbwB2HmxpDqu0WYY7/E7pNrZ+7tSMrJxZlT8Zsd+lFaO23JVFMEBqjjBnpLBr+XkNZgOpD1BYwA==",
+      "requires": {
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+          "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
-    "@aws-sdk/util-body-length-node": {
-      "version": "0.1.0-preview.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-0.1.0-preview.5.tgz",
-      "integrity": "sha512-ZmqB7E/RizTe8ajxLyXdshoyzQg47CAkbnCK7yRE4A9N7XMEUgzyFVXuKT08DmbAwYSYWI5jaUwm3jpMKqG+bw==",
+    "@aws-sdk/util-locate-window": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.29.0.tgz",
+      "integrity": "sha512-gvcbl9UdTOvuCCzgbtTTsKnL1l/cnT/CFl0f6ZCQ6qubUTRCuL/aK8DvgWa1n9p/ddCiVKPLmHu/L1xtX4gc0A==",
       "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
+        "tslib": "^2.3.0"
       }
     },
-    "@aws-sdk/util-buffer-from": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-0.1.0-preview.3.tgz",
-      "integrity": "sha512-n78cUmI1SbluJgTgyqp24GgNQ3A5NUGB4rwRAoID7k7JpsiNJUWTXkijl3hxfNov2sEjMWvdQIGvAF6F/Q2mfw==",
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.29.0.tgz",
+      "integrity": "sha512-se9WLQS3H36u8FUA3/DfnzH3LU77QBRpJN4FmQtcQHR3A5mR2tRty+eOrvIf2R4QtveMWXrQbvScTrca7ZFZug==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
+        "@aws-sdk/types": "3.29.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
       }
     },
-    "@aws-sdk/util-error-constructor": {
-      "version": "0.1.0-preview.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-error-constructor/-/util-error-constructor-0.1.0-preview.7.tgz",
-      "integrity": "sha512-sb8gruiOadl0YXG2yn0EMBkB/Oy/7y4mt8Wfl7G3crvWXcHtD7flbW7wjbFiMcQU91vi5sTaZ56hwvDA9lu0ug==",
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.29.0.tgz",
+      "integrity": "sha512-ZIHbBYByMq5vadQ1SZOQTHVtrkGAFiuypATYF5ST8YB3j7XKvflv+fiBX2xQ8xpqb28noEg6dNPnvqkQQ1n/aw==",
       "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
+        "tslib": "^2.3.0"
       }
     },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-0.1.0-preview.3.tgz",
-      "integrity": "sha512-X/Qq5e2H4/EQ0WEwWUiSxGbFARk7IKZpa+E4pzQm49sxS2omVsvuphcr4yYJq4SZKEtuB2w2nHMr7NmGlWt4Xg==",
+    "@aws-sdk/util-waiter": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.29.0.tgz",
+      "integrity": "sha512-9qNsX+yRpX8xE0eW9qHZCy7W6+MFkYFR10umSPVl9gc5p+RViQwS0D2wVYmQblrqGK6VpK+wAb3faFf6KaDesg==",
       "requires": {
-        "tslib": "^1.8.0"
+        "@aws-sdk/abort-controller": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "0.1.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-0.1.0-preview.3.tgz",
-      "integrity": "sha512-axArIOq8+2PKjY9Fz+LKfCY127rjWQD50F1DAhCC0BV3mrG0OlhcQ8uKaNfMXVrveTqT+QYvrpTsrziHYjjTQw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/util-user-agent-node": {
-      "version": "0.1.0-preview.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-0.1.0-preview.9.tgz",
-      "integrity": "sha512-V/1n0KAFvAIsguDXMJ9zvbJmv3j5dyOhjHKf6nhWYBR7hLYGdKA5HlZmQsoRCJf3B3whl6z1HSkmtTPOtY9Hlg==",
-      "requires": {
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "0.1.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-0.1.0-preview.4.tgz",
-      "integrity": "sha512-FxIWpC4LdKiJgJgiaLWMdZY/DbreSIRgVGO9cOlV5fI59KdN+2Aqb6sLnlp7yVbo2hiL0Hlcv7fcf4MEtELn0g==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "^0.1.0-preview.3",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
-      }
-    },
-    "@aws-sdk/xml-body-parser": {
-      "version": "0.1.0-preview.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-body-parser/-/xml-body-parser-0.1.0-preview.8.tgz",
-      "integrity": "sha512-qK9+ZT5c1pj30e8td4E04ly3JczgnKAwNdJp76eTJzHXzZewQhL7VlFg2TU5UVNc/3MWSgwQHcWEtcRaOtOEiw==",
-      "requires": {
-        "@aws-sdk/protocol-timestamp": "^0.1.0-preview.7",
-        "@aws-sdk/types": "^0.1.0-preview.7",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        "@aws-sdk/abort-controller": {
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+          "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
+          "requires": {
+            "@aws-sdk/types": "3.29.0",
+            "tslib": "^2.3.0"
+          }
         }
       }
     },
@@ -24511,6 +26378,11 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -27707,6 +29579,11 @@
       "requires": {
         "punycode": "^1.3.2"
       }
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fastest-levenshtein": {
       "version": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -106,8 +106,9 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudwatch-node": "^0.1.0-preview.2",
-    "@aws-sdk/client-resource-groups-tagging-api-node": "0.1.0-preview.2",
+    "@aws-sdk/client-cloudwatch": "^3.31.0",
+    "@aws-sdk/client-resource-groups-tagging-api": "^3.31.0",
+    "@aws-sdk/types": "^3.29.0",
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-react": "^7.14.5",
     "aws-sdk": "^2.989.0",

--- a/src/@types/jest/index.d.ts
+++ b/src/@types/jest/index.d.ts
@@ -1,0 +1,6 @@
+declare namespace jest {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface Matchers<R> {
+    toBeCalledWithStringified<E>(expected: E): R;
+  }
+}

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http';
 
-import awsTypes from '@aws-sdk/types';
+import { Credentials as awsCredentials } from '@aws-sdk/types';
 import compression from 'compression';
 import cookieSession from 'cookie-session';
 import csrf from 'csurf';
@@ -61,7 +61,7 @@ export interface IAppConfig {
   readonly awsRegion: string;
   readonly awsCloudwatchEndpoint?: string;
   readonly awsResourceTaggingAPIEndpoint?: string;
-  readonly awsCredentials?: awsTypes.Credentials;
+  readonly awsCredentials?: awsCredentials;
   readonly adminFee: number;
   readonly platformMetricsEndpoint: string;
   readonly prometheusEndpoint: string;

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -492,11 +492,13 @@ export async function downloadServiceMetrics(
       headers = ['Service', 'Time', 'Value'];
       contents = values(sqsMetricSeries[params.metric])
         .map(metric =>
-          metric.metrics.map(series => [
-            serviceLabel,
-            formatISO(series.date),
-            composeValue(series.value, params.units),
-          ]),
+          metric.metrics
+            .filter(series => isValid(series.date))
+            .map(series => [
+              serviceLabel,
+              formatISO(series.date),
+              composeValue(series.value, params.units),
+            ]),
         )
         .reduceRight((list, flatList) => [...flatList, ...list], []);
       break;
@@ -521,11 +523,13 @@ export async function downloadServiceMetrics(
       headers = ['Service', 'Time', 'Value'];
       contents = values(cloudfrontMetricSeries[params.metric])
         .map(metric =>
-          metric.metrics.map(series => [
-            serviceLabel,
-            formatISO(series.date),
-            composeValue(series.value, params.units),
-          ]),
+          metric.metrics
+            .filter(series => isValid(series.date))
+            .map(series => [
+              serviceLabel,
+              formatISO(series.date),
+              composeValue(series.value, params.units),
+            ]),
         )
         .reduceRight((list, flatList) => [...flatList, ...list], []);
       break;
@@ -547,11 +551,13 @@ export async function downloadServiceMetrics(
       headers = ['Service', 'Time', 'Value'];
       contents = values(rdsMetricSeries[params.metric])
         .map(metric =>
-          metric.metrics.map(series => [
-            serviceLabel,
-            formatISO(series.date),
-            composeValue(series.value, params.units),
-          ]),
+          metric.metrics
+            .filter(series => isValid(series.date))
+            .map(series => [
+              serviceLabel,
+              formatISO(series.date),
+              composeValue(series.value, params.units),
+            ]),
         )
         .reduceRight((list, flatList) => [...flatList, ...list], []);
       break;
@@ -572,12 +578,14 @@ export async function downloadServiceMetrics(
       headers = ['Service', 'Instance', 'Time', 'Value'];
       contents = values(elasticacheMetricSeries[params.metric])
         .map(metric =>
-          metric.metrics.map(series => [
-            serviceLabel,
-            metric.label || '',
-            formatISO(series.date),
-            composeValue(series.value, params.units),
-          ]),
+          metric.metrics
+            .filter(series => isValid(series.date))
+            .map(series => [
+              serviceLabel,
+              metric.label || '',
+              formatISO(series.date),
+              composeValue(series.value, params.units),
+            ]),
         )
         .reduceRight((list, flatList) => [...flatList, ...list], []);
       break;
@@ -600,13 +608,15 @@ export async function downloadServiceMetrics(
       headers = ['Service', 'Instance', 'Time', 'Value'];
       contents = values(elasticsearchMetricSeries[params.metric])
         .map(metric =>
-          metric.metrics.map(series => [
-            serviceLabel,
-            /* istanbul ignore next */
-            metric.label || '',
-            formatISO(series.date),
-            composeValue(series.value, params.units),
-          ]),
+          metric.metrics
+            .filter(series => isValid(series.date))
+            .map(series => [
+              serviceLabel,
+              /* istanbul ignore next */
+              metric.label || '',
+              formatISO(series.date),
+              composeValue(series.value, params.units),
+            ]),
         )
         .reduceRight((list, flatList) => [...flatList, ...list], []);
       break;

--- a/src/components/service-metrics/controllers.tsx
+++ b/src/components/service-metrics/controllers.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-case-declarations */
-import * as cw from '@aws-sdk/client-cloudwatch-node';
-import * as rg from '@aws-sdk/client-resource-groups-tagging-api-node';
+import * as cw from '@aws-sdk/client-cloudwatch';
+import * as rg from '@aws-sdk/client-resource-groups-tagging-api';
 import { Duration, format, formatISO, isBefore, isValid, sub } from 'date-fns';
 import { mapValues, values } from 'lodash';
 import React from 'react';

--- a/src/lib/aws/aws-cloudwatch.test.data.ts
+++ b/src/lib/aws/aws-cloudwatch.test.data.ts
@@ -1,4 +1,5 @@
 import { getGappyRandomData } from '../metrics';
+import { format, fromUnixTime } from 'date-fns'
 
 interface IServiceIdAndLabel {
   readonly id: string;
@@ -37,10 +38,12 @@ export function getStubCloudwatchMetricsData(
   const members = metricSeriesLabelsAndIds
     .map(({ label, id }) => {
       const { timestamps, values } = getGappyRandomData();
+      console.log(timestamps)
+      console.log(fromUnixTime(parseInt('1631535900')))
 
       return `<member>
       <Timestamps>
-        ${timestamps.map(t => `<member>${t}</member>`).join('\n')}
+        ${timestamps.map(t => `<member>${format(fromUnixTime(parseInt(t)),'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'')}</member>`).join('\n')}
       </Timestamps>
       <Values>
         ${values.map(v => `<member>${v}</member>`).join('\n')}

--- a/src/lib/metric-data-getters/cloudfront.test.ts
+++ b/src/lib/metric-data-getters/cloudfront.test.ts
@@ -1,4 +1,4 @@
-import { GetResourcesCommand } from '@aws-sdk/client-resource-groups-tagging-api-node';
+import { GetResourcesCommand } from '@aws-sdk/client-resource-groups-tagging-api';
 
 import { CloudFrontMetricDataGetter } from './cloudfront';
 

--- a/src/lib/metric-data-getters/cloudfront.test.ts
+++ b/src/lib/metric-data-getters/cloudfront.test.ts
@@ -2,6 +2,34 @@ import { GetResourcesCommand } from '@aws-sdk/client-resource-groups-tagging-api
 
 import { CloudFrontMetricDataGetter } from './cloudfront';
 
+const isMock = (received: any) =>
+  received != null && received._isMockFunction === true;
+
+expect.extend({
+  toBeCalledWithStringified: (received: jest.Mock, ...expected: any): jest.CustomMatcherResult => {
+    if (!isMock(received)) {
+      throw new Error('`toBeCalledWithStringified(received)` value needs to be mock');
+    }
+
+    const call = JSON.stringify(received.mock.calls[0]);
+    const expectation = JSON.stringify(expected);
+
+    const pass = expectation === call;
+
+    return {
+      message: () => {
+        return `${pass
+            ? 'The expected call input matches the received input.'
+            : 'The purest stringified arguments of the mocked and expected function are not the same.'
+          }\n\n` +
+          `Expected: ${expectation}\n` +
+          `Received: ${call}`;
+      },
+      pass,
+    };
+  },
+});
+
 describe('Cloudfront', () => {
   describe('getCloudFrontDistributionId', () => {
     it('should fetch and transform the identifier correctly', async () => {
@@ -27,7 +55,7 @@ describe('Cloudfront', () => {
         'a-service-guid',
       );
 
-      expect(send).toBeCalledWith(
+      expect(send).toBeCalledWithStringified(
         new GetResourcesCommand({
           ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [
@@ -56,7 +84,7 @@ describe('Cloudfront', () => {
         dg.getCloudFrontDistributionId('a-service-guid'),
       ).rejects.toThrow(/Could not get tags for CloudFront distribution/);
 
-      expect(send).toBeCalledWith(
+      expect(send).toBeCalledWithStringified(
         new GetResourcesCommand({
           ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [
@@ -83,7 +111,7 @@ describe('Cloudfront', () => {
         dg.getCloudFrontDistributionId('a-service-guid'),
       ).rejects.toThrow(/Could not get tags for CloudFront distribution/);
 
-      expect(send).toBeCalledWith(
+      expect(send).toBeCalledWithStringified(
         new GetResourcesCommand({
           ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [
@@ -110,8 +138,9 @@ describe('Cloudfront', () => {
         dg.getCloudFrontDistributionId('a-service-guid'),
       ).rejects.toThrow(/Could not get ARN for CloudFront distribution/);
 
-      expect(send).toBeCalledWith(
+      expect(send).toBeCalledWithStringified(
         new GetResourcesCommand({
+          ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [
             {
               Key: 'ServiceInstance',
@@ -144,7 +173,7 @@ describe('Cloudfront', () => {
         dg.getCloudFrontDistributionId('a-service-guid'),
       ).rejects.toThrow(/Malformed ARN/);
 
-      expect(send).toBeCalledWith(
+      expect(send).toBeCalledWithStringified(
         new GetResourcesCommand({
           ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [

--- a/src/lib/metric-data-getters/cloudfront.test.ts
+++ b/src/lib/metric-data-getters/cloudfront.test.ts
@@ -29,13 +29,13 @@ describe('Cloudfront', () => {
 
       expect(send).toBeCalledWith(
         new GetResourcesCommand({
+          ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [
             {
               Key: 'ServiceInstance',
               Values: ['a-service-guid'],
             },
           ],
-          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
 
@@ -58,13 +58,13 @@ describe('Cloudfront', () => {
 
       expect(send).toBeCalledWith(
         new GetResourcesCommand({
+          ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [
             {
               Key: 'ServiceInstance',
               Values: ['a-service-guid'],
             },
           ],
-          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
     });
@@ -85,13 +85,13 @@ describe('Cloudfront', () => {
 
       expect(send).toBeCalledWith(
         new GetResourcesCommand({
+          ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [
             {
               Key: 'ServiceInstance',
               Values: ['a-service-guid'],
             },
           ],
-          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
     });
@@ -118,7 +118,6 @@ describe('Cloudfront', () => {
               Values: ['a-service-guid'],
             },
           ],
-          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
     });
@@ -147,13 +146,13 @@ describe('Cloudfront', () => {
 
       expect(send).toBeCalledWith(
         new GetResourcesCommand({
+          ResourceTypeFilters: ['cloudfront:distribution'],
           TagFilters: [
             {
               Key: 'ServiceInstance',
               Values: ['a-service-guid'],
             },
           ],
-          ResourceTypeFilters: ['cloudfront:distribution'],
         }),
       );
     });

--- a/src/lib/metric-data-getters/cloudfront.ts
+++ b/src/lib/metric-data-getters/cloudfront.ts
@@ -9,21 +9,8 @@ import { IMetricDataGetter, IMetricSerie, MetricName } from '../metrics';
 import { CloudWatchMetricDataGetter, ICloudWatchMetric } from './cloudwatch';
 
 const cloudfrontMetricPropertiesById: {
-  [key in MetricName]: ICloudWatchMetric;
+  readonly [key in MetricName]: ICloudWatchMetric;
 } = {
-  mRequests: {
-    name: 'Requests',
-    stat: 'Sum',
-  },
-  mBytesUploaded: {
-    name: 'BytesUploaded',
-    stat: 'Sum',
-  },
-  mBytesDownloaded: {
-    name: 'BytesDownloaded',
-    stat: 'Sum',
-  },
-
   m4xxErrorRate: {
     name: '4xxErrorRate',
     stat: 'Average',
@@ -31,6 +18,18 @@ const cloudfrontMetricPropertiesById: {
   m5xxErrorRate: {
     name: '5xxErrorRate',
     stat: 'Average',
+  },
+  mBytesDownloaded: {
+    name: 'BytesDownloaded',
+    stat: 'Sum',
+  },
+  mBytesUploaded: {
+    name: 'BytesUploaded',
+    stat: 'Sum',
+  },
+  mRequests: {
+    name: 'Requests',
+    stat: 'Sum',
   },
   mTotalErrorRate: {
     name: 'TotalErrorRate',
@@ -57,14 +56,14 @@ export class CloudFrontMetricDataGetter extends CloudWatchMetricDataGetter
     const arn = await this.resourceGroupsTaggingAPIClient
       .send(
         new rg.GetResourcesCommand({
+          ResourceTypeFilters: [
+            'cloudfront:distribution',
+          ],
           TagFilters: [
             {
               Key: 'ServiceInstance',
               Values: [serviceGUID],
             },
-          ],
-          ResourceTypeFilters: [
-            'cloudfront:distribution',
           ],
         }),
       )
@@ -109,6 +108,7 @@ export class CloudFrontMetricDataGetter extends CloudWatchMetricDataGetter
 
     const metricDataInputs = [
       {
+        EndTime: rangeStop,
         MetricDataQueries: metricNames.map(metricId => ({
           Id: metricId,
           MetricStat: {
@@ -125,7 +125,6 @@ export class CloudFrontMetricDataGetter extends CloudWatchMetricDataGetter
           },
         })),
         StartTime: rangeStart,
-        EndTime: rangeStop,
       },
     ];
 
@@ -137,6 +136,7 @@ export class CloudFrontMetricDataGetter extends CloudWatchMetricDataGetter
 
     const results = _.flatMap(
       responses,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       response => response.MetricDataResults!,
     );
 

--- a/src/lib/metric-data-getters/cloudfront.ts
+++ b/src/lib/metric-data-getters/cloudfront.ts
@@ -1,5 +1,5 @@
-import * as cw from '@aws-sdk/client-cloudwatch-node';
-import * as rg from '@aws-sdk/client-resource-groups-tagging-api-node';
+import * as cw from '@aws-sdk/client-cloudwatch';
+import * as rg from '@aws-sdk/client-resource-groups-tagging-api';
 import { Duration, milliseconds, millisecondsToSeconds } from 'date-fns';
 import _ from 'lodash';
 

--- a/src/lib/metric-data-getters/cloudwatch.ts
+++ b/src/lib/metric-data-getters/cloudwatch.ts
@@ -1,4 +1,4 @@
-import { _UnmarshalledMetricDataResult as CloudWatchResult } from '@aws-sdk/client-cloudwatch-node';
+import { _UnmarshalledMetricDataResult as CloudWatchResult } from '@aws-sdk/client-cloudwatch';
 import { add, Duration, isBefore, isEqual } from 'date-fns';
 import _ from 'lodash';
 

--- a/src/lib/metric-data-getters/cloudwatch.ts
+++ b/src/lib/metric-data-getters/cloudwatch.ts
@@ -1,4 +1,4 @@
-import { _UnmarshalledMetricDataResult as CloudWatchResult } from '@aws-sdk/client-cloudwatch';
+import { MetricDataResult as CloudWatchResult } from '@aws-sdk/client-cloudwatch';
 import { add, Duration, isBefore, isEqual } from 'date-fns';
 import _ from 'lodash';
 

--- a/src/lib/metric-data-getters/elasticache.ts
+++ b/src/lib/metric-data-getters/elasticache.ts
@@ -1,5 +1,5 @@
 
-import * as cw from '@aws-sdk/client-cloudwatch-node';
+import * as cw from '@aws-sdk/client-cloudwatch';
 import base32Encode from 'base32-encode'; // eslint-disable-line import/default
 import { Duration, milliseconds, millisecondsToSeconds } from 'date-fns';
 import fnv from 'fnv-plus';

--- a/src/lib/metric-data-getters/rds.ts
+++ b/src/lib/metric-data-getters/rds.ts
@@ -1,4 +1,4 @@
-import * as cw from '@aws-sdk/client-cloudwatch-node';
+import * as cw from '@aws-sdk/client-cloudwatch';
 import { Duration, milliseconds, millisecondsToSeconds } from 'date-fns';
 import _ from 'lodash';
 

--- a/src/lib/metric-data-getters/sqs.ts
+++ b/src/lib/metric-data-getters/sqs.ts
@@ -1,4 +1,4 @@
-import * as cw from '@aws-sdk/client-cloudwatch-node';
+import * as cw from '@aws-sdk/client-cloudwatch';
 import { Duration, milliseconds, millisecondsToSeconds } from 'date-fns';
 import _ from 'lodash';
 


### PR DESCRIPTION
What
----

[@aws-sdk/client-cloudwatch-node](https://www.npmjs.com/package/@aws-sdk/client-cloudwatch-node) and [@aws-sdk/client-resource-groups-tagging-api-node](https://www.npmjs.com/package/@aws-sdk/client-resource-groups-tagging-api-node) have been [deprecated](https://github.com/aws/aws-sdk-js-v3/issues/1397) and replaced with [@aws-sdk/client-cloudwatch](https://www.npmjs.com/package/@aws-sdk/client-cloudwatch) and [@aws-sdk/client-resource-groups-tagging-api ](https://www.npmjs.com/package/@aws-sdk/client-resource-groups-tagging-api)respectively

This updated the packages and imports where required

[Modular AWS SDK for JavaScript](https://aws.amazon.com/blogs/developer/modular-aws-sdk-for-javascript-release-candidate/)

How to review
-------------

- deploy to a dev env
- check affected metrics have data

Who can review
---------------

not @kr8n3r

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
