### PR TITLE
Add marinemanagement.org.uk as good signup domain

### DIFF
--- a/src/components/support/controllers.test.tsx
+++ b/src/components/support/controllers.test.tsx
@@ -77,7 +77,7 @@ describe(controller.HandleSignupFormPost, () => {
     expect(response.status).toEqual(400);
     expect(response.body).not.toContain('We have received your request');
     expect(response.body).toContain('Error');
-    expect(response.body).toContain('We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, .police.uk or police.uk email addresses');
+    expect(response.body).toContain('We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, marinemanagement.org.uk, .police.uk or police.uk email addresses');
   });
 
   it('should throw a validation error when option to add additional users was selected but no email addresses entered', async () => {

--- a/src/components/support/controllers.tsx
+++ b/src/components/support/controllers.tsx
@@ -260,7 +260,7 @@ function validateServiceTeam({ service_team }: ISupportFormServiceTeam): Readonl
 function validateSignupEmail({ email }: ISignupForm): ReadonlyArray<IDualValidationError> {
   const errors = [];
 
-  const allowedEmailAddresses = /(.+\.gov\.uk|.+nhs\.(net|uk)|.+mod\.uk|.+digitalaccessibilitycentre\.org|.+\.police\.uk|police\.uk)$/;
+  const allowedEmailAddresses = /(.+\.gov\.uk|.+nhs\.(net|uk)|.+mod\.uk|.+digitalaccessibilitycentre\.org|.+marinemanagement\.org\.uk|.+\.police\.uk|police\.uk.)$/;
 
   if (!email || !VALID_EMAIL.test(email)) {
     errors.push({
@@ -272,7 +272,7 @@ function validateSignupEmail({ email }: ISignupForm): ReadonlyArray<IDualValidat
   if (email && VALID_EMAIL.test(email) && !allowedEmailAddresses.test(email)) {
     errors.push({
       field: 'email',
-      message: 'We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, .police.uk or police.uk email addresses',
+      message: 'We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, marinemanagement.org.uk, .police.uk or police.uk email addresses',
       messageExtra: `
         If you work for a government organisation or public body with a different email address, please contact us on
         <a class="govuk-link"


### PR DESCRIPTION
What
----
Add marinemanagement.org.uk as good signup domain.
The marine management organisation is an arms length body of DEFRA and they are interested in hosting a thing on GOV.UK PaaS.

How to review
-------------

- Code review
- CI
- Test locally that a `marinemanagement.org.uk` email address is accepted for platform signup.

Who can review
---------------

not @schmie

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
