### PR TITLE
Downgrade and pin axios to 0.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "paas-admin",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -13,7 +14,7 @@
         "@babel/preset-env": "^7.15.6",
         "@babel/preset-react": "^7.14.5",
         "aws-sdk": "^2.988.0",
-        "axios": "^0.21.4",
+        "axios": "0.21.1",
         "babel-jest": "^27.2.0",
         "base32-encode": "^1.2.0",
         "compression": "^1.7.4",
@@ -5240,11 +5241,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/axobject-query": {
@@ -24425,11 +24426,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.10.0"
       }
     },
     "axobject-query": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@babel/preset-env": "^7.15.6",
     "@babel/preset-react": "^7.14.5",
     "aws-sdk": "^2.988.0",
-    "axios": "^0.21.4",
+    "axios": "0.21.1",
     "babel-jest": "^27.2.0",
     "base32-encode": "^1.2.0",
     "compression": "^1.7.4",


### PR DESCRIPTION
What
----

Upgrade to 0.21.4 to resolve a CVE broke our password reset functionality

It seems there are issues bein reiased by the community for the latest release

https://github.com/axios/axios/issues

This downgrades to a working 0.21.1 release

How to review
-------------

test password reset in staging https://admin.london.staging.cloudpipeline.digital/password/request-reset

Who can review
---------------
not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
