### PR TITLE
Run CI test on node 16

### DIFF
--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: 14-alpine
+    tag: 16-alpine
 inputs:
   - name: repo
 run:


### PR DESCRIPTION
What
----

Run CI test on node 16

Missed in https://github.com/alphagov/paas-admin/pull/2218

Tag taken from https://hub.docker.com/layers/node/library/node/16-alpine/images/sha256-b48580972490b3344047758d93ac454fe6fa0dc0bb7690a4f75212485b4afd5d?context=explore

How to review
-------------

concourse tests pass

Who can review
---------------

anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
