### PR TITLE
Fix HTML markup for hint on manage organisation page

### DIFF
--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -337,12 +337,12 @@ export function EditOrganization(props: IEditOrganizationProperties): ReactEleme
           <label className="govuk-label govuk-label--m" htmlFor="suspended">
             Organisation Suspension
           </label>
-          <span id="suspended-hint" className="govuk-hint">
+          <div id="suspended-hint" className="govuk-hint">
             By default, an org has the status of <code>Active</code>. An admin can set the status of an org to {}
             <code>Suspended</code> for various reasons such as failure to provide payment or misuse. When an org is {}
             <code>Suspended</code>, users cannot perform certain activities within the org, such as push apps, modify
             spaces, or bind services.
-          </span>
+          </div>
           <select className="govuk-select" id="suspended" name="suspended" aria-describedby="suspended-hint">
             <option selected={!props.organization.suspended} value="false">Active</option>
             <option selected={props.organization.suspended} value="true">Suspended</option>


### PR DESCRIPTION
What
----

Fix HTML markup for hint on manage organisation page

Missed in b772fefd6664179a962d49a3ff7d9af4af5f4480

**Before**

![before](https://user-images.githubusercontent.com/3758555/150554758-ad1cc837-a488-45ad-a1ac-0e46ef924702.png)


After

![after](https://user-images.githubusercontent.com/3758555/150554790-d14687c6-c71a-41b0-9faa-8ffa880c9155.png)


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
