### PR TITLE
Replace method of generating UUIDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,7 @@
         "react-markdown": "^6.0.3",
         "route-parser": "^0.0.5",
         "source-map-support": "^0.5.21",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -149,8 +149,7 @@
     "react-markdown": "^6.0.3",
     "route-parser": "^0.0.5",
     "source-map-support": "^0.5.21",
-    "tslib": "^2.3.1",
-    "uuid": "^8.3.2"
+    "tslib": "^2.3.1"
   },
   "engines": {
     "node": "16.x.x",

--- a/src/components/application-events/controllers.tsx
+++ b/src/components/application-events/controllers.tsx
@@ -1,8 +1,7 @@
 import lodash from 'lodash';
 import React from 'react';
-import { validate as uuidValidate } from 'uuid';
 
-import { Template } from '../../layouts';
+import { checkIfValidUuid, Template } from '../../layouts';
 import { AccountsClient, IAccountsUser } from '../../lib/accounts';
 import CloudFoundryClient from '../../lib/cf';
 import { IParameters, IResponse } from '../../lib/router';
@@ -37,7 +36,7 @@ export async function viewApplicationEvent(
   ]);
 
   const eventActorGUID: string | undefined =
-    event.actor.type === 'user' && uuidValidate(event.actor.guid)
+    event.actor.type === 'user' && checkIfValidUuid(event.actor.guid)
       ? event.actor.guid
       : undefined;
 
