### PR TITLE
Add `chartset=utf-8` to UAA axios password reset request

### DIFF
--- a/src/lib/uaa/uaa.test.ts
+++ b/src/lib/uaa/uaa.test.ts
@@ -283,7 +283,7 @@ describe('lib/uaa test suite', () => {
         const acceptHeader = this.req.headers['accept'];
         const contentTypeHeader = this.req.headers['content-type'];
 
-        if (acceptHeader !== 'application/json' || contentTypeHeader !== 'application/json') {
+        if (acceptHeader !== 'application/json' || contentTypeHeader !== 'application/json;chartset=utf-8') {
           return [
             404,
             {

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -305,7 +305,7 @@ export default class UAAClient {
       data: username,
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json;chartset=utf-8',
       },
     });
 


### PR DESCRIPTION
What
----

In axios release v0.21.2 they have [removed the charset field from application/json Content-type header](axios/axios#2154) which UAA api doesn't like so paas-admin password reset requests have been 404ing for users.

This adds the charset back so all is good now.

How to review
-------------

- check out staging https://admin.london.staging.cloudpipeline.digital/password/request-reset
- or deploy to own dev env

Who can review
---------------
not @kr8n3r 

https://user-images.githubusercontent.com/3758555/133302167-8b72c4f5-1328-48d0-bd5e-664f61483e45.mov

![Screenshot 2021-09-14 at 18 05 45](https://user-images.githubusercontent.com/3758555/133302295-f02061e8-3826-425a-a8ad-796db7ec0af9.png)





---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
