### PR TITLE
Show expiration notice / days count for trial organisations

### DIFF
--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -457,4 +457,157 @@ describe(SpacesPage, () => {
     expect($('.govuk-table')).toHaveLength(0);
   });
 
+  it('should not show expiration notice / count if the organisation is of type billable', () => {
+
+    const organization = ({
+      metadata: { guid: 'ORG_GUID' },
+      entity: { name: 'org-name' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: {
+        entity: { name: 'name', memory_limit: (5 * GIBIBYTE) / MEBIBYTE },
+      },
+    } as unknown) as IEnhancedOrganization;
+    const space = ({
+      metadata: { guid: 'SPACE_GUID_1' },
+      entity: { name: 'space-name' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: { entity: { memory_limit: (5 * GIBIBYTE) / MEBIBYTE } },
+      running_apps: [null],
+      stopped_apps: [null],
+      serviceInstances: [null],
+    } as unknown) as IEnhancedSpace;
+
+    const markup = shallow(
+      <SpacesPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        isAdmin={false}
+        isManager={false}
+        isBillingManager={false}
+        organization={organization}
+        spaces={[space, { ...space, quota: undefined }]}
+        users={[null]}
+        daysLeftInTrialPeriod={null}
+      />,
+    );
+
+    const $ = cheerio.load(markup.html());
+    expect($('p').text()).not.toContain(
+      'Trial period',
+    );
+  });
+
+  it('should show expiration notice if the trial org is more than 90 days old', () => {
+
+    const organization = ({
+      metadata: { guid: 'ORG_GUID' },
+      entity: { name: 'org-name' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: {
+        entity: { name: 'default', memory_limit: (5 * GIBIBYTE) / MEBIBYTE },
+      },
+    } as unknown) as IEnhancedOrganization;
+    const space = ({
+      metadata: { guid: 'SPACE_GUID_1' },
+      entity: { name: 'space-name' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: { entity: { memory_limit: (5 * GIBIBYTE) / MEBIBYTE } },
+      running_apps: [null],
+      stopped_apps: [null],
+      serviceInstances: [null],
+    } as unknown) as IEnhancedSpace;
+
+    const markup = shallow(
+      <SpacesPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        isAdmin={false}
+        isManager={false}
+        isBillingManager={false}
+        organization={organization}
+        spaces={[space, { ...space, quota: undefined }]}
+        users={[null]}
+        daysLeftInTrialPeriod={-2}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('p').text()).toContain(
+      'Trial period has expired',
+    );
+  });
+
+  it('should show count of days until trial period expires', () => {
+
+    const organization = ({
+      metadata: { guid: 'ORG_GUID' },
+      entity: { name: 'org-name' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: {
+        entity: { name: 'default', memory_limit: (5 * GIBIBYTE) / MEBIBYTE },
+      },
+    } as unknown) as IEnhancedOrganization;
+    const space = ({
+      metadata: { guid: 'SPACE_GUID_1' },
+      entity: { name: 'space-name' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: { entity: { memory_limit: (5 * GIBIBYTE) / MEBIBYTE } },
+      running_apps: [null],
+      stopped_apps: [null],
+      serviceInstances: [null],
+    } as unknown) as IEnhancedSpace;
+
+    const markup = shallow(
+      <SpacesPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        isAdmin={false}
+        isManager={false}
+        isBillingManager={false}
+        organization={organization}
+        spaces={[space, { ...space, quota: undefined }]}
+        users={[null]}
+        daysLeftInTrialPeriod={60}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('p').text()).toContain(
+      'Trial period expires in 60 days',
+    );
+  });
+
+  it('should show count of 1 day until trial period expires', () => {
+
+    const organization = ({
+      metadata: { guid: 'ORG_GUID' },
+      entity: { name: 'org-name' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: {
+        entity: { name: 'default', memory_limit: (5 * GIBIBYTE) / MEBIBYTE },
+      },
+    } as unknown) as IEnhancedOrganization;
+    const space = ({
+      metadata: { guid: 'SPACE_GUID_1' },
+      entity: { name: 'space-name' },
+      memory_allocated: GIBIBYTE / MEBIBYTE,
+      quota: { entity: { memory_limit: (5 * GIBIBYTE) / MEBIBYTE } },
+      running_apps: [null],
+      stopped_apps: [null],
+      serviceInstances: [null],
+    } as unknown) as IEnhancedSpace;
+
+    const markup = shallow(
+      <SpacesPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        isAdmin={false}
+        isManager={false}
+        isBillingManager={false}
+        organization={organization}
+        spaces={[space, { ...space, quota: undefined }]}
+        users={[null]}
+        daysLeftInTrialPeriod={1}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('p').text()).toContain(
+      'Trial period expires in 1 day.',
+    );
+  });
+
 });

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -53,6 +53,7 @@ interface ISpacesPageProperties {
   readonly organization: IEnhancedOrganization;
   readonly spaces: ReadonlyArray<IEnhancedSpace>;
   readonly users: ReadonlyArray<IUser>;
+  readonly daysLeftInTrialPeriod?: number | null;
 }
 
 interface IApplicationPageProperties {
@@ -273,6 +274,18 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
               ? 'Trial organisations have limited access to backing services'
               : 'Billable organisations have full access to backing services'}
           </p>
+          
+          {props.daysLeftInTrialPeriod ?
+            <p className="govuk-body">
+              Trial period{' '}
+              <span className="govuk-!-font-weight-bold">
+                {props.daysLeftInTrialPeriod! <= 0 ? 'has expired' : 
+                  props.daysLeftInTrialPeriod! === 1 ? 'expires in 1 day' 
+                  : `expires in ${props.daysLeftInTrialPeriod} days`}
+              </span>.
+            </p>
+            : <></>
+          }
 
           {help.conditionallyDisplay(
             props.isAdmin || props.isManager || props.isBillingManager,


### PR DESCRIPTION
What
----

For trial organisations show text depending on number of days left of the trial period as follows:

- between 1 and 90 days (trial period duration): "Trial period expires in X day(s)"
- 0 and negative days (more than 90 days have passed): "Trial period has expired."

If an org is a trial org (it's quota is still "default") we calculate the number of calendar days between current date and when organisation was created.

If an org is a billable org, then we pass null to the view and no text is displayed.

Visual changes
-------------
![Screenshot 2021-12-10 at 11 15 53](https://user-images.githubusercontent.com/3758555/145567588-17479f1f-1f04-4d1c-95bb-d5d405f17d38.png)
![Screenshot 2021-12-10 at 11 27 31](https://user-images.githubusercontent.com/3758555/145567591-3304d994-f6d3-4b40-b3ad-26bad1ecf268.png)


How to review
-------------

- run locally and manipulate test data
- or deploy to dev 01/02

Who can review
---------------

not @kr8n3r

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
