### PR TITLE
Bump govuk-frontend to v4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "express-pino-logger": "^7.0.0",
         "express-static-gzip": "^2.1.3",
         "fnv-plus": "^1.3.1",
-        "govuk-frontend": "^4.0.0",
+        "govuk-frontend": "^4.0.1",
         "happy-dom": "^2.31.1",
         "helmet": "^5.0.2",
         "jsonwebtoken": "^8.5.1",
@@ -10796,9 +10796,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
-      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
+      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -27827,9 +27827,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
-      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
+      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
     },
     "graceful-fs": {
       "version": "4.2.9",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "express-pino-logger": "^7.0.0",
     "express-static-gzip": "^2.1.3",
     "fnv-plus": "^1.3.1",
-    "govuk-frontend": "^4.0.0",
+    "govuk-frontend": "^4.0.1",
     "happy-dom": "^2.31.1",
     "helmet": "^5.0.2",
     "jsonwebtoken": "^8.5.1",

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -469,7 +469,6 @@ export function EditPage(props: IEditPageProperties): ReactElement {
             className="govuk-error-summary"
             aria-labelledby="error-summary-title"
             role="alert"
-            tabIndex={-1}
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">
@@ -559,7 +558,6 @@ export function InvitePage(props: IInvitePageProperties): ReactElement {
             className="govuk-error-summary"
             aria-labelledby="error-summary-title"
             role="alert"
-            tabIndex={-1}
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">

--- a/src/components/platform-admin/views.tsx
+++ b/src/components/platform-admin/views.tsx
@@ -250,8 +250,12 @@ export function CreateOrganizationPage(props: ICreateOrganizationPageProperties)
       <input type="hidden" name="_csrf" value={props.csrf} />
 
       {props.errors
-        ? <div className="govuk-error-summary" aria-labelledby="error-summary-title"
-            role="alert" tabIndex={-1} data-module="govuk-error-summary">
+        ? <div 
+            className="govuk-error-summary"
+            aria-labelledby="error-summary-title"
+            role="alert"
+            data-module="govuk-error-summary"
+          >
             <h2 className="govuk-error-summary__title" id="error-summary-title">
               There is a problem
             </h2>
@@ -324,8 +328,12 @@ export function ContactOrganisationManagersPage(props: IContactOrganisationManag
         <input type="hidden" name="_csrf" value={props.csrf} />
 
         {props.errors
-          ? <div className="govuk-error-summary" aria-labelledby="error-summary-title"
-              role="alert" tabIndex={-1} data-module="govuk-error-summary">
+          ? <div 
+              className="govuk-error-summary"
+              aria-labelledby="error-summary-title"
+              role="alert"
+              data-module="govuk-error-summary"
+            >
               <h2 className="govuk-error-summary__title" id="error-summary-title">
                 There is a problem
               </h2>

--- a/src/components/support/views.tsx
+++ b/src/components/support/views.tsx
@@ -99,7 +99,6 @@ export function SupportSelectionPage(props: ISupportSelectionFormProperties): Re
             className="govuk-error-summary"
             aria-labelledby="error-summary-title"
             role="alert"
-            tabIndex={-1}
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">
@@ -248,7 +247,6 @@ export function SomethingWrongWithServicePage(props: ISomethingWrongWithServiceF
             className="govuk-error-summary"
             aria-labelledby="error-summary-title"
             role="alert"
-            tabIndex={-1}
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">
@@ -586,7 +584,6 @@ export function HelpUsingPaasPage(props: IHelpUsingPaasFormProperties): ReactEle
             className="govuk-error-summary"
             aria-labelledby="error-summary-title"
             role="alert"
-            tabIndex={-1}
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">
@@ -764,7 +761,6 @@ export function FindOutMorePage(props: IFindOutMoreFormProperties): ReactElement
             className="govuk-error-summary"
             aria-labelledby="error-summary-title"
             role="alert"
-            tabIndex={-1}
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">
@@ -974,7 +970,6 @@ export function ContactUsPage(props: IContactUsFormProperties): ReactElement {
             className="govuk-error-summary"
             aria-labelledby="error-summary-title"
             role="alert"
-            tabIndex={-1}
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">
@@ -1296,7 +1291,6 @@ export function SignUpPage(props: ISignupFormProperties): ReactElement {
             className="govuk-error-summary"
             aria-labelledby="error-summary-title"
             role="alert"
-            tabIndex={-1}
             data-module="govuk-error-summary"
           >
             <h2 className="govuk-error-summary__title" id="error-summary-title">

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -124,7 +124,6 @@ export function PasswordResetRequest(props: IPasswordResetFormProperties): React
         className="govuk-error-summary"
         aria-labelledby="error-summary-title"
         role="alert"
-        tabIndex={-1}
         data-module="govuk-error-summary"
       >
         <h2 className="govuk-error-summary__title" id="error-summary-title">
@@ -218,7 +217,6 @@ export function PasswordResetSetPasswordForm(props: IPasswordResetSetPasswordFor
         className="govuk-error-summary"
         aria-labelledby="error-summary-title"
         role="alert"
-        tabIndex={-1}
         data-module="govuk-error-summary"
       >
         <h2 className="govuk-error-summary__title" id="error-summary-title">


### PR DESCRIPTION
What
----

- bump govuk-frontend to v4.0.1
- remove `tabIndex` property from error-summary as per https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.1

How to review
-------------

- run locally and check that `tabindex` attribute gets applied by javascript on page load focus when submitting an empty form (say /support)

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
