### PR TITLE
Feature: Ability to contact organisation's org or billing managers

### DIFF
--- a/src/@types/node-zendesk/index.d.ts
+++ b/src/@types/node-zendesk/index.d.ts
@@ -474,6 +474,7 @@ declare module 'node-zendesk' {
       /**
        * @see {@link https://developer.zendesk.com/rest_api/docs/support/tickets#create-ticket|Zendesk Tickets Create}
        */
+
       interface CreateModel {
           readonly comment: Requests.Comments.CreateModel;
           readonly external_id?: string | null;
@@ -483,6 +484,7 @@ declare module 'node-zendesk' {
           readonly priority?: Priority | null;
           readonly status?: Status | null;
           readonly recipient?: string | null;
+          readonly requester?: Requester;
           readonly requester_id?: ZendeskID;
           readonly submitter_id?: ZendeskID | null;
           readonly assignee_id?: ZendeskID | null;
@@ -492,6 +494,7 @@ declare module 'node-zendesk' {
           readonly collaborators?: ReadonlyArray<any> | null;
           readonly follower_ids?: ReadonlyArray<number> | null;
           readonly email_cc_ids?: ReadonlyArray<number> | null;
+          readonly email_ccs?: ReadonlyArray<EmailCC> | null;
           readonly forum_topic_id?: number | null;
           readonly problem_id?: number | null;
           readonly due_at?: string | null;
@@ -574,6 +577,12 @@ declare module 'node-zendesk' {
           readonly comment_count?: number;
       }
 
+      interface Requester {
+        readonly name: string;
+        readonly email?: string;
+        readonly locale_id?: ZendeskID;
+     }
+
       interface Audit {
           readonly id: ZendeskID;
           readonly ticket_id: ZendeskID;
@@ -587,7 +596,7 @@ declare module 'node-zendesk' {
       interface EmailCC {
           readonly user_id?: ZendeskID;
           readonly user_email?: string;
-          readonly action: string;
+          readonly action?: string;
       }
 
       interface Field {

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -259,6 +259,17 @@ export const router = new Router([
     path: '/platform-admin/create-org',
   },
   {
+    action: platformAdmin.contactOrganisationManagers,
+    name: 'platform-admin.contact-organization-managers',
+    path: '/platform-admin/contact-organisation-managers',
+  },
+  {
+    action: platformAdmin.contactOrganisationManagersPost,
+    method: 'post',
+    name: 'platform-admin.contact-organization-managers.post',
+    path: '/platform-admin/contact-organisation-managers',
+  },
+  {
     action: performance.viewDashboard,
     name: 'performance.view',
     path: '/performance',

--- a/src/components/platform-admin/controllers.test.tsx
+++ b/src/components/platform-admin/controllers.test.tsx
@@ -1,20 +1,61 @@
 import cheerio from 'cheerio';
 import jwt from 'jsonwebtoken';
+import nock from 'nock';
 
 import { spacesMissingAroundInlineElements } from '../../layouts/react-spacing.test';
+import { AccountsClient } from '../../lib/accounts';
 import CloudFoundryClient from '../../lib/cf';
 import { IResponse } from '../../lib/router';
+import UAAClient from '../../lib/uaa';
 import { createTestContext } from '../app/app.test-helpers';
 import { IContext } from '../app/context';
 import { Token } from '../auth';
 import { CLOUD_CONTROLLER_ADMIN } from '../auth/has-role';
 
-import { createOrganization, createOrganizationForm, viewHomepage } from './controllers';
+
+import {
+  constructZendeskRequesterObject,
+  contactOrganisationManagers,
+  contactOrganisationManagersPost,
+  contactOrgManagersZendeskContent,
+  createOrganization,
+  createOrganizationForm,
+  viewHomepage,
+} from './controllers';
 
 jest.mock('../../lib/cf');
+jest.mock('../../lib/accounts');
+jest.mock('../../lib/uaa');
+
 const mockOrg = { metadata: { annotations: { owner: 'TEST_OWNER' } } };
+const contactManagersMockOrg = { guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20', name: 'an-org', suspended: false };
+const mockCfUser = {
+  metadata: {
+    guid: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
+  },
+  entity: {
+    username: 'user@uaa.example.com',
+    organization_roles: ['org_manager'],
+  },
+};
+const mockUaaUser = {
+  id: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
+  userName: 'uaa-id-253@fake.cabinet-office.gov.uk',
+  name: { familyName: 'Stub', givenName: 'User' },
+  emails: [{
+    value: 'uaa-id-253@fake.cabinet-office.gov.uk',
+    primary: false,
+  }],
+};
+const mockAccountsUser = {
+    email: 'uaa-id-253@fake.cabinet-office.gov.uk',
+    username: 'uaa-id-253@fake.cabinet-office.gov.uk',
+    uuid: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
+};
 
 const tokenKey = 'secret';
+
+let nockZD: nock.Scope;
 
 describe(viewHomepage, () => {
   describe('when not a platform admin', () => {
@@ -224,4 +265,242 @@ describe(createOrganization, () => {
       expect(response.body).toContain('New organisation successfully created');
     });
   });
+});
+
+describe(contactOrganisationManagers, () => {
+  describe('when not a platform admin', () => {
+    const time = Math.floor(Date.now() / 1000);
+    const rawToken = {
+      exp: time + 24 * 60 * 60,
+      origin: 'uaa',
+      scope: [],
+      user_id: 'uaa-id-253',
+    };
+    const accessToken = jwt.sign(rawToken, tokenKey);
+
+    const token = new Token(accessToken, [tokenKey]);
+    const ctx: IContext = createTestContext({ token });
+
+    it('should return an error', async () => {
+      await expect(contactOrganisationManagers(ctx, {} as any)).rejects.toThrow(
+        /Not a platform admin/,
+      );
+    });
+  });
+  describe('when platform admin', () => {
+    let ctx: IContext;
+    beforeEach(() => {
+
+      const time = Math.floor(Date.now() / 1000);
+      const rawToken = {
+        exp: time + 24 * 60 * 60,
+        origin: 'uaa',
+        scope: [CLOUD_CONTROLLER_ADMIN],
+        user_id: 'uaa-id-253',
+      };
+      const accessToken = jwt.sign(rawToken, tokenKey);
+
+      const token = new Token(accessToken, [tokenKey]);
+
+      ctx = createTestContext({ token });
+
+      // @ts-ignore
+      CloudFoundryClient.mockClear();
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should render the page correctly', async () => {
+      // @ts-ignore
+      CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ contactManagersMockOrg ]));
+
+      const response = await contactOrganisationManagers(ctx, {} as any);
+
+      expect(response.body).toContain('a7aff246-5f5b-4cf8-87d8-f316053e4a20');
+      expect(response.body).toContain('Contact organisation managers');
+      expect(response.body).toContain('Organisation name');
+      expect(response.body).toContain('Manager role');
+      expect(response.body).toContain('Message');
+    });
+  });
+});
+
+describe(contactOrganisationManagersPost, () => {
+  let ctx: IContext;
+  beforeEach(() => {
+
+    const time = Math.floor(Date.now() / 1000);
+    const rawToken = {
+      exp: time + 24 * 60 * 60,
+      origin: 'uaa',
+      scope: [CLOUD_CONTROLLER_ADMIN],
+      user_id: 'uaa-id-253',
+    };
+    const accessToken = jwt.sign(rawToken, tokenKey);
+
+    const token = new Token(accessToken, [tokenKey]);
+
+    ctx = createTestContext({ token });
+
+    // @ts-ignore
+    CloudFoundryClient.mockClear();
+    // @ts-ignore
+    UAAClient.mockClear();
+    // @ts-ignore
+    AccountsClient.mockClear();
+
+    nock.cleanAll();
+    nockZD = nock(ctx.app.zendeskConfig.remoteUri);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should create a zendesk ticket correctly', async () => {
+    // @ts-ignore
+    CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ contactManagersMockOrg ]));
+     // @ts-ignore
+    CloudFoundryClient.prototype.usersForOrganization.mockReturnValueOnce(Promise.resolve([ mockCfUser ]));
+    // @ts-ignore
+    UAAClient.prototype.getUser.mockReturnValueOnce(Promise.resolve(mockUaaUser));
+    // @ts-ignore
+    AccountsClient.prototype.getUser.mockReturnValueOnce(Promise.resolve(mockAccountsUser));
+
+
+    nockZD
+      .post('/tickets.json')
+      .reply(201, {});
+
+    const response = await contactOrganisationManagersPost(ctx, {}, {
+      organisation: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+      managerRole: 'org_manager',
+      message: 'message text',
+    } as any);
+
+    expect(response.status).toBeUndefined();
+    expect(response.body).toContain('Message has been sent');
+    expect(response.body).toContain('A Zendesk ticket has also been created to track progress');
+  });
+
+  it('should throw validation errors when missing data has been submited', async () => {
+    // @ts-ignore
+    CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ contactManagersMockOrg ]));
+
+    const response = await contactOrganisationManagersPost(ctx, {}, {} as any);
+
+    expect(response.status).toEqual(400);
+    expect(response.body).not.toContain('We have received your request');
+    expect(response.body).toContain('Error');
+    expect(response.body).toContain('Select an organisation');
+    expect(response.body).toContain('Select a manager role');
+    expect(response.body).toContain('Enter your message');
+  });
+
+  it('should throw and error if org has no managers of selected type', async () => {
+    // @ts-ignore
+    CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ contactManagersMockOrg ]));
+     // @ts-ignore
+    CloudFoundryClient.prototype.usersForOrganization.mockReturnValueOnce(Promise.resolve([]));
+    // @ts-ignore
+    UAAClient.prototype.getUser.mockReturnValueOnce(Promise.resolve([]));
+    // @ts-ignore
+    AccountsClient.prototype.getUser.mockReturnValueOnce(Promise.resolve([mockAccountsUser]));
+
+    const response = await contactOrganisationManagersPost(ctx, {}, {
+      organisation: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+      managerRole: 'billing_manager',
+      message: 'message text',
+    } as any);
+
+    expect(response.status).toEqual(400);
+    expect(response.body).not.toContain('We have received your request');
+    expect(response.body).toContain('Error');
+    expect(response.body).toContain('Select organisation does not have any of the selected manager roles');
+  });
+
+});
+
+describe('helper functions', () => {
+  describe(contactOrgManagersZendeskContent, () => {
+    const zendeskEmailContent = contactOrgManagersZendeskContent({
+      organisation: 'test',
+      message: 'Message content',
+      managerRole: 'billing_manager',
+    },'narnia');
+
+    // whitespace matters
+    const expectedOutput = `
+Message content
+
+You are receiving this email as you are listed as a billing manager of the test organisation in our NARNIA region.
+
+Thank you,
+GOV.UK PaaS`;
+
+    it('should output expected text', () => {
+      expect(zendeskEmailContent).toEqual(expectedOutput);
+    });
+  });
+
+  describe(constructZendeskRequesterObject, () => {
+
+    it('should object with correct data if user is not null', () => {
+      const expectedOutput = {
+        name: 'Stub User',
+        locale_id: 1176,
+        email: 'stub-user@digital.cabinet-office.gov.uk',
+      };
+
+      const functionOutput = constructZendeskRequesterObject({
+        meta: {
+          version: 0,
+          created: '2019-01-01T00:00:00',
+          lastModified: '2019-01-02T00:00:00',
+        },
+        id: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
+        externalId: 'stub-user',
+        userName: 'stub-user@digital.cabinet-office.gov.uk',
+        origin: 'uaa',
+        active: true,
+        verified: true,
+        zoneId: 'uaa',
+        name: { familyName: 'User', givenName: 'Stub' },
+        emails: [
+          { value: 'stub-user@digital.cabinet-office.gov.uk', primary: true },
+        ],
+        schemas: [ 'urn:scim:schemas:core:1.0' ],
+        groups: [
+          {
+            display: 'cloud_controller.read',
+            type: 'DIRECT',
+            value: '177eb558-5e9a-42a5-9316-438aee2b88a4',
+          },
+        ],
+        phoneNumbers: [],
+        approvals: [],
+        passwordLastModified: '2019-01-01T00:00:00',
+        previousLogonTime: 1527032725657,
+        lastLogonTime: 1527032725657,
+      });
+
+      expect(functionOutput).toMatchObject(expectedOutput);
+    });
+
+    it('should output object with substitute data if user is null', () => {
+
+      const userIsNull = constructZendeskRequesterObject(null);
+
+      const expecteNullUserOutput = {
+        name: 'GOV.UK PaaS Admin',
+        locale_id: 1176,
+        email: 'gov-uk-paas-support@digital.cabinet-office.gov.uk',
+      };
+
+      expect(userIsNull).toMatchObject(expecteNullUserOutput);
+    });
+  });
+
 });

