### PR TITLE
Add last logon infromation to organisation user list

### DIFF
--- a/src/components/org-users/_org-users.scss
+++ b/src/components/org-users/_org-users.scss
@@ -12,27 +12,6 @@
   @include govuk-media-query($from:desktop) {
     .name {
       min-width: 280px;
-      width: 20%;
-    }
-
-    .authentication {
-      width: 15%;
-    }
-
-    th.is-billing-manager {
-      width: 15%;
-    }
-
-    th.is-org-manager {
-      width: 15%;
-    }
-
-    th.is-org-auditor {
-      width: 15%;
-    }
-
-    th.spaces {
-      width: 20%;
     }
   }
 }

--- a/src/components/org-users/controllers.test.tsx
+++ b/src/components/org-users/controllers.test.tsx
@@ -129,6 +129,7 @@ describe('org-users test suite', () => {
     expect(response.body).toContain('Custom-origin-1');
     expect(response.body).toContain('Custom-origin-2');
     expect(response.body).toContain('Custom-origin-3');
+    expect(response.body).toContain('Last login');
     expect(
       spacesMissingAroundInlineElements(response.body as string),
     ).toHaveLength(0);

--- a/src/components/org-users/views.test.tsx
+++ b/src/components/org-users/views.test.tsx
@@ -18,6 +18,9 @@ import {
   SuccessPage,
 } from './views';
 
+import { format } from 'date-fns';
+import { DATE_TIME } from '../../layouts';
+
 describe(Permission, () => {
   it('should produce a checkbox with appropriate values provided', () => {
     const markup = shallow(
@@ -326,6 +329,9 @@ describe(OrganizationUsersPage, () => {
     } as unknown) as IUserRoles,
   };
 
+  const lastLogonTime = + new Date()
+  const lastLogonTimeFormatted = format(lastLogonTime, DATE_TIME)
+
   it('should produce the org users view', () => {
     const markup = shallow(
       <OrganizationUsersPage
@@ -333,7 +339,10 @@ describe(OrganizationUsersPage, () => {
         organizationGUID="ORG_GUID"
         privileged={false}
         users={users}
-        userOriginMapping={{ USER_GUID: 'origin-name', USER_GUID_2: 'uaa' }}
+        userExtraInfo={{
+          "USER_GUID": { origin: 'origin-name', lastLogonTime: undefined },
+          "USER_GUID_2": { origin: 'uaa', lastLogonTime: lastLogonTime },
+        }}
       />,
     );
     const $ = cheerio.load(markup.html());
@@ -344,6 +353,7 @@ describe(OrganizationUsersPage, () => {
     expect($('li').text()).toContain(space.entity.name);
     expect($('.tick-symbol').length).toEqual(2);
     expect($('.govuk-table__body td:nth-child(4)').text()).toContain('no');
+    expect($('thead th:nth-child(6)').text()).not.toContain('Last login');
   });
 
   it('should produce the org users view when being privileged', () => {
@@ -353,14 +363,24 @@ describe(OrganizationUsersPage, () => {
         organizationGUID="ORG_GUID"
         privileged={true}
         users={users}
-        userOriginMapping={{ USER_GUID: 'origin-name', USER_GUID_2: 'uaa' }}
+        userExtraInfo={{
+          "USER_GUID": { origin: 'origin-name', lastLogonTime: undefined },
+          "USER_GUID_2": { origin: 'uaa', lastLogonTime: lastLogonTime },
+        }}
       />,
     );
+
+    
+
     const $ = cheerio.load(markup.html());
     expect($('tbody th:first-of-type').text()).toContain('user-name');
     expect($('tbody th:first-of-type a').length).toEqual(2);
     expect($('td').text()).toContain('Origin-name');
     expect($('td').text()).toContain('Password');
+    expect($('thead th:nth-child(7)').text()).toContain('Last login');
+    expect($('tbody tr:nth-child(1) td:nth-child(7)').text()).toContain('No login');
+    expect($('tbody tr:nth-child(2) td:nth-child(7)').text()).toContain(lastLogonTimeFormatted);
+    
   });
 });
 

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -1,4 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
+import { format } from 'date-fns';
+import { DATE_TIME } from '../../layouts';
 
 import { capitalize } from '../../layouts';
 import { NoTick, Tick } from '../../layouts/partials';
@@ -90,12 +92,19 @@ export interface IUserRolesByGuid {
   readonly [guid: string]: IUserRoles;
 }
 
+export interface IExtraUserInfo {
+  readonly [key: string]: {
+    readonly origin: string; 
+    readonly lastLogonTime?: number;
+  }
+}
+
 interface IOrganizationUsersPageProperties {
   readonly linkTo: RouteLinker;
   readonly organizationGUID: string;
   readonly privileged: boolean;
   readonly users: IUserRolesByGuid;
-  readonly userOriginMapping: { readonly [key: string]: string };
+  readonly userExtraInfo: IExtraUserInfo;
 }
 
 export function Permission(props: IPermissionProperties): ReactElement {
@@ -733,6 +742,13 @@ export function OrganizationUsersPage(
                 <th className="govuk-table__header spaces" scope="col">
                   Spaces assigned or can access
                 </th>
+                {props.privileged ? (
+                  <th className="govuk-table__header" scope="col">
+                    Last login
+                  </th>
+                ) : (
+                  <></>
+                )}
               </tr>
             </thead>
             <tbody className="govuk-table__body">
@@ -756,7 +772,7 @@ export function OrganizationUsersPage(
                   {props.privileged ? (
                     <td className="govuk-table__cell">
                       <span className="govuk-visually-hidden">Authentication method:</span> {
-                        props.userOriginMapping[guid] === 'uaa' ? 'Password' : capitalize(props.userOriginMapping[guid])
+                        props.userExtraInfo[guid].origin === 'uaa' ? 'Password' : capitalize(props.userExtraInfo[guid].origin)
                       }
                     </td>
                   ) : (
@@ -803,6 +819,17 @@ export function OrganizationUsersPage(
                       ))}
                     </ul>
                   </td>
+                  {props.privileged ? (
+                    <td className="govuk-table__cell">
+                      {props.userExtraInfo[guid].lastLogonTime ? (
+                        format(props.userExtraInfo[guid].lastLogonTime!, DATE_TIME)
+                      ) : (
+                        "No login"
+                      )}
+                    </td>
+                  ): (
+                    <></>
+                  )}
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
What
----

For privileged users (admin, org manager) we show information when was the last time the user logged in. This information comes from [UAA](https://docs.cloudfoundry.org/api/uaa/version/75.7.0/index.html#get-3)

How to review
-------------

- run locally or deploy to a dev env
- test pass
- check code makes sense

Visual changes
---------------

**Privileged user view**
![Screenshot 2021-09-16 at 16 55 10](https://user-images.githubusercontent.com/3758555/133645129-5da077fb-9d00-4f7d-baa5-fdf09f19e45d.png)


**Regular user view**

![Screenshot 2021-09-16 at 15 59 41](https://user-images.githubusercontent.com/3758555/133644436-561eadc9-b35a-4d05-8500-515b8359a37e.png)


Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
