### PR TITLE
[#179507076] Make Zendesk tickets convey urgency when a service is down

### DIFF
--- a/src/components/support/controllers.test.tsx
+++ b/src/components/support/controllers.test.tsx
@@ -341,6 +341,26 @@ describe(controller.HandleSomethingWrongWithServiceFormPost, () => {
     expect(response.status).toBeUndefined();
     expect(response.body).toContain('We have received your message');
   });
+
+  it('should create a ticket with the word "URGENT" toward the front when a service is down', async () => {
+    nockZD
+      .post('/requests.json', (body: any) => {
+        let subject = body["request"]["subject"] as string;
+        return subject.substr(0, (subject.length/2)).includes("URGENT")
+      })
+      .reply(201, {});
+
+    const response = await controller.HandleSomethingWrongWithServiceFormPost(ctx, {}, {
+      name: 'Jeff',
+      email: 'jeff@example.gov.uk',
+      message: 'Help my service is down',
+      affected_paas_organisation: '__fake_org__',
+      impact_severity: 'service-down',
+    } as any);
+
+    expect(response.status).toBeUndefined();
+    expect(response.body).toContain('We have received your message');
+  })
 });
 
 describe(controller.HandleSupportSelectionFormPost, () => {

--- a/src/components/support/controllers.tsx
+++ b/src/components/support/controllers.tsx
@@ -431,6 +431,12 @@ export async function HandleSomethingWrongWithServiceFormPost(
 
   const client = zendesk.createClient(ctx.app.zendeskConfig);
 
+  let subject = ""
+  if(body.impact_severity === "service-down") {
+    subject = `[PaaS Support] URGENT: ${body.affected_paas_organisation} at ${TODAY_DATE.toDateString()}`;
+  } else {
+    subject = `[PaaS Support] ${TODAY_DATE.toDateString()} something wrong in ${body.affected_paas_organisation} live service`;
+  }
   await client.requests.create({
     request: {
       comment: {
@@ -442,7 +448,7 @@ export async function HandleSomethingWrongWithServiceFormPost(
           name: body.name,
         }),
       },
-      subject: `[PaaS Support] ${TODAY_DATE.toDateString()} something wrong in ${body.affected_paas_organisation} live service`,
+      subject: subject,
       requester: {
         email: body.email,
         name: body.name,


### PR DESCRIPTION
What
----

In the past we've missed service down events from tenants because the ticket
subject was identical to less severe problems. By changing the subject when the
severity is high is enough, we hope to avoid that in future.

How to review
-------------
1. Code review
2. In the test I've written, is that the correct way to test the content of a POST request to another service?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