--- a/src/components/platform-admin/controllers.tsx
+++ b/src/components/platform-admin/controllers.tsx
@@ -1,20 +1,29 @@
+import * as zendesk from 'node-zendesk';
 import React from 'react';
 
 import { Template } from '../../layouts';
+import { AccountsClient, IAccountsUser } from '../../lib/accounts';
 import CloudFoundryClient from '../../lib/cf';
 import { IParameters, IResponse, NotAuthorisedError } from '../../lib/router';
+import UAAClient, { IUaaUser } from '../../lib/uaa';
 import { IContext } from '../app/context';
 import { Token } from '../auth';
+import { IValidationError } from '../errors/types';
 
 import { validateNewOrganization } from './validators';
 import {
+  ContactOrganisationManagersConfirmationPage,
+  ContactOrganisationManagersPage,
   CreateOrganizationPage,
   CreateOrganizationSuccessPage,
+  IContactOrganisationManagersPageValues,
   INewOrganizationUserBody,
   PlatformAdministratorPage,
 } from './views';
 
+
 const TITLE_CREATE_ORG = 'Create Organisation';
+const TITLE_EMAIL_ORG_MANAGERS = 'Email organisation managers';
 
 function throwErrorIfNotAdmin({ token }: { readonly token: Token }): void {
   if (token.hasAdminScopes()) {
@@ -22,6 +31,71 @@ function throwErrorIfNotAdmin({ token }: { readonly token: Token }): void {
   }
 
   throw new NotAuthorisedError('Not a platform admin');
+}
+
+// form field validations
+function validateEmailMessage({ message }: IContactOrganisationManagersPageValues): ReadonlyArray<IValidationError> {
+  const errors = [];
+
+  if (!message) {
+    errors.push({
+      field: 'message',
+      message: 'Enter your message',
+    });
+  }
+
+  return errors;
+}
+
+function validateOrgSelection({ organisation }: IContactOrganisationManagersPageValues): ReadonlyArray<IValidationError> {
+  const errors = [];
+
+  if (!organisation) {
+    errors.push({
+      field: 'organisation',
+      message: 'Select an organisation',
+    });
+  }
+
+  return errors;
+}
+
+function validateManagerRoleSelection({ managerRole }: IContactOrganisationManagersPageValues): ReadonlyArray<IValidationError> {
+  const errors = [];
+
+  if (!managerRole) {
+    errors.push({
+      field: 'managerRole',
+      message: 'Select a manager role',
+    });
+  }
+
+  return errors;
+}
+
+// body of the zendesk email
+export function contactOrgManagersZendeskContent(variables: IContactOrganisationManagersPageValues, region: string): string {
+// whitespace matters
+  return `
+${variables.message}
+
+You are receiving this email as you are listed as ${variables.managerRole === 'org_manager' ? 'an organisation' : 'a billing'} manager of the ${variables.organisation} organisation in our ${region.toUpperCase()} region.
+
+Thank you,
+GOV.UK PaaS`;
+}
+
+// construct requester object for zendesk api
+export function constructZendeskRequesterObject(user: IUaaUser | null): any {
+  const user_name = user === null ? 'GOV.UK PaaS Admin' : `${user!.name.givenName} ${user!.name.familyName}`;
+  const user_email = user === null ? 'gov-uk-paas-support@digital.cabinet-office.gov.uk' : user!.emails[0].value;
+
+return {
+    name: user_name,
+    // en-gb via https://developer.zendesk.com/api-reference/ticketing/account-configuration/locales/#list-available-public-locales
+    locale_id: 1176,
+    email: user_email,
+  };
 }
 
 export async function createOrganizationForm(ctx: IContext, _params: IParameters): Promise<IResponse> {
@@ -100,6 +174,168 @@ export async function createOrganization(
       linkTo={ctx.linkTo}
       organizationGUID={organization.guid}
     />),
+  };
+}
+
+// intial form display
+export async function contactOrganisationManagers(
+  ctx: IContext, _params: IParameters,
+): Promise<IResponse> {
+  throwErrorIfNotAdmin(ctx);
+
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const orgsList = (await cf.v3Organizations()).filter(
+    org => !org.name.match(/^(CATS|ACC|BACC|SMOKE|PERF|AIVENBACC|ASATS)-/),
+  );
+
+  const template = new Template(ctx.viewContext, TITLE_EMAIL_ORG_MANAGERS);
+
+return {
+    body: template.render(<ContactOrganisationManagersPage
+      linkTo={ctx.linkTo}
+      csrf={ctx.viewContext.csrf}
+      orgs={orgsList}
+    />),
+  };
+}
+
+// when form is submitted
+export async function contactOrganisationManagersPost(
+  ctx: IContext, _params: IParameters, body: IContactOrganisationManagersPageValues,
+): Promise<IResponse> {
+  throwErrorIfNotAdmin(ctx);
+
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const uaa = new UAAClient({
+    apiEndpoint: ctx.app.uaaAPI,
+    clientCredentials: {
+      clientID: ctx.app.oauthClientID,
+      clientSecret: ctx.app.oauthClientSecret,
+    },
+  });
+
+  const accountsClient = new AccountsClient({
+    apiEndpoint: ctx.app.accountsAPI,
+    logger: ctx.app.logger,
+    secret: ctx.app.accountsSecret,
+  });
+
+  const errors = [];
+
+  // check if any fields are missing
+  // if so, create error messages
+  errors.push(
+    ...validateOrgSelection(body),
+    ...validateManagerRoleSelection(body),
+    ...validateEmailMessage(body),
+  );
+
+  const template = new Template(ctx.viewContext);
+  const orgsList = (await cf.v3Organizations()).filter(
+    org => !org.name.match(/^(CATS|ACC|BACC|SMOKE|PERF|AIVENBACC|ASATS)-/),
+  );
+  let orgUserEmails:ReadonlyArray<any> = [];
+
+  // get email adfresses for all managers for the selected type and organisation
+  if (body.organisation) {
+    const usersForGivenOrg = await cf.usersForOrganization(body.organisation);
+    // we need to look into paas-accounts for their actual email address
+    const filteredManagers = await Promise.all(
+      usersForGivenOrg.filter(user => user.entity.organization_roles.includes(body.managerRole))
+        .map(async manager => await accountsClient.getUser(manager.metadata.guid)),
+    );
+
+    // create a zendesk api-friendly array of email address objects
+    orgUserEmails = Array.from(
+      new Set(
+        filteredManagers
+          .filter((user): user is IAccountsUser => !!user)
+          .map(user => ({ user_email: user.email })),
+      ),
+    );
+
+    // if manager role type has been selected but there are no users with selected role, update the error message
+    // message property is readonly so cannot just update the message
+    if (orgUserEmails.length === 0 && body.managerRole ) {
+      /* istanbul ignore next */
+      const managerRoleErrorIndex = errors.findIndex(
+        error => error.field === 'managerRole',
+      );
+      errors.splice(managerRoleErrorIndex, 0, { field: 'managerRole', message: 'Select organisation does not have any of the selected manager roles' });
+    }
+  }
+
+  // if there are errors, rerender the page with error messages
+  if (errors.length > 0) {
+
+    template.title = `Error: ${TITLE_EMAIL_ORG_MANAGERS}`;
+
+    return {
+      body: template.render(<ContactOrganisationManagersPage
+        csrf={ctx.viewContext.csrf}
+        linkTo={ctx.linkTo}
+        errors={errors}
+        orgs={orgsList}
+        values={body}
+      />),
+      status: 400,
+    };
+  }
+
+  // get org name from selected org guid
+  const orgDisplayName = orgsList
+    .filter(org => org.guid === body.organisation)
+    .map(org => org.name)
+    .toString();
+
+  // get admin user details to populate requester field for zendesk
+  const adminUser: IUaaUser | null = await uaa.getUser(ctx.token.userID);
+
+ // send zendesk api request with all the data
+  const client = zendesk.createClient(ctx.app.zendeskConfig);
+  await client.tickets.create({
+    ticket: {
+      comment: {
+        body: contactOrgManagersZendeskContent({
+          organisation: orgDisplayName,
+          message: body.message,
+          managerRole: body.managerRole,
+        },
+        ctx.viewContext.location),
+      },
+      subject: '[PaaS Support] About your organisation on GOV.UK PaaS',
+      status: 'pending',
+      tags: ['govuk_paas_support'],
+      requester: constructZendeskRequesterObject(adminUser),
+      email_ccs: orgUserEmails,
+    },
+  });
+
+  template.title = 'Message has been sent';
+
+  return {
+    body: template.render(
+      <ContactOrganisationManagersConfirmationPage
+        linkTo={ctx.linkTo}
+        heading={'Message has been sent'}
+        text={'A Zendesk ticket has also been created to track progress.'}
+      >
+        <a className="govuk-link"
+          href="/platform-admin/contact-organisation-managers">
+            Contact more organisation managers
+        </a>.
+      </ContactOrganisationManagersConfirmationPage>,
+    ),
   };
 }
 

