### PR TITLE
Filter out more unreal orgs

### DIFF
--- a/src/components/platform-admin/controllers.test.tsx
+++ b/src/components/platform-admin/controllers.test.tsx
@@ -514,6 +514,7 @@ GOV.UK PaaS`;
         lodash.merge(defaultV3Org(), { name: 'ACC-123' }),
         lodash.merge(defaultV3Org(), { name: 'BACC-123' }),
         lodash.merge(defaultV3Org(), { name: 'CATS-123' }),
+        lodash.merge(defaultV3Org(), { name: 'CAT-123' }),
         lodash.merge(defaultV3Org(), { name: 'org b' }),
         lodash.merge(defaultV3Org(), { name: 'SMOKE-' }),
       ];

--- a/src/components/platform-admin/controllers.tsx
+++ b/src/components/platform-admin/controllers.tsx
@@ -93,7 +93,7 @@ export function sortOrganisationsByName(organisations: ReadonlyArray<IV3Organiza
 }
 
 export function filterOutRealOrganisations(organisations: ReadonlyArray<IV3OrganizationResource>): ReadonlyArray<IV3OrganizationResource> {
-  return organisations.filter(org => !org.name.match(/^(CATS|ACC|BACC|SMOKE|PERF|AIVENBACC|ASATS)-/));
+  return organisations.filter(org => !org.name.match(/^(CATS?|ACC|BACC|SMOKE|PERF|AIVENBACC|ASATS)-/));
 }
 
 // construct requester object for zendesk api


### PR DESCRIPTION

What
----

It seems we have some test orgs that begin with CAT not CATS that weren't filtered out.
![stray test org](https://user-images.githubusercontent.com/3758555/145215296-2c915f32-656a-47d6-926e-63d8ecd987c9.png)



This update to the regex and extended test resolve it.

How to review
-------------

- check code
- tests pass

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
