### PR TITLE
Only show table of spaces if spaces exist

### DIFF
--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -441,4 +441,20 @@ describe(SpacesPage, () => {
     expect($('h1').text()).toContain('Status: Suspended');
   })
 
+  it('should not display a table of spaces if there are no spaces', () => {
+    const markup = shallow(
+      <SpacesPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        isAdmin={false}
+        isManager={false}
+        isBillingManager={false}
+        organization={organization}
+        spaces={[]}
+        users={[null]}
+      />)
+
+    const $ = cheerio.load(markup.html());
+    expect($('.govuk-table')).toHaveLength(0);
+  });
+
 });

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -318,6 +318,7 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
           </a>
         </div>
       </details>
+      {props.spaces.length > 0 ?
       <div className="scrollable-table-container">
         <table className="govuk-table">
         <thead className="govuk-table__head">
@@ -390,6 +391,8 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
         </tbody>
       </table>
       </div>
+      : <></>
+      }
     </>
   );
 }


### PR DESCRIPTION
What
----

There is currently a case where org has no spaces, but the table is still rendered - https://admin.cloud.service.gov.uk/organisations/e86ef8a3-ef98-4ae3-8e8a-e007eb566fd9

This work only renders the table if spaces exist.

![before](https://user-images.githubusercontent.com/3758555/145386327-a137bc79-4e1f-4bda-bb8b-ab5370d12e8d.png)

![after](https://user-images.githubusercontent.com/3758555/145386326-1c6e9955-57e9-4cf0-a597-8fb4cfe6fc6e.png)



How to review
-------------

- review code
- tests pass

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