--- a/src/components/platform-admin/views.test.tsx
+++ b/src/components/platform-admin/views.test.tsx
@@ -2,7 +2,13 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { IParameters } from '../../lib/router';
-import { CreateOrganizationPage, CreateOrganizationSuccessPage } from './views';
+
+import {
+  ContactOrganisationManagersConfirmationPage,
+  ContactOrganisationManagersPage,
+  CreateOrganizationPage,
+  CreateOrganizationSuccessPage,
+} from './views';
 
 function linker(route: string, params?: IParameters): string {
   return `__LINKS_TO__${route}_WITH_${(new URLSearchParams(params)).toString()}`;
@@ -21,7 +27,7 @@ describe(CreateOrganizationPage, () => {
       csrf="CSRF_TOKEN"
       linkTo={linker}
       values={{ organization: '<script>alert("pwnd by test");</script>' }}
-      owners={[{ name: `<em>hacking</em>`, owner: '<strong>Hackers</strong>' }]}
+      owners={[{ name: '<em>hacking</em>', owner: '<strong>Hackers</strong>' }]}
     />);
 
     expect(markup.find('input#organization')).toHaveLength(1);
@@ -49,5 +55,79 @@ describe(CreateOrganizationSuccessPage, () => {
 
     expect(markup.html())
       .toContain('href="__LINKS_TO__admin.organizations.users.invite_WITH_organizationGUID=ORG_GUID"');
+  });
+});
+
+describe(ContactOrganisationManagersPage, () => {
+  it('should correctly render the form', () => {
+    const orgs = [{ name: 'a-different-org', guid: '123', suspended: false }];
+    const markup = shallow(<ContactOrganisationManagersPage
+      csrf="CSRF_TOKEN"
+      linkTo={linker}
+      orgs={orgs}
+    />);
+
+    expect(markup.find('#organisation').text()).toContain('a-different-org');
+    expect(markup.find('#managerRole').text()).toContain('Billing manager');
+    expect(markup.find('#managerRole').text()).toContain('Organisation manager');
+  });
+
+  it('should correctly render the form errors', () => {
+    const orgs = [{ name: 'a-different-org', guid: '123', suspended: false }];
+    const markup = shallow(<ContactOrganisationManagersPage
+      csrf="CSRF_TOKEN"
+      linkTo={linker}
+      orgs={orgs}
+      errors={
+        [
+          { field: 'organisation', message: 'Select an organisation' },
+          { field: 'managerRole', message: 'Select a manager role' },
+          { field: 'message', message: 'Enter your message' },
+        ]
+      }
+    />);
+
+    expect(markup.find('.govuk-error-summary')).toHaveLength(1);
+    expect(markup.find('.govuk-error-summary li')).toHaveLength(3);
+    expect(markup.find('.govuk-error-message')).toHaveLength(3);
+    expect(markup.find('#organisation-error').text()).toContain('Select an organisation');
+    expect(markup.find('#managerRole-error').text()).toContain('Select a manager role');
+    expect(markup.find('#message-error').text()).toContain('Enter your message');
+  });
+
+  it('should use provided form values on resubmission', () => {
+    const orgs = [{ name: 'a-different-org', guid: '123', suspended: true }];
+    const markup = shallow(<ContactOrganisationManagersPage
+      csrf="CSRF_TOKEN"
+      linkTo={linker}
+      orgs={orgs}
+      values={{
+        organisation: '123',
+        managerRole: 'billing_manager',
+        message: 'Text message',
+      }}
+    />);
+
+    expect(markup.render().find('#organisation option[selected]').text()).toEqual('a-different-org (suspended)');
+    expect(markup.render().find('#managerRole option[selected]').text()).toEqual('Billing manager');
+    expect(markup.render().find('#message').val()).toContain('Text message');
+  });
+});
+
+describe(ContactOrganisationManagersConfirmationPage, () => {
+  const markup = shallow(
+    <ContactOrganisationManagersConfirmationPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        heading={'confirmation panel heading'}
+        text={'confirmation panel text'}
+      >
+        children text
+      </ContactOrganisationManagersConfirmationPage>,
+  );
+
+  it('should render the page with all provided properties', () => {
+    expect(markup.find('.govuk-panel__title').text()).toContain('confirmation panel heading');
+    expect(markup.find('.govuk-panel__body').text()).toContain('confirmation panel text');
+    expect(markup.find('.govuk-body').text()).toContain('children text');
   });
 });

