### PR TITLE
[#179507076] Extend Zendesk ticket urgency to other live service severities

### DIFF
--- a/src/components/support/controllers.test.tsx
+++ b/src/components/support/controllers.test.tsx
@@ -342,24 +342,26 @@ describe(controller.HandleSomethingWrongWithServiceFormPost, () => {
     expect(response.body).toContain('We have received your message');
   });
 
-  it('should create a ticket with the word "URGENT" toward the front when a service is down', async () => {
-    nockZD
-      .post('/requests.json', (body: any) => {
-        let subject = body["request"]["subject"] as string;
-        return subject.substr(0, (subject.length/2)).includes("URGENT")
-      })
-      .reply(201, {});
+  ["service-down", "service-downgraded", "cannot_operate_live"].forEach(impactSeverity => {
+    it('should create a ticket with the word "URGENT" toward the front when a support form severity is "'+impactSeverity+'"', async () => {
+      nockZD
+        .post('/requests.json', (body: any) => {
+          let subject = body["request"]["subject"] as string;
+          return subject.substr(0, (subject.length/2)).includes("URGENT")
+        })
+        .reply(201, {});
 
-    const response = await controller.HandleSomethingWrongWithServiceFormPost(ctx, {}, {
-      name: 'Jeff',
-      email: 'jeff@example.gov.uk',
-      message: 'Help my service is down',
-      affected_paas_organisation: '__fake_org__',
-      impact_severity: 'service-down',
-    } as any);
+      const response = await controller.HandleSomethingWrongWithServiceFormPost(ctx, {}, {
+        name: 'Jeff',
+        email: 'jeff@example.gov.uk',
+        message: 'Help my service is down',
+        affected_paas_organisation: '__fake_org__',
+        impact_severity: impactSeverity,
+      } as any);
 
-    expect(response.status).toBeUndefined();
-    expect(response.body).toContain('We have received your message');
+      expect(response.status).toBeUndefined();
+      expect(response.body).toContain('We have received your message');
+    })
   })
 });
 

--- a/src/components/support/controllers.tsx
+++ b/src/components/support/controllers.tsx
@@ -432,8 +432,9 @@ export async function HandleSomethingWrongWithServiceFormPost(
   const client = zendesk.createClient(ctx.app.zendeskConfig);
 
   let subject = ""
-  if(body.impact_severity === "service-down") {
-    subject = `[PaaS Support] URGENT: ${body.affected_paas_organisation} at ${TODAY_DATE.toDateString()}`;
+  const urgentSeverities = ["service-down", "service-downgraded", "cannot_operate_live"]
+  if(urgentSeverities.includes(body.impact_severity)) {
+    subject = `[PaaS Support] URGENT: ${body.impact_severity} for ${body.affected_paas_organisation} at ${TODAY_DATE.toDateString()}`;
   } else {
     subject = `[PaaS Support] ${TODAY_DATE.toDateString()} something wrong in ${body.affected_paas_organisation} live service`;
   }


### PR DESCRIPTION
What
----
Extends Zendesk ticket urgency to other live service severities 

Now covers:
* service-down
* service-downgraded
* cannot_operate_live

How to review
-------------
1. Code review

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