@@ -114,7 +113,7 @@ export async function viewApplicationEvents(
     .chain(events)
     .filter(e => e.actor.type === 'user')
     .map(e => e.actor.guid)
-    .filter(guid => uuidValidate(guid))
+    .filter(guid => checkIfValidUuid(guid))
     .uniq()
     .value();
 

--- a/src/components/calculator/controllers.tsx
+++ b/src/components/calculator/controllers.tsx
@@ -1,7 +1,8 @@
+import { randomUUID } from 'crypto';
+
 import { endOfMonth, format, startOfMonth } from 'date-fns';
 import { isMatch, sum } from 'lodash';
 import React from 'react';
-import * as uuid from 'uuid';
 
 import { Template } from '../../layouts';
 import { BillingClient } from '../../lib/billing';
@@ -63,7 +64,7 @@ async function getQuote(
   const forecastEvents = state.items.map((item: IResourceItem) => {
     const plan = state.plans.find(p => p.planGUID === item.planGUID);
     const defaultEvent: IBillableEvent = {
-      eventGUID: uuid.v1(),
+      eventGUID: randomUUID(),
       eventStart: rangeStart,
       eventStop: rangeStop,
       memoryInMB: parseFloat(item.memoryInMB),
@@ -75,7 +76,7 @@ async function getQuote(
         exVAT: 0,
         incVAT: 0,
       },
-      resourceGUID: uuid.v4(),
+      resourceGUID: randomUUID(),
       resourceName: 'unknown',
       resourceType: 'unknown',
       spaceGUID: '00000001-0001-0000-0000-000000000000',

--- a/src/components/service-events/controllers.tsx
+++ b/src/components/service-events/controllers.tsx
@@ -1,8 +1,7 @@
 import lodash from 'lodash';
 import React from 'react';
-import { validate as uuidValidate } from 'uuid';
 
-import { Template } from '../../layouts';
+import { checkIfValidUuid, Template } from '../../layouts';
 import { AccountsClient, IAccountsUser } from '../../lib/accounts';
 import CloudFoundryClient from '../../lib/cf';
 import { IParameters, IResponse } from '../../lib/router';
@@ -55,7 +54,7 @@ export async function viewServiceEvent(
   };
 
   const eventActorGUID: string | undefined =
-    event.actor.type === 'user' && uuidValidate(event.actor.guid)
+    event.actor.type === 'user' && checkIfValidUuid(event.actor.guid)
       ? event.actor.guid
       : undefined;
 
@@ -151,7 +150,7 @@ export async function viewServiceEvents(
     .filter(e => e.actor.type === 'user')
     .map(e => e.actor.guid)
     .uniq()
-    .filter(guid => uuidValidate(guid))
+    .filter(guid => checkIfValidUuid(guid))
     .value();
 
   if (userActorGUIDs.length > 0) {

--- a/src/components/spaces/controllers.tsx
+++ b/src/components/spaces/controllers.tsx
@@ -1,9 +1,8 @@
+import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
 import lodash from 'lodash';
 import React from 'react';
-import { validate as uuidValidate } from 'uuid';
-import differenceInCalendarDays from 'date-fns/differenceInCalendarDays'
 
-import { Template } from '../../layouts';
+import { checkIfValidUuid , Template } from '../../layouts';
 import { AccountsClient, IAccountsUser } from '../../lib/accounts';
 import CloudFoundryClient from '../../lib/cf';
 import {
@@ -96,7 +95,7 @@ export async function viewSpaceEvent(
   ]);
 
   const eventActorGUID: string | undefined =
-    event.actor.type === 'user' && uuidValidate(event.actor.guid)
+    event.actor.type === 'user' && checkIfValidUuid(event.actor.guid)
       ? event.actor.guid
       : undefined;
 
@@ -164,13 +163,13 @@ export async function viewSpaceEvents(
     .chain(events)
     .filter(e => e.actor.type === 'user')
     .map(e => e.actor.guid)
-    .filter(guid => uuidValidate(guid))
+    .filter(guid => checkIfValidUuid(guid))
     .value();
   const userTargetGUIDs = lodash
     .chain(events)
     .filter(e => e.target.type === 'user')
     .map(e => e.target.guid)
-    .filter(guid => uuidValidate(guid))
+    .filter(guid => checkIfValidUuid(guid))
     .value();
   const userGUIDs = lodash.uniq(userActorGUIDs.concat(userTargetGUIDs));
 

--- a/src/layouts/helpers.test.tsx
+++ b/src/layouts/helpers.test.tsx
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import cheerio from 'cheerio';
 import { shallow } from 'enzyme';
 import React from 'react';
@@ -7,6 +9,7 @@ import {
   Abbreviation,
   bytesToHuman,
   capitalize,
+  checkIfValidUuid,
   conditionallyDisplay,
   percentage,
 } from './helpers';
@@ -67,5 +70,15 @@ describe(Abbreviation, () => {
     expect($('abbr').text()).toBe('FTW');
     expect($('abbr').attr('aria-label')).toBe('For the win');
     expect($('abbr').attr('role')).toBe('tooltip');
+  });
+});
+
+describe(checkIfValidUuid, () => {
+  it('should return true if string is a valid UUID', () => {
+    expect(checkIfValidUuid(randomUUID())).toBeTruthy();
+  });
+
+  it('should return false if string is not a valid UUID', () => {
+    expect(checkIfValidUuid('a24a6ea4-ce75-4665-a070')).toBeFalsy();
   });
 });

--- a/src/layouts/helpers.tsx
+++ b/src/layouts/helpers.tsx
@@ -72,3 +72,10 @@ export function conditionallyDisplay(
 export function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
+
+/* Check if string is a valid UUID */
+export function checkIfValidUuid(input: string): boolean {
+  // 8-4-4-4-12 arrangement of 36 characters
+  const regexExp = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+  return regexExp.test(input.toLowerCase());
+}


### PR DESCRIPTION
What
----

Replace the use of `uuid` package for generating and validating UUIDs with NodeJS `crypto.randomUUID` and custom test function to check UUID validity.

Why
----

We'd like to reduce the number of dependencies we use for maintenance reasons and take advantage of native methods (if available) or own code if feasible. 

Added bonus: `randomUUID` is marginally faster, but negligible for our use-case

Assumption 
----

- we only need to use [UUID version 4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) (which is what `crypto.randomUUID` generates)

How to review
-------------

- review by commit
- run locally or deploy to dev env

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