--- a/src/components/platform-admin/views.tsx
+++ b/src/components/platform-admin/views.tsx
@@ -1,10 +1,14 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import { SLUG_REGEX } from '../../layouts';
+import {
+  OrganizationUserRoles,
+} from '../../lib/cf/types';
 import { RouteLinker } from '../app';
 import { IValidationError } from '../errors/types';
 import { SuccessPage } from '../org-users/views';
 import { owners } from '../organizations/owners';
+
 
 interface IProperties {
   readonly linkTo: RouteLinker;
@@ -22,15 +26,38 @@ export interface INewOrganizationUserBody {
 interface IFormProperties extends IProperties {
   readonly csrf: string;
   readonly errors?: ReadonlyArray<IValidationError>;
-  readonly values?: INewOrganizationUserBody;
 }
 
 interface ICreateOrganizationPageProperties extends IFormProperties {
+  readonly values?: INewOrganizationUserBody;
   readonly owners: ReadonlyArray<{
     readonly name: string;
     readonly owner: string;
   }>;
 }
+
+export interface IContactOrganisationManagersPageValues {
+  readonly organisation: string;
+  readonly message: string;
+  readonly managerRole: OrganizationUserRoles;
+}
+
+interface IContactOrganisationManagersPageProperties extends IFormProperties {
+  readonly orgs: ReadonlyArray<{
+    readonly guid: string;
+    readonly name: string;
+    readonly suspended: boolean;
+  }>;
+  readonly values?: IContactOrganisationManagersPageValues;
+}
+
+interface ContactOrganisationManagersConfirmationPageProperties {
+  readonly heading: string;
+  readonly text: string;
+  readonly children: ReactNode;
+  readonly linkTo: RouteLinker;
+}
+
 
 function Costs(props: IFormProperties): ReactElement {
   return (
@@ -150,6 +177,11 @@ function Organizations(props: IProperties): ReactElement {
         <li>
           <a className="govuk-link" href={props.linkTo('admin.reports.organizations')}>
             View trial and billable organisations
+          </a>
+        </li>
+        <li>
+          <a className="govuk-link" href={props.linkTo('platform-admin.contact-organization-managers')}>
+            Contact organisation managers
           </a>
         </li>
       </ul>
@@ -274,11 +306,197 @@ export function CreateOrganizationPage(props: ICreateOrganizationPageProperties)
 
 export function CreateOrganizationSuccessPage(props: ICreateOrganizationSuccessPageProperties): ReactElement {
   return (
-    <SuccessPage 
-    linkTo={props.linkTo} 
+    <SuccessPage
+    linkTo={props.linkTo}
     organizationGUID={props.organizationGUID}
     heading={'New organisation successfully created'}
     text={'You still need to invite people and assign permissions.'}
     >
   </SuccessPage>);
+}
+
+export function ContactOrganisationManagersPage(props: IContactOrganisationManagersPageProperties): ReactElement {
+  return (<div className="govuk-grid-row">
+    <div className="govuk-grid-column-two-thirds">
+      <form method="post" noValidate>
+        <h1 className="govuk-heading-xl">Contact organisation managers</h1>
+
+        <input type="hidden" name="_csrf" value={props.csrf} />
+
+        {props.errors
+          ? <div className="govuk-error-summary" aria-labelledby="error-summary-title"
+              role="alert" tabIndex={-1} data-module="govuk-error-summary">
+              <h2 className="govuk-error-summary__title" id="error-summary-title">
+                There is a problem
+              </h2>
+              <div className="govuk-error-summary__body">
+                <ul className="govuk-list govuk-error-summary__list">
+                  {props.errors.map((error, index) => (
+                    <li key={index}><a href={`#${error.field}`}>{error.message}</a></li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          : null
+        }
+
+        <p className="govuk-body">
+        This form will create a Zendesk ticket and send an email to all selected managers of an organisation.
+        </p>
+
+        <div className={`govuk-form-group ${
+            props.errors?.some(e => e.field === 'organisation')
+              ? 'govuk-form-group--error'
+              : ''
+          }`}>
+          <label className="govuk-label" htmlFor="organisation">
+            Organisation name
+          </label>
+          {props.errors
+            ?.filter(error => error.field === 'organisation')
+            .map((error, index) => (
+              <span
+                key={index}
+                id="organisation-error"
+                className="govuk-error-message"
+              >
+                <span className="govuk-visually-hidden">Error:</span>{' '}
+                {error.message}
+              </span>
+            ))}
+          <select
+            className={`govuk-select ${
+              props.errors?.some(e => e.field === 'organisation')
+                  ? 'govuk-select--error'
+                  : ''
+              }`}
+            id="organisation"
+            name="organisation"
+            aria-describedby={
+              props.errors?.some(e => e.field === 'organisation')
+                ? 'organisation-error'
+                : ''
+            }
+          >
+            <option value="">Select an organisation</option>
+            {props.orgs.map(org => (
+              <option key={org.guid} selected={org.guid === props.values?.organisation} value={org.guid}>{org.name} { org.suspended ? '(suspended)' : null }</option>
+            ))},
+          </select>
+        </div>
+
+        <div className={`govuk-form-group ${
+            props.errors?.some(e => e.field === 'managerRole')
+              ? 'govuk-form-group--error'
+              : ''
+          }`}>
+          <label className="govuk-label" htmlFor="managerRole">
+            Manager role
+          </label>
+          {props.errors
+            ?.filter(error => error.field === 'managerRole')
+            .map((error, index) => (
+              <span
+                key={index}
+                id="managerRole-error"
+                className="govuk-error-message"
+              >
+                <span className="govuk-visually-hidden">Error:</span>{' '}
+                {error.message}
+              </span>
+            ))}
+          <select
+            className={`govuk-select ${
+              props.errors?.some(e => e.field === 'managerRole')
+                  ? 'govuk-select--error'
+                  : ''
+              }`}
+            id="managerRole"
+            name="managerRole"
+            aria-describedby={
+              props.errors?.some(e => e.field === 'managerRole')
+                ? 'managerRole-error'
+                : ''
+            }
+          >
+            <option value="">Select manager role</option>
+            <option value="billing_manager" selected={props.values?.managerRole === 'billing_manager'}>Billing manager</option>
+            <option value="org_manager" selected={props.values?.managerRole === 'org_manager'}>Organisation manager</option>
+          </select>
+        </div>
+
+        <div className={`govuk-form-group ${
+            props.errors?.some(e => e.field === 'message')
+              ? 'govuk-form-group--error'
+              : ''
+          }`}>
+          <label className="govuk-label" htmlFor="message">
+            Message
+          </label>
+          {props.errors
+            ?.filter(error => error.field === 'message')
+            .map((error, index) => (
+              <span
+                key={index}
+                id="message-error"
+                className="govuk-error-message"
+              >
+                <span className="govuk-visually-hidden">Error:</span>{' '}
+                {error.message}
+              </span>
+            ))}
+
+          <textarea
+            className={`govuk-textarea ${
+              props.errors?.some(e => e.field === 'message')
+                  ? 'govuk-textarea--error'
+                  : ''
+              }`}
+            id="message"
+            name="message"
+            aria-describedby={
+              props.errors?.some(e => e.field === 'message')
+                ? 'message-error message-hint'
+                : 'message-hint'
+            }
+            rows={8}
+            defaultValue={props.values?.message}
+          />
+        </div>
+
+        <p className="govuk-body">
+        Message will automatically include the following:
+        <span id="message-hint" className="govuk-hint govuk-!-display-block">
+          You are receiving this email as you are listed as a [manager_role] manager of the [organisation_name] organisation in our [paas_region] region.<br /><br />
+          Thank you,<br />
+          GOV.UK PaaS
+          </span>
+        </p>
+
+        <button className="govuk-button" data-module="govuk-button" data-prevent-double-click="true">
+          Send
+        </button>
+      </form>
+    </div>
+
+  </div>);
+}
+
+export function ContactOrganisationManagersConfirmationPage(props: ContactOrganisationManagersConfirmationPageProperties): ReactElement {
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-two-thirds">
+        <div className="govuk-panel govuk-panel--confirmation">
+          <h1 className="govuk-panel__title">
+            {props.heading}
+          </h1>
+          <div className="govuk-panel__body">
+            {props.text}
+          </div>
+        </div>
+
+        <p className="govuk-body">{props.children}</p>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
What
----

Add a contact form to allow platform admins to contact billing or org manager for any organisation on the platform.
On submission, the form creates a Zendesk ticket with a 'pending' status via their API and CC's all managers for the selected type and organisation.

If any form fields are empty or organisation has no manager for the selected role, error messages are shown

How to review
-------------
 - suggest reviewing by commit
 - run locally (with zendesk api credentials from the credentials store)
 or
- test on dev02 https://admin.dev02.dev.cloudpipeline.digital/platform-admin
By default neither of orgs have an managers. add some demo ones for testing


Visuals
---------------

<details>
<summary>default form view</summary>

![default form view](https://user-images.githubusercontent.com/3758555/141321278-f2d78a63-6029-43b7-bea0-c06e90cef63e.png)

</details>

<details>
<summary>form with errors</summary>

![form with errors](https://user-images.githubusercontent.com/3758555/141321076-506a3b42-4b18-453b-8768-bf3233fd92ea.png)

</details>

<details>
    <summary>error if org has no manager of selected type</summary>

![error if org has no manager of selected type)](https://user-images.githubusercontent.com/3758555/141321550-180db4a5-ec8a-4efa-9499-3c1f91ef4489.png)

</details>


<details>
    <summary>success page</summary>

![success page](https://user-images.githubusercontent.com/3758555/141321793-421bbaf3-2ea6-4d7a-83e5-115c582056f1.png)

</details>


Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
