### PR TITLE
Use new-billing API output format (used in statement, report)

### DIFF
--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -132,8 +132,8 @@ describe('app test suite', () => {
   });
 
   it('should be able to handle 500 error when accessing pricing calculator', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     nockBilling
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)

--- a/src/components/calculator/controllers.test.tsx
+++ b/src/components/calculator/controllers.test.tsx
@@ -36,8 +36,8 @@ describe('calculator test suite', () => {
   });
 
   it('should get calculator', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     nock(config.billingAPI)
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
@@ -109,8 +109,8 @@ describe('calculator test suite', () => {
   });
 
   it('should get a zero quote if no items are specified', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     nock(config.billingAPI)
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
@@ -128,8 +128,8 @@ describe('calculator test suite', () => {
   });
 
   it('should calculate prices (including exchange rate) when provided fake services', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     nock(config.billingAPI)
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
@@ -203,8 +203,8 @@ describe('calculator test suite', () => {
   });
 
   it('should sort the quote by order added', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     const postgresGuid = 'f4d4b95a-f55e-4593-8d54-3364c25798c4';
     const appGuid = 'f4d4b95b-f55e-4593-8d54-3364c25798c0';
@@ -257,8 +257,8 @@ describe('calculator test suite', () => {
   });
 
   it('should filter out compose plans', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     nock(config.billingAPI)
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
@@ -281,8 +281,8 @@ describe('calculator test suite', () => {
   });
 
   it('should show postgres plan and sort the versions', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     nock(config.billingAPI)
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
@@ -339,8 +339,8 @@ describe('calculator test suite', () => {
   });
 
   it('should use calculator and ignore empty application', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     nock(config.billingAPI)
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)
@@ -397,8 +397,8 @@ describe('calculator test suite', () => {
   });
 
   it('should omit printing "default" when there is only a default pricing plan', async () => {
-    const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
-    const rangeStop = format(endOfMonth(new Date()), 'yyyy-MM-dd');
+    const rangeStart = format(startOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    const rangeStop = format(endOfMonth(new Date()), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     nock(config.billingAPI)
       .get(`/pricing_plans?range_start=${rangeStart}&range_stop=${rangeStop}`)

--- a/src/components/reports/controllers.test.tsx
+++ b/src/components/reports/controllers.test.tsx
@@ -469,17 +469,17 @@ describe('cost report test suite', () => {
         "resource_guid": "a585feac-32a1-44f6-92e2-cdb1377e42f4",
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
-        "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
-	"org_name": "org",
+        "org_guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+	"org_name": "the-system_domain-org-name",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
 	"space_name": "space",
 	"component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
 	"plan_name": "plan",
-        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "org_quota_definition_guid": "ORG-QUOTA-GUID",
         "charge_gbp_exc_vat": "0.02",
         "charge_gbp_inc_vat": "0.024",
-	"charge_usd_exc_vat": "0.015"
+	"charge_usd_exc_vat": "0.025"
         }]`,
       );
 

--- a/src/components/reports/controllers.test.tsx
+++ b/src/components/reports/controllers.test.tsx
@@ -358,48 +358,21 @@ describe('cost report test suite', () => {
       .reply(
         200,
         `[{
-        "event_guid": "fecc9eb5-b027-42fe-ba1f-d90a0474b620",
-        "event_start": "2018-04-20T14:36:09+00:00",
-        "event_stop": "2018-04-20T14:45:46+00:00",
         "resource_guid": "a585feac-32a1-44f6-92e2-cdb1377e42f4",
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
         "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
+	"org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
+	"space_name": "space",
+	"component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-        "quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
-        "number_of_nodes": 1,
-        "memory_in_mb": 64,
-        "storage_in_mb": 0,
-        "price": {
-          "ex_vat": "0.02",
-          "inc_vat": "0.024",
-          "details": [
-            {
-              "name": "instance",
-              "start": "2018-04-20T14:36:09+00:00",
-              "stop": "2018-04-20T14:45:46+00:00",
-              "plan_name": "app",
-              "ex_vat": "0.01",
-              "inc_vat": "0.012",
-              "vat_rate": "0.2",
-              "vat_code": "Standard",
-              "currency_code": "GBP"
-            },
-            {
-              "name": "platform",
-              "start": "2018-04-20T14:36:09+00:00",
-              "stop": "2018-04-20T14:45:46+00:00",
-              "plan_name": "app",
-              "ex_vat": "0.01",
-              "inc_vat": "0.012",
-              "vat_rate": "0.2",
-              "vat_code": "Standard",
-              "currency_code": "GBP"
-            }
-          ]
-        }
-      }]`,
+	"plan_name": "plan",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "0.02",
+        "charge_gbp_inc_vat": "0.024",
+	"charge_usd_exc_vat": "0.015"
+        }]`,
       );
 
     const response = await reports.viewCostReport(ctx, { rangeStart });
@@ -432,37 +405,21 @@ describe('cost report test suite', () => {
       .reply(
         200,
         `[{
-        "event_guid": "fecc9eb5-b027-42fe-ba1f-d90a0474b620",
-        "event_start": "2018-04-20T14:36:09+00:00",
-        "event_stop": "2018-04-20T14:45:46+00:00",
         "resource_guid": "a585feac-32a1-44f6-92e2-cdb1377e42f4",
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
-        "org_guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+        "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
+	"org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
+	"space_name": "space",
+	"component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-        "quota_definition_guid": "ORG-QUOTA-GUID",
-        "number_of_nodes": 1,
-        "memory_in_mb": 64,
-        "storage_in_mb": 0,
-        "price": {
-          "ex_vat": "1337.13",
-          "inc_vat": "1337.00",
-          "details": [
-            {
-              "name": "instance",
-              "start": "2018-04-20T14:36:09+00:00",
-              "stop": "2018-04-20T14:45:46+00:00",
-              "plan_name": "matching plan",
-              "ex_vat": "1337.13",
-              "inc_vat": "1337.00",
-              "vat_rate": "0.2",
-              "vat_code": "Standard",
-              "currency_code": "GBP"
-            }
-          ]
-        }
-      }]`,
+	"plan_name": "matching plan",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "1337.13",
+        "charge_gbp_inc_vat": "1337.00",
+	"charge_usd_exc_vat": "0.015"
+        }]`,
       );
 
     const firstResponse = await reports.viewCostReport(ctx, {
@@ -509,48 +466,21 @@ describe('cost report test suite', () => {
       .reply(
         200,
         `[{
-        "event_guid": "fecc9eb5-b027-42fe-ba1f-d90a0474b620",
-        "event_start": "2018-04-20T14:36:09+00:00",
-        "event_stop": "2018-04-20T14:45:46+00:00",
         "resource_guid": "a585feac-32a1-44f6-92e2-cdb1377e42f4",
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
-        "org_guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
+        "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
+	"org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
+	"space_name": "space",
+	"component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-        "quota_definition_guid": "ORG-QUOTA-GUID",
-        "number_of_nodes": 1,
-        "memory_in_mb": 64,
-        "storage_in_mb": 0,
-        "price": {
-          "ex_vat": "0.02",
-          "inc_vat": "0.024",
-          "details": [
-            {
-              "name": "instance",
-              "start": "2018-04-20T14:36:09+00:00",
-              "stop": "2018-04-20T14:45:46+00:00",
-              "plan_name": "app",
-              "ex_vat": "0.01",
-              "inc_vat": "0.012",
-              "vat_rate": "0.2",
-              "vat_code": "Standard",
-              "currency_code": "GBP"
-            },
-            {
-              "name": "platform",
-              "start": "2018-04-20T14:36:09+00:00",
-              "stop": "2018-04-20T14:45:46+00:00",
-              "plan_name": "app",
-              "ex_vat": "0.01",
-              "inc_vat": "0.012",
-              "vat_rate": "0.2",
-              "vat_code": "Standard",
-              "currency_code": "GBP"
-            }
-          ]
-        }
-      }]`,
+	"plan_name": "plan",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "0.02",
+        "charge_gbp_inc_vat": "0.024",
+	"charge_usd_exc_vat": "0.015"
+        }]`,
       );
 
     const response = await reports.viewCostReport(ctx, { rangeStart });
@@ -957,38 +887,23 @@ describe('html cost report by service test suite', () => {
   it('should group billable events by org and service', async () => {
     const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
 
-    const defaultPriceDetails = {
-      currency_code: 'default-currency-code',
-      ex_vat: 0,
-      inc_vat: 0,
-      name: 'instance',
-      plan_name: 'default-plan-name',
-      start: '2018-04-20T14:36:09+00:00',
-      stop: '2018-04-20T14:45:46+00:00',
-      vat_code: 'default-vat-code',
-      vat_rate: '0.2',
-    };
-    const defaultPrice = {
-      details: [defaultPriceDetails],
-      ex_vat: 0,
-      inc_vat: 0,
-    };
-    const defaultBillableEvent = {
-      event_guid: 'default-event-guid',
-      event_start: '2018-04-20T14:36:09+00:00',
-      event_stop: '2018-04-20T14:45:46+00:00',
-      memory_in_mb: 64,
-      number_of_nodes: 1,
-      org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-      plan_guid: 'default-plan-guid',
-      price: defaultPrice,
-      quota_definition_guid: 'default-quota-definition-guid',
-      resource_guid: 'default-resource-guid',
-      resource_name: 'default-resource-name',
-      resource_type: 'app',
-      space_guid: 'default-space-guid',
-      storage_in_mb: 0,
-    };
+    const defaultBillableEvent = 
+	{
+        resource_guid: 'a585feac-32a1-44f6-92e2-cdb1377e42f4',
+        resource_name: 'default-resource-guid',
+        resource_type: 'app',
+        org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+	org_name: 'org',
+        space_guid: 'default-space-guid',
+	space_name: 'space',
+	component_name : 'component',
+        plan_guid: 'default-plan-guid',
+	plan_name: 'unknown',
+        org_quota_definition_guid: 'default-quota-definition-guid',
+        charge_gbp_exc_vat: '0.02',
+        charge_gbp_inc_vat: '0.024',
+	charge_usd_exc_vat: '0.015',
+      };
 
     nockCF
       .get('/v3/organizations')
@@ -1004,44 +919,34 @@ describe('html cost report by service test suite', () => {
         JSON.stringify([
           {
             ...defaultBillableEvent,
-            price: {
-              ...defaultPrice,
-              details: [{ ...defaultPriceDetails, plan_name: 'task' }],
-              inc_vat: '1',
-            },
+	    plan_name: 'task',
+	    charge_gbp_inc_vat: '1'
           },
           {
             ...defaultBillableEvent,
-            price: {
-              ...defaultPrice,
-              details: [{ ...defaultPriceDetails, plan_name: 'staging' }],
-              inc_vat: '10',
-            },
+            plan_name: 'staging',
+            charge_gbp_inc_vat: '10',
+            
           },
           {
             ...defaultBillableEvent,
-            price: {
-              ...defaultPrice,
-              details: [{ ...defaultPriceDetails, plan_name: 'app' }],
-              inc_vat: '100',
-            },
+            plan_name: 'app',
+            charge_gbp_inc_vat: '100',
           },
           {
             ...defaultBillableEvent,
-            price: {
-              ...defaultPrice,
-              details: [{ ...defaultPriceDetails, plan_name: 'postgres' }],
-              inc_vat: '1000',
-            },
+           plan_name: 'postgres',
+           charge_gbp_inc_vat: '1000',
+           
           },
           {
             ...defaultBillableEvent,
-            price: { ...defaultPrice, details: [], inc_vat: '10000' },
+            charge_gbp_inc_vat: '10000',
           },
           {
             ...defaultBillableEvent,
             org_guid: 'some-unknown-org',
-            price: { ...defaultPrice, details: [], inc_vat: '100000' },
+            charge_gbp_inc_vat: '100000',
           },
         ]),
       );
@@ -1523,36 +1428,25 @@ describe('csv organisation monthly spend report for the pmo team', () => {
   it('should apply the 10% admin fee', async () => {
     const rangeStart = startOfMonth(new Date());
 
-    const defaultPriceDetails = {
-      ex_vat: 0,
-      inc_vat: 0,
-      name: 'instance',
-      plan_name: 'default-plan-name',
-      start: '2018-04-20T14:36:09+00:00',
-      stop: '2018-04-20T14:45:46+00:00',
-      vat_rate: 10,
-    };
-    const defaultPrice = {
-      details: [defaultPriceDetails],
-      ex_vat: 0,
-      inc_vat: 0,
-    };
-    const defaultBillableEvent = {
-      event_guid: 'default-event-guid',
-      event_start: '2018-04-20T14:36:09+00:00',
-      event_stop: '2018-04-20T14:45:46+00:00',
-      memory_in_mb: 64,
-      number_of_nodes: 1,
-      org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-      plan_guid: 'default-plan-guid',
-      price: defaultPrice,
-      quota_definition_guid: 'default-quota-definition-guid',
-      resource_guid: 'default-resource-guid',
-      resource_name: 'default-resource-name',
-      resource_type: 'app',
-      space_guid: 'default-space-guid',
-      storage_in_mb: 0,
-    };
+
+
+    const defaultBillableEvent = 
+	{
+        resource_guid: 'a585feac-32a1-44f6-92e2-cdb1377e42f4',
+        resource_name: 'default-resource-guid',
+        resource_type: 'app',
+        org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+	org_name: 'org',
+        space_guid: 'default-space-guid',
+	space_name: 'space',
+	component_name : 'component',
+        plan_guid: 'default-plan-guid',
+	plan_name: 'plan',
+        org_quota_definition_guid: 'default-quota-definition-guid',
+        charge_gbp_exc_vat: '0.02',
+        charge_gbp_inc_vat: '0.024',
+	charge_usd_exc_vat: '0.015',
+      };
     nock(config.billingAPI)
       .get('/billable_events')
       .query(true)
@@ -1563,7 +1457,7 @@ describe('csv organisation monthly spend report for the pmo team', () => {
           {
             ...defaultBillableEvent,
             org_guid: 'org-one',
-            price: { ...defaultPrice, ex_vat: '1' },
+            charge_gbp_exc_vat: '1',
           },
         ]),
       );
@@ -1594,36 +1488,47 @@ describe('csv organisation monthly spend report for the pmo team', () => {
   it('should group billable events by org', async () => {
     const rangeStart = startOfMonth(new Date());
 
-    const defaultPriceDetails = {
-      ex_vat: 0,
-      inc_vat: 0,
-      name: 'instance',
-      plan_name: 'default-plan-name',
-      start: '2018-04-20T14:36:09+00:00',
-      stop: '2018-04-20T14:45:46+00:00',
-      vat_rate: 10,
-    };
-    const defaultPrice = {
-      details: [ defaultPriceDetails ],
-      ex_vat: 0,
-      inc_vat: 0,
-    };
+
     const defaultBillableEvent = {
-      event_guid: 'default-event-guid',
-      event_start: '2018-04-20T14:36:09+00:00',
-      event_stop: '2018-04-20T14:45:46+00:00',
-      memory_in_mb: 64,
-      number_of_nodes: 1,
-      org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-      plan_guid: 'default-plan-guid',
-      price: defaultPrice,
-      quota_definition_guid: 'default-quota-definition-guid',
-      resource_guid: 'default-resource-guid',
-      resource_name: 'default-resource-name',
-      resource_type: 'app',
-      space_guid: 'default-space-guid',
-      storage_in_mb: 0,
-    };
+    eventGUID: '',
+    eventStart: new Date(),
+    eventStop: new Date(),
+    memoryInMB: 0,
+    numberOfNodes: 0,
+    orgGUID: '',
+    planGUID: '',
+    price: {
+      details: [],
+      exVAT: 0,
+      incVAT: 0,
+    },
+    quotaGUID: '',
+    resourceGUID: '',
+    resourceName: '',
+    resourceType: '',
+    spaceGUID: '',
+    spaceName: '',
+    storageInMB: 0,
+    };      
+
+    const defaultFlatBillableEvent = 
+	{
+        resource_guid: 'a585feac-32a1-44f6-92e2-cdb1377e42f4',
+        resource_name: 'default-resource-guid',
+        resource_type: 'app',
+        org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+	org_name: 'org',
+        space_guid: 'default-space-guid',
+	space_name: 'space',
+	component_name : 'component',
+        plan_guid: 'default-plan-guid',
+	plan_name: 'plan',
+        org_quota_definition_guid: 'default-quota-definition-guid',
+        charge_gbp_exc_vat: '0.02',
+        charge_gbp_inc_vat: '0.024',
+	charge_usd_exc_vat: '0.015',
+      };
+
     nock(config.billingAPI)
       .get('/billable_events')
       .query(true)
@@ -1632,29 +1537,29 @@ describe('csv organisation monthly spend report for the pmo team', () => {
         200,
         JSON.stringify([
           {
-            ...defaultBillableEvent,
+            ...defaultFlatBillableEvent,
             org_guid: 'org-one',
-            price: { ...defaultPrice, ex_vat: '1' },
+            charge_gbp_exc_vat: '1',
           },
           {
-            ...defaultBillableEvent,
+            ...defaultFlatBillableEvent,
             org_guid: 'org-two',
-            price: { ...defaultPrice, ex_vat: '10' },
+            charge_gbp_exc_vat: '10',
           },
           {
-            ...defaultBillableEvent,
+            ...defaultFlatBillableEvent,
             org_guid: 'org-one',
-            price: { ...defaultPrice, ex_vat: '100' },
+            charge_gbp_exc_vat: '100',
           },
           {
-            ...defaultBillableEvent,
+            ...defaultFlatBillableEvent,
             org_guid: 'org-one',
-            price: { ...defaultPrice, ex_vat: '1000' },
+            charge_gbp_exc_vat: '1000',
           },
           {
-            ...defaultBillableEvent,
+            ...defaultFlatBillableEvent,
             org_guid: 'org-two',
-            price: { ...defaultPrice, ex_vat: '10000' },
+            charge_gbp_exc_vat: '10000',
           },
         ]),
       );
@@ -1728,7 +1633,24 @@ describe('csv organisation monthly spend report for the pmo team', () => {
 });
 
 describe('cost report grouping functions', () => {
-  const defaultPrice = { details: [], exVAT: 0, incVAT: 0 };
+  const defaultFlatBillableEvent = 
+	{
+        resource_guid: 'a585feac-32a1-44f6-92e2-cdb1377e42f4',
+        resource_name: 'default-resource-guid',
+        resource_type: 'app',
+        org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+	org_name: 'org',
+        space_guid: 'default-space-guid',
+	space_name: 'space',
+	component_name : 'component',
+        plan_guid: 'default-plan-guid',
+	plan_name: 'plan',
+        org_quota_definition_guid: 'default-quota-definition-guid',
+        charge_gbp_exc_vat: '0.02',
+        charge_gbp_inc_vat: '0.024',
+	charge_usd_exc_vat: '0.015',
+  };
+
   const defaultBillableEvent = {
     eventGUID: '',
     eventStart: new Date(),
@@ -1737,14 +1659,20 @@ describe('cost report grouping functions', () => {
     numberOfNodes: 0,
     orgGUID: '',
     planGUID: '',
-    price: defaultPrice,
+    price: {
+      details: [],
+      exVAT: 0,
+      incVAT: 0,
+    },
+    quotaGUID: '',
     resourceGUID: '',
     resourceName: '',
     resourceType: '',
     spaceGUID: '',
     spaceName: '',
     storageInMB: 0,
-  };
+    };
+  const defaultPrice = { details: [], exVAT: 0, incVAT: 0 };
 
   describe('getBillablesByOrganisation', () => {
     it('should work with zero orgs and events', () => {
@@ -1770,11 +1698,13 @@ describe('cost report grouping functions', () => {
             ...defaultBillableEvent,
             orgGUID: 'org-one',
             price: { ...defaultPrice, exVAT: 1 },
+
           },
           {
             ...defaultBillableEvent,
             orgGUID: 'org-one',
             price: { ...defaultPrice, exVAT: 10 },
+
           },
         ],
         adminFee,
@@ -1937,31 +1867,21 @@ describe('html visualisation report test suite', () => {
       .reply(
         200,
         `[{
-        "event_guid":"default-event-guid",
-        "event_start":"2018-04-20T14:36:09+00:00",
-        "event_stop":"2018-04-20T14:45:46+00:00",
-        "resource_guid":"default-resource-guid",
-        "resource_name":"default-resource-name",
-        "resource_type":"app",
-        "org_guid":"a7aff246-5f5b-4cf8-87d8-f316053e4a20",
-        "space_guid":"default-space-guid",
-        "plan_guid":"default-plan-guid",
-        "quota_definition_guid":"default-quota-definition-guid",
-        "number_of_nodes":1,
-        "memory_in_mb":64,
-        "storage_in_mb":0,
-        "price":{"ex_vat":0,"inc_vat":0,"details":[{
-          "name":"instance",
-          "start":"2018-04-20T14:36:09+00:00",
-          "stop":"2018-04-20T14:45:46+00:00",
-          "plan_name":"default-plan-name",
-          "ex_vat":0,
-          "inc_vat":0,
-          "vat_rate":"0.2",
-          "vat_code":"default-vat-code",
-          "currency_code":"default-currency-code"
-        }]}
-      }]`,
+        "resource_guid": "a585feac-32a1-44f6-92e2-cdb1377e42f4",
+        "resource_name": "api-availability-test-app",
+        "resource_type": "app",
+        "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
+	"org_name": "org",
+        "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
+	"space_name": "space",
+	"component_name": "component",
+        "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
+	"plan_name": "plan",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "0.02",
+        "charge_gbp_inc_vat": "0.024",
+	"charge_usd_exc_vat": "0.015"
+        }]`,
       );
 
     const response = await reports.viewVisualisation(ctx, { rangeStart });

--- a/src/components/reports/controllers.test.tsx
+++ b/src/components/reports/controllers.test.tsx
@@ -362,16 +362,16 @@ describe('cost report test suite', () => {
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
         "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
-	"org_name": "org",
+        "org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
-	"space_name": "space",
-	"component_name": "component",
+        "space_name": "space",
+        "component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-	"plan_name": "plan",
+        "plan_name": "plan",
         "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
         "charge_gbp_exc_vat": "0.02",
         "charge_gbp_inc_vat": "0.024",
-	"charge_usd_exc_vat": "0.015"
+        "charge_usd_exc_vat": "0.015"
         }]`,
       );
 
@@ -409,16 +409,16 @@ describe('cost report test suite', () => {
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
         "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
-	"org_name": "org",
+        "org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
-	"space_name": "space",
-	"component_name": "component",
+        "space_name": "space",
+        "component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-	"plan_name": "matching plan",
+        "plan_name": "matching plan",
         "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
         "charge_gbp_exc_vat": "1337.13",
         "charge_gbp_inc_vat": "1337.00",
-	"charge_usd_exc_vat": "0.015"
+        "charge_usd_exc_vat": "0.015"
         }]`,
       );
 
@@ -470,16 +470,16 @@ describe('cost report test suite', () => {
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
         "org_guid": "a7aff246-5f5b-4cf8-87d8-f316053e4a20",
-	"org_name": "the-system_domain-org-name",
+        "org_name": "the-system_domain-org-name",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
-	"space_name": "space",
-	"component_name": "component",
+        "space_name": "space",
+        "component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-	"plan_name": "plan",
+        "plan_name": "plan",
         "org_quota_definition_guid": "ORG-QUOTA-GUID",
         "charge_gbp_exc_vat": "0.02",
         "charge_gbp_inc_vat": "0.024",
-	"charge_usd_exc_vat": "0.025"
+        "charge_usd_exc_vat": "0.025"
         }]`,
       );
 
@@ -887,22 +887,22 @@ describe('html cost report by service test suite', () => {
   it('should group billable events by org and service', async () => {
     const rangeStart = format(startOfMonth(new Date()), 'yyyy-MM-dd');
 
-    const defaultBillableEvent = 
-	{
+    const defaultBillableEvent =
+        {
         resource_guid: 'a585feac-32a1-44f6-92e2-cdb1377e42f4',
         resource_name: 'default-resource-guid',
         resource_type: 'app',
         org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-	org_name: 'org',
+        org_name: 'org',
         space_guid: 'default-space-guid',
-	space_name: 'space',
-	component_name : 'component',
+        space_name: 'space',
+        component_name : 'component',
         plan_guid: 'default-plan-guid',
-	plan_name: 'unknown',
+        plan_name: 'unknown',
         org_quota_definition_guid: 'default-quota-definition-guid',
         charge_gbp_exc_vat: '0.02',
         charge_gbp_inc_vat: '0.024',
-	charge_usd_exc_vat: '0.015',
+        charge_usd_exc_vat: '0.015',
       };
 
     nockCF
@@ -919,14 +919,14 @@ describe('html cost report by service test suite', () => {
         JSON.stringify([
           {
             ...defaultBillableEvent,
-	    plan_name: 'task',
-	    charge_gbp_inc_vat: '1'
+            plan_name: 'task',
+            charge_gbp_inc_vat: '1',
           },
           {
             ...defaultBillableEvent,
             plan_name: 'staging',
             charge_gbp_inc_vat: '10',
-            
+
           },
           {
             ...defaultBillableEvent,
@@ -937,7 +937,7 @@ describe('html cost report by service test suite', () => {
             ...defaultBillableEvent,
            plan_name: 'postgres',
            charge_gbp_inc_vat: '1000',
-           
+
           },
           {
             ...defaultBillableEvent,
@@ -1430,22 +1430,22 @@ describe('csv organisation monthly spend report for the pmo team', () => {
 
 
 
-    const defaultBillableEvent = 
-	{
+    const defaultBillableEvent =
+        {
         resource_guid: 'a585feac-32a1-44f6-92e2-cdb1377e42f4',
         resource_name: 'default-resource-guid',
         resource_type: 'app',
         org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-	org_name: 'org',
+        org_name: 'org',
         space_guid: 'default-space-guid',
-	space_name: 'space',
-	component_name : 'component',
+        space_name: 'space',
+        component_name : 'component',
         plan_guid: 'default-plan-guid',
-	plan_name: 'plan',
+        plan_name: 'plan',
         org_quota_definition_guid: 'default-quota-definition-guid',
         charge_gbp_exc_vat: '0.02',
         charge_gbp_inc_vat: '0.024',
-	charge_usd_exc_vat: '0.015',
+        charge_usd_exc_vat: '0.015',
       };
     nock(config.billingAPI)
       .get('/billable_events')
@@ -1488,45 +1488,22 @@ describe('csv organisation monthly spend report for the pmo team', () => {
   it('should group billable events by org', async () => {
     const rangeStart = startOfMonth(new Date());
 
-
-    const defaultBillableEvent = {
-    eventGUID: '',
-    eventStart: new Date(),
-    eventStop: new Date(),
-    memoryInMB: 0,
-    numberOfNodes: 0,
-    orgGUID: '',
-    planGUID: '',
-    price: {
-      details: [],
-      exVAT: 0,
-      incVAT: 0,
-    },
-    quotaGUID: '',
-    resourceGUID: '',
-    resourceName: '',
-    resourceType: '',
-    spaceGUID: '',
-    spaceName: '',
-    storageInMB: 0,
-    };      
-
-    const defaultFlatBillableEvent = 
-	{
+    const defaultFlatBillableEvent =
+        {
         resource_guid: 'a585feac-32a1-44f6-92e2-cdb1377e42f4',
         resource_name: 'default-resource-guid',
         resource_type: 'app',
         org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-	org_name: 'org',
+        org_name: 'org',
         space_guid: 'default-space-guid',
-	space_name: 'space',
-	component_name : 'component',
+        space_name: 'space',
+        component_name : 'component',
         plan_guid: 'default-plan-guid',
-	plan_name: 'plan',
+        plan_name: 'plan',
         org_quota_definition_guid: 'default-quota-definition-guid',
         charge_gbp_exc_vat: '0.02',
         charge_gbp_inc_vat: '0.024',
-	charge_usd_exc_vat: '0.015',
+        charge_usd_exc_vat: '0.015',
       };
 
     nock(config.billingAPI)
@@ -1633,23 +1610,6 @@ describe('csv organisation monthly spend report for the pmo team', () => {
 });
 
 describe('cost report grouping functions', () => {
-  const defaultFlatBillableEvent = 
-	{
-        resource_guid: 'a585feac-32a1-44f6-92e2-cdb1377e42f4',
-        resource_name: 'default-resource-guid',
-        resource_type: 'app',
-        org_guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-	org_name: 'org',
-        space_guid: 'default-space-guid',
-	space_name: 'space',
-	component_name : 'component',
-        plan_guid: 'default-plan-guid',
-	plan_name: 'plan',
-        org_quota_definition_guid: 'default-quota-definition-guid',
-        charge_gbp_exc_vat: '0.02',
-        charge_gbp_inc_vat: '0.024',
-	charge_usd_exc_vat: '0.015',
-  };
 
   const defaultBillableEvent = {
     eventGUID: '',
@@ -1871,16 +1831,16 @@ describe('html visualisation report test suite', () => {
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
         "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
-	"org_name": "org",
+        "org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
-	"space_name": "space",
-	"component_name": "component",
+        "space_name": "space",
+        "component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-	"plan_name": "plan",
+        "plan_name": "plan",
         "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
         "charge_gbp_exc_vat": "0.02",
         "charge_gbp_inc_vat": "0.024",
-	"charge_usd_exc_vat": "0.015"
+        "charge_usd_exc_vat": "0.015"
         }]`,
       );
 

--- a/src/components/statements/controllers.test.tsx
+++ b/src/components/statements/controllers.test.tsx
@@ -99,11 +99,11 @@ describe('statements test suite', () => {
 
   it('should show the statement page', async () => {
     nockBilling
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, '[]')
 
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
       )
       .reply(200, billingData.billableEvents);
 
@@ -142,11 +142,11 @@ describe('statements test suite', () => {
 
   it('should show the statement page to admins for a deleted org', async () => {
     nockBilling
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, '[]')
 
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=3deb9f04-b449-4f94-b3dd-c73cefe5b275',
       )
       .reply(200, billingData.billableEvents);
 
@@ -170,11 +170,11 @@ describe('statements test suite', () => {
   it('should prepare statement to download', async () => {
     nockBilling
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
       )
       .reply(200, billingData.billableEvents)
 
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, '[]');
 
     nockCF
@@ -198,11 +198,11 @@ describe('statements test suite', () => {
   it('should be able to use filters', async () => {
     nockBilling
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
       )
       .reply(200, billingData.billableEvents)
 
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, billingData.currencyRates);
 
     nockCF
@@ -227,11 +227,11 @@ describe('statements test suite', () => {
   it('should be reflect the selected filters in the main heading', async () => {
     nockBilling
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
       )
       .reply(200, billingData.billableEvents)
 
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, billingData.currencyRates);
 
     nockCF
@@ -258,11 +258,11 @@ describe('statements test suite', () => {
   it('populates filter dropdowns with all spaces / services', async () => {
     nockBilling
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
       )
       .reply(200, billingData.billableEvents)
 
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, billingData.currencyRates);
 
     nockCF
@@ -294,11 +294,11 @@ describe('statements test suite', () => {
   it('does not outputs USD rate if not known', async () => {
     nockBilling
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
       )
       .reply(200, billingData.billableEvents)
 
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, []);
 
     nockCF
@@ -322,11 +322,11 @@ describe('statements test suite', () => {
   it('outputs a single USD rate if there is only one', async () => {
     nockBilling
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
       )
       .reply(200, billingData.billableEvents)
 
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, [{ code: 'USD', rate: 0.8, valid_from: '2017-01-01' }]);
 
     nockCF
@@ -351,11 +351,11 @@ describe('statements test suite', () => {
   it('outputs multiple USD rates if there are multiple this month', async () => {
     nockBilling
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-02-01&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z&org_guid=a7aff246-5f5b-4cf8-87d8-f316053e4a20',
       )
       .reply(200, billingData.billableEvents)
 
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2018-02-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2018-02-01T00:00:00Z')
       .reply(200, [
         { code: 'USD', rate: 0.8, valid_from: '2017-01-01' },
         { code: 'USD', rate: 0.5, valid_from: '2017-01-15' },

--- a/src/components/statements/controllers.tsx
+++ b/src/components/statements/controllers.tsx
@@ -1,4 +1,4 @@
-import { add, format, isValid, startOfMonth, sub } from 'date-fns';
+import { add, format, isValid, isEqual, startOfMonth, sub } from 'date-fns';
 import React from 'react';
 
 import { Template } from '../../layouts';
@@ -202,6 +202,15 @@ export async function viewStatement(
     );
   }
 
+  const today = new Date();
+
+  let rangeStop;
+  if (isEqual(startOfMonth(today), startOfMonth(rangeStart))) {
+    rangeStop = today;
+  } else {
+    rangeStop = add(rangeStart, { months: 1 });
+  }
+
   const currentMonth = format(rangeStart, 'MMMM');
 
   const cf = new CloudFoundryClient({
@@ -262,7 +271,7 @@ export async function viewStatement(
   const filter = {
     orgGUIDs: [organization.metadata.guid],
     rangeStart: rangeStart,
-    rangeStop: add(rangeStart, { months: 1 }),
+    rangeStop: rangeStop,
   };
 
   let events;

--- a/src/components/statements/controllers.tsx
+++ b/src/components/statements/controllers.tsx
@@ -1,4 +1,4 @@
-import { add, format, isValid, isEqual, startOfMonth, sub } from 'date-fns';
+import { add, format, isValid, isEqual, startOfMonth, sub, startOfDay } from 'date-fns';
 import React from 'react';
 
 import { Template } from '../../layouts';
@@ -202,7 +202,7 @@ export async function viewStatement(
     );
   }
 
-  const today = new Date();
+  const today = startOfDay(new Date());
 
   let rangeStop;
   if (isEqual(startOfMonth(today), startOfMonth(rangeStart))) {

--- a/src/lib/billing/billing.test.data.ts
+++ b/src/lib/billing/billing.test.data.ts
@@ -1,7 +1,51 @@
-export const billableEvents = `[
-  {"event_guid":"0231ecbf-799c-4afa-8b76-76cb47a43b58","event_start":"2018-06-22T12:35:02+00:00","event_stop":"2018-06-22T12:35:54+00:00","resource_guid":"e0a488d0-6f1d-4d01-8ad6-725422405250","resource_name":"alfred","resource_type":"postgres","org_guid":"3deb9f04-b449-4f94-b3dd-c73cefe5b275","org_name":"admin","space_guid":"5489e195-c42b-4e61-bf30-323c331ecc01","space_name":"real-hero","plan_guid":"f4d4b95a-f55e-4593-8d54-3364c25798c4","number_of_nodes":1,"memory_in_mb":1024,"storage_in_mb":0,"price":{"ex_vat" : "0.02", "inc_vat" : "0.024", "details" : [{"name" : "platform", "start" : "2018-06-22T12:35:02+00:00", "stop" : "2018-06-22T12:35:54+00:00", "plan_name" : "staging", "ex_vat" : "0.01", "inc_vat" : "0.012", "vat_rate" : "0.2", "vat_code" : "Standard", "currency_code" : "USD", "currency_rate" : "0.8"}, {"name" : "instance", "start" : "2018-06-22T12:35:02+00:00", "stop" : "2018-06-22T12:35:54+00:00", "plan_name" : "staging", "ex_vat" : "0.01", "inc_vat" : "0.012", "vat_rate" : "0.2", "vat_code" : "Standard", "currency_code" : "USD", "currency_rate" : "0.8"}]}},
-  {"event_guid":"03365088-7e43-4e89-aacf-5b6ed459b299","event_start":"2018-06-27T12:42:41+00:00","event_stop":"2018-06-27T12:42:45+00:00","resource_guid":"537594b7-b76a-4f5a-941b-675d0297abf8","resource_name":"batman","resource_type":"app","org_guid":"3deb9f04-b449-4f94-b3dd-c73cefe5b275","org_name":"admin","space_guid":"bc8d3381-390d-4bd7-8c71-25309900a2e3","space_name":"pretty-face","plan_guid":"f4d4b95a-f55e-4593-8d54-3364c25798c4","number_of_nodes":1,"memory_in_mb":1024,"storage_in_mb":0,"price":{"ex_vat" : "0.02", "inc_vat" : "0.024", "details" : [{"name" : "platform", "start" : "2018-06-27T12:42:41+00:00", "stop" : "2018-06-27T12:42:45+00:00", "plan_name" : "staging", "ex_vat" : "0.01", "inc_vat" : "0.012", "vat_rate" : "0.2", "vat_code" : "Standard", "currency_code" : "USD", "currency_rate" : "0.8"}, {"name" : "instance", "start" : "2018-06-27T12:42:41+00:00", "stop" : "2018-06-27T12:42:45+00:00", "plan_name" : "staging", "ex_vat" : "0.01", "inc_vat" : "0.012", "vat_rate" : "0.2", "vat_code" : "Standard", "currency_code" : "USD", "currency_rate" : "0.8"}]}},
-  {"event_guid":"ffe09a3a-b6f4-4b04-a462-35614bd10498","event_start":"2018-06-21T11:07:28+00:00","event_stop":"2018-06-22T07:33:42+00:00","resource_guid":"029e0254-5307-4628-815a-2b8f4eb2d8fa","resource_name":"robin","resource_type":"app","org_guid":"3deb9f04-b449-4f94-b3dd-c73cefe5b275","org_name":"admin","space_guid":"bc8d3381-390d-4bd7-8c71-25309900a2e3","space_name":"pretty-face","plan_guid":"eaa243f8-2ae6-47eb-8ee7-5a457a308c68","number_of_nodes":1,"memory_in_mb":128,"storage_in_mb":0,"price":{"ex_vat" : "0.031", "inc_vat" : "0.037", "details" : [{"name" : "instance", "start" : "2018-06-21T11:07:28+00:00", "stop" : "2018-06-22T07:33:42+00:00", "plan_name" : "app", "ex_vat" : "0.021", "inc_vat" : "0.025", "vat_rate" : "0.2", "vat_code" : "Standard", "currency_code" : "USD", "currency_rate" : "0.8"}, {"name" : "platform", "start" : "2018-06-21T11:07:28+00:00", "stop" : "2018-06-22T07:33:42+00:00", "plan_name" : "app", "ex_vat" : "0.01", "inc_vat" : "0.012", "vat_rate" : "0.2", "vat_code" : "Standard", "currency_code" : "USD", "currency_rate" : "0.8"}]}}
+export const billableEvents = `[{
+        "resource_guid": "e0a488d0-6f1d-4d01-8ad6-725422405250",
+        "resource_name": "alfred",
+        "resource_type": "postgres",
+        "org_guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275",
+	"org_name": "admin",
+        "space_guid": "5489e195-c42b-4e61-bf30-323c331ecc01",
+	"space_name": "real-hero",
+	"component_name": "component",
+        "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
+	"plan_name": "staging",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "0.02",
+        "charge_gbp_inc_vat": "0.024",
+	"charge_usd_exc_vat": "0.015"
+        },
+	{
+        "resource_guid": "537594b7-b76a-4f5a-941b-675d0297abf8",
+        "resource_name": "batman",
+        "resource_type": "app",
+        "org_guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275",
+	"org_name": "admin",
+        "space_guid": "bc8d3381-390d-4bd7-8c71-25309900a2e3",
+	"space_name": "pretty-face",
+	"component_name": "component",
+        "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
+	"plan_name": "staging",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "0.02",
+        "charge_gbp_inc_vat": "0.024",
+	"charge_usd_exc_vat": "0.015"
+        },
+{
+        "resource_guid": "029e0254-5307-4628-815a-2b8f4eb2d8fa",
+        "resource_name": "robin",
+        "resource_type": "app",
+        "org_guid": "3deb9f04-b449-4f94-b3dd-c73cefe5b275",
+	"org_name": "admin",
+        "space_guid": "bc8d3381-390d-4bd7-8c71-25309900a2e3",
+	"space_name": "pretty-face",
+	"component_name": "component",
+        "plan_guid": "eaa243f8-2ae6-47eb-8ee7-5a457a308c68",
+	"plan_name": "app",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "0.021",
+        "charge_gbp_inc_vat": "0.025",
+	"charge_usd_exc_vat": "0.015"
+        }
 ]`;
 
 export const currencyRates = `[

--- a/src/lib/billing/billing.test.ts
+++ b/src/lib/billing/billing.test.ts
@@ -15,21 +15,21 @@ describe('lib/billing test suite', () => {
       )
       .reply(
         200,
-	`[{
+        `[{
         "resource_guid": "a585feac-32a1-44f6-92e2-cdb1377e42f4",
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
         "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
-	"org_name": "org",
+        "org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
-	"space_name": "space",
-	"component_name": "component",
+        "space_name": "space",
+        "component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-	"plan_name": "plan",
+        "plan_name": "plan",
         "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
         "charge_gbp_exc_vat": "0.02",
         "charge_gbp_inc_vat": "0.024",
-	"charge_usd_exc_vat": "0.015"
+        "charge_usd_exc_vat": "0.015"
         }
       ]`,
       );
@@ -318,16 +318,16 @@ describe('lib/billing test suite', () => {
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
         "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
-	"org_name": "org",
+        "org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
-	"space_name": "space",
-	"component_name": "component",
+        "space_name": "space",
+        "component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-	"plan_name": "plan",
+        "plan_name": "plan",
         "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
         "charge_gbp_exc_vat": "not-a-number",
         "charge_gbp_inc_vat": "0.024",
-	"charge_usd_exc_vat": "0.015"
+        "charge_usd_exc_vat": "0.015"
         }
       ]`
       ,

--- a/src/lib/billing/billing.test.ts
+++ b/src/lib/billing/billing.test.ts
@@ -11,53 +11,27 @@ describe('lib/billing test suite', () => {
   it('should return billable events', async () => {
     nock(config.billingAPI)
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-01-02&org_guid=3deb9f04-b449-4f94-b3dd-c73cefe5b275',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-01-02T00:00:00Z&org_guid=3deb9f04-b449-4f94-b3dd-c73cefe5b275',
       )
       .reply(
         200,
-        `[{
-        "event_guid": "fecc9eb5-b027-42fe-ba1f-d90a0474b620",
-        "event_start": "2018-04-20T14:36:09+00:00",
-        "event_stop": "2018-04-20T14:45:46+00:00",
+	`[{
         "resource_guid": "a585feac-32a1-44f6-92e2-cdb1377e42f4",
         "resource_name": "api-availability-test-app",
         "resource_type": "app",
         "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
+	"org_name": "org",
         "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
+	"space_name": "space",
+	"component_name": "component",
         "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
-        "quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
-        "number_of_nodes": 1,
-        "memory_in_mb": 64,
-        "storage_in_mb": 0,
-        "price": {
-          "ex_vat": "0.02",
-          "inc_vat": "0.024",
-          "details": [
-            {
-              "name": "instance",
-              "start": "2018-04-20T14:36:09+00:00",
-              "stop": "2018-04-20T14:45:46+00:00",
-              "plan_name": "app",
-              "ex_vat": "0.01",
-              "inc_vat": "0.012",
-              "vat_rate": "0.2",
-              "vat_code": "Standard",
-              "currency_code": "GBP"
-            },
-            {
-              "name": "platform",
-              "start": "2018-04-20T14:36:09+00:00",
-              "stop": "2018-04-20T14:45:46+00:00",
-              "plan_name": "app",
-              "ex_vat": "0.01",
-              "inc_vat": "0.012",
-              "vat_rate": "0.2",
-              "vat_code": "Standard",
-              "currency_code": "GBP"
-            }
-          ]
+	"plan_name": "plan",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "0.02",
+        "charge_gbp_inc_vat": "0.024",
+	"charge_usd_exc_vat": "0.015"
         }
-      }]`,
+      ]`,
       );
 
     const bc = new BillingClient({
@@ -152,7 +126,7 @@ describe('lib/billing test suite', () => {
 
   it('should return pricing plans', async () => {
     nock(config.billingAPI)
-      .get('/pricing_plans?range_start=2018-01-01&range_stop=2018-01-02')
+      .get('/pricing_plans?range_start=2018-01-01T00:00:00Z&range_stop=2018-01-02T00:00:00Z')
       .reply(
         200,
         `[
@@ -198,7 +172,7 @@ describe('lib/billing test suite', () => {
 
   it('should return currency rates', async () => {
     nock(config.billingAPI)
-      .get('/currency_rates?range_start=2018-01-01&range_stop=2019-01-01')
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2019-01-01T00:00:00Z')
       .reply(
         200,
         `[
@@ -244,7 +218,7 @@ describe('lib/billing test suite', () => {
 
   it('should return VAT rates', async () => {
     nock(config.billingAPI)
-      .get('/vat_rates?range_start=2018-01-01&range_stop=2019-01-01')
+      .get('/vat_rates?range_start=2018-01-01T00:00:00Z&range_stop=2019-01-01T00:00:00Z')
       .reply(
         200,
         `[
@@ -291,7 +265,7 @@ describe('lib/billing test suite', () => {
   it('should throw an error when API response with 500', async () => {
     nock(config.billingAPI)
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-01-02&org_guid=org-guid-500',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-01-02T00:00:00Z&org_guid=org-guid-500',
       )
       .reply(500, '{"message":"NOT OK"}');
 
@@ -313,7 +287,7 @@ describe('lib/billing test suite', () => {
   it('should throw an error when API response with 500 and no data', async () => {
     nock(config.billingAPI)
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-01-02&org_guid=org-guid-500-no-data',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-01-02T00:00:00Z&org_guid=org-guid-500-no-data',
       )
       .reply(500);
 
@@ -335,19 +309,28 @@ describe('lib/billing test suite', () => {
   it('should throw an error when API response contains invalid price', async () => {
     nock(config.billingAPI)
       .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-01-02&org_guid=org-guid-bad-price',
+        '/billable_events?range_start=2018-01-01T00:00:00Z&range_stop=2018-01-02T00:00:00Z&org_guid=org-guid-bad-price',
       )
       .reply(
         200,
         `[{
-        "event_start": "2018-04-20T14:36:09+00:00",
-        "event_stop": "2018-04-20T14:45:46+00:00",
-        "price": {
-          "ex_vat": "not-a-number",
-          "inc_vat": "1.0",
-          "details": []
+        "resource_guid": "a585feac-32a1-44f6-92e2-cdb1377e42f4",
+        "resource_name": "api-availability-test-app",
+        "resource_type": "app",
+        "org_guid": "7f9c0e11-e7f1-41d7-9d3f-cb9d05110f9e",
+	"org_name": "org",
+        "space_guid": "2e030634-2640-4535-88ed-e67235b52ceb",
+	"space_name": "space",
+	"component_name": "component",
+        "plan_guid": "f4d4b95a-f55e-4593-8d54-3364c25798c4",
+	"plan_name": "plan",
+        "org_quota_definition_guid": "3f2dd80c-7dfb-4e7f-b8a9-406b0b8abfa3",
+        "charge_gbp_exc_vat": "not-a-number",
+        "charge_gbp_inc_vat": "0.024",
+	"charge_usd_exc_vat": "0.015"
         }
-      }]`,
+      ]`
+      ,
       );
 
     const bc = new BillingClient({
@@ -365,36 +348,4 @@ describe('lib/billing test suite', () => {
     ).rejects.toThrow(/failed to parse 'not-a-number' as a number/);
   });
 
-  it('should throw an error when API response contains invalid start_date', async () => {
-    nock(config.billingAPI)
-      .get(
-        '/billable_events?range_start=2018-01-01&range_stop=2018-01-02&org_guid=org-guid-invalid-date',
-      )
-      .reply(
-        200,
-        `[{
-        "event_start": "14:36 20-04-2018",
-        "event_stop": "2018-04-20T14:45:46+00:00",
-        "price": {
-          "ex_vat": "0.02",
-          "inc_vat": "0.024",
-          "details": []
-        }
-      }]`,
-      );
-
-    const bc = new BillingClient({
-      accessToken: '__ACCESS_TOKEN__',
-      apiEndpoint: config.billingAPI,
-      logger: pino({ level: 'silent' }),
-    });
-
-    await expect(
-      bc.getBillableEvents({
-        orgGUIDs: ['org-guid-invalid-date'],
-        rangeStart: new Date('2018-01-01'),
-        rangeStop: new Date('2018-01-02'),
-      }),
-    ).rejects.toThrow(/invalid date format: 14:36 20-04-2018/);
-  });
 });

--- a/src/lib/billing/billing.test.ts
+++ b/src/lib/billing/billing.test.ts
@@ -347,5 +347,31 @@ describe('lib/billing test suite', () => {
       }),
     ).rejects.toThrow(/failed to parse 'not-a-number' as a number/);
   });
+it('should throw invalid date', async () => {
+    nock(config.billingAPI)
+      .get('/currency_rates?range_start=2018-01-01T00:00:00Z&range_stop=2019-01-01T00:00:00Z')
+      .reply(
+        200,
+        `[
+        {
+          "code": "GBP",
+          "rate": 1.0,
+          "valid_from": "2017-13-13"
+        }
+      ]`,
+      );
+
+    const bc = new BillingClient({
+      accessToken: '__ACCESS_TOKEN__',
+      apiEndpoint: config.billingAPI,
+      logger: pino({ level: 'silent' }),
+    });
+    await expect( bc.getCurrencyRates({
+      rangeStart: new Date('2018-01-01'),
+      rangeStop: new Date('2019-01-01'),
+    }),
+    ).rejects.toThrow(/BillingClient: invalid date format: 2017-13-13/)
+
+  });
 
 });

--- a/src/lib/billing/billing.ts
+++ b/src/lib/billing/billing.ts
@@ -100,6 +100,44 @@ function parseBillableEvent(ev: t.IBillableEventResponse): t.IBillableEvent {
   };
 }
 
+function parseFlatBillableEvent(ev: t.IFlatBillableEventResponse): t.IBillableEvent {
+  return {
+    eventGUID: "",
+    eventStart: new Date("1970-01-01"),
+    eventStop: new Date("1970-01-01"),
+    resourceGUID: ev.resource_guid,
+    resourceName: ev.resource_name,
+    resourceType: ev.resource_type,
+    orgGUID: ev.org_guid,
+    spaceGUID: ev.space_guid,
+    spaceName: ev.space_name,
+    planGUID: ev.plan_guid,
+    numberOfNodes: 0,
+    memoryInMB: 0,
+    storageInMB: 0,
+    price: {
+      details: parseFlatPriceComponent(ev),
+      exVAT: parseNumber(ev.charge_gbp_exc_vat),
+      incVAT: parseNumber(ev.charge_gbp_inc_vat,),
+    },
+    quotaGUID: ev.org_quota_definition_guid,
+  };
+}
+
+function parseFlatPriceComponent(ev: t.IFlatBillableEventResponse): ReadonlyArray<t.IPriceComponent> {
+  return [{
+    name: ev.component_name,
+    planName: ev.plan_name,
+    start: new Date("1970-01-01"),
+    stop: new Date("1970-01-01"),
+    VATCode: "Standard",
+    VATRate: 0.2,
+    currencyCode: "GBP",
+    incVAT: parseNumber(ev.charge_gbp_inc_vat),
+    exVAT: parseNumber(ev.charge_gbp_exc_vat),
+  }]
+}
+
 function parseComponentResponse(component: t.IComponentResponse): t.IComponent {
   return {
     currencyCode: component.currency_code,

--- a/src/lib/billing/billing.ts
+++ b/src/lib/billing/billing.ts
@@ -118,7 +118,7 @@ function parseFlatBillableEvent(ev: t.IFlatBillableEventResponse): t.IBillableEv
     price: {
       details: parseFlatPriceComponent(ev),
       exVAT: parseNumber(ev.charge_gbp_exc_vat),
-      incVAT: parseNumber(ev.charge_gbp_inc_vat,),
+      incVAT: parseNumber(ev.charge_gbp_inc_vat),
     },
     quotaGUID: ev.org_quota_definition_guid,
   };

--- a/src/lib/billing/billing.ts
+++ b/src/lib/billing/billing.ts
@@ -16,7 +16,7 @@ interface IBillingClientConfig {
 }
 
 function parseDate(d: Date): string {
-  return format(new Date(d), 'yyyy-MM-dd');
+  return format(new Date(d), "yyyy-MM-dd'T'HH:mm:ss'Z'");
 }
 
 function parseTimestamp(s: string): Date {

--- a/src/lib/billing/billing.ts
+++ b/src/lib/billing/billing.ts
@@ -243,9 +243,9 @@ export default class BillingClient {
       url: '/billable_events',
     });
 
-    const data: ReadonlyArray<t.IBillableEventResponse> = response.data;
+    const data: ReadonlyArray<t.IFlatBillableEventResponse> = response.data;
 
-    return data.map(parseBillableEvent);
+    return data.map(parseFlatBillableEvent);
   }
 
   public async getForecastEvents(params: t.IForecastParameters): Promise<ReadonlyArray<t.IBillableEvent>> {

--- a/src/lib/billing/types.ts
+++ b/src/lib/billing/types.ts
@@ -110,6 +110,23 @@ export interface IBillableEventResponse extends IUsageEventResponse {
   };
 }
 
+export interface IFlatBillableEventResponse  {
+  readonly org_guid: string;
+  readonly org_name: string;
+  readonly org_quota_definition_guid: string;
+  readonly plan_guid: string;
+  readonly plan_name: string;
+  readonly space_guid: string;
+  readonly space_name: string;
+  readonly resource_guid: string;
+  readonly resource_type: string;
+  readonly resource_name: string;
+  readonly component_name: string;
+  readonly charge_gbp_inc_vat: string;
+  readonly charge_gbp_exc_vat: string;
+  readonly charge_usd_exc_vat: string;
+}
+
 export interface IPriceComponentResponse {
   readonly name: string;
   readonly plan_name: string;

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -9,6 +9,7 @@ const envVars = {
   AUTHORIZATION_URL: 'https://example.com/login',
   AWS_REGION: 'eu-west-1',
   BILLING_URL: 'https://example.com/billing',
+  NEW_BILLING_URL: 'https://example.com/billing',
   DOMAIN_NAME: 'https://admin.example.com',
   GOOGLE_CLIENT_ID: 'GOOGLE_CLIENT_ID',
   GOOGLE_CLIENT_SECRET: 'GOOGLE_CLIENT_SECRET',

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,7 @@ async function main() {
       accessKeyId: "FAKE_ACCESS_KEY_ID",
       secretAccessKey: "FAKE_SECRET_ACCESS_KEY",
     },
-    billingAPI: expectEnvVariable('BILLING_URL'),
+    billingAPI: expectEnvVariable('NEW_BILLING_URL'),
     cloudFoundryAPI,
     domainName: expectEnvVariable('DOMAIN_NAME'),
     location,


### PR DESCRIPTION
What
----

- Introduce data type and parsers to handle new-billing output for statements and reports.
- Switch over data type and parser use to actually work against the new output (this will require additional steps to minimise downtime [link](https://hackmd.cloudapps.digital/bR_sdMLASVSbozHGbUyLfQ)).
- Change time range stop handling in current month to explicitly pass current time (new-billing would otherwise extrapolate data).

How to review
-------------

- Code review
- Deploy/test against dev env (we currently have dfe production data available in `dev03` in org `mini-test`).
- Testing might require to point the BILLING_URL environment variable of paas-admin against a new-billing endpoint (e.g.: `cf set-env paas-admin BILLING_URL https://new-billing.dev03.dev.cloudpipeline.digital; cf restage paas-admin;`).
I (@schmie) am happy to pair if anything is unclear : )

Who can review
---------------

not @schmie 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
