### PR TITLE
Upgrade typescript and fix unknown ypes

### DIFF
--- a/acceptance-tests/main.test.ts
+++ b/acceptance-tests/main.test.ts
@@ -40,7 +40,7 @@ describe('paas-admin', () => {
       try {
         await axios.request({ maxRedirects: 0, url: PAAS_ADMIN_BASE_URL });
       }
-      catch(rejection) {
+      catch(rejection: any) {
         expect(rejection.response.status).toEqual(302);
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "ts-jest": "^27.0.5",
         "ts-loader": "^9.2.5",
         "ts-node": "^10.2.1",
-        "typescript": "^4.3.5",
+        "typescript": "^4.4.2",
         "webpack": "^5.38.1",
         "webpack-cli": "^4.8.0",
         "webpack-node-externals": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ts-jest": "^27.0.5",
     "ts-loader": "^9.2.5",
     "ts-node": "^10.2.1",
-    "typescript": "^4.3.5",
+    "typescript": "^4.4.2",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.8.0",
     "webpack-node-externals": "^3.0.0"

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -244,7 +244,7 @@ export class AccountsClient {
       const data: IAccountsUserResponse = response.data;
 
       return parseUser(data);
-    } catch (err) {
+    } catch (err: any) {
       if (err.response.status === 404) {
         return;
       }

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -192,7 +192,7 @@ export default class UAAClient {
     try {
       const response = await this.request('get', `/Users/${userGUID}`);
       return response.data as types.IUaaUser;
-    } catch (err) {
+    } catch (err: any) {
       if (err.response.status === 404) {
         return null;
       }


### PR DESCRIPTION
What
----

In Typescript 4.4.2 there is a breaking change https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#using-unknown-in-catch-variables

Our acceptance tests that run on staging and prod fail.

This adds type `any` to variable in the try/catch block.

more info:
- https://github.com/microsoft/TypeScript/pull/41013
- https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables

How to review
-------------

- if you have a dev env, deploy there and run the acceptance test
-  alternatively, obtain envs from cf and credhub, export variable to point to dev01 or dev02 and run `npm run test:acceptance`

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
