### PR TITLE
[#179606510] Enable paas-admin to use a CF dev environment during development

### DIFF
--- a/config/use-dev-env.sh
+++ b/config/use-dev-env.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+
+DEPLOY_ENV="$1"
+SYSTEM_DOMAIN="${DEPLOY_ENV}.dev.cloudpipeline.digital"
+
+function service_domain () {
+  echo "https://${1}.${SYSTEM_DOMAIN}"
+}
+
+echo "You will need to access to Credhub for ${DEPLOY_ENV}."
+echo "In the paas-cf repository run"
+echo "  gds aws paas-dev-admin -- make ${DEPLOY_ENV} credhub"
+echo "and follow the instructions on screen"
+echo ""
+
+
+## Set up environment
+export PORT=${PORT-3000}
+export DOMAIN_NAME="http://localhost:3000/"
+
+export STUB_ACCOUNTS_PORT=${STUB_ACCOUNTS_PORT-1337}
+export STUB_BILLING_PORT=${STUB_BILLING_PORT-1338}
+export STUB_CF_PORT=${STUB_CF_PORT-1339}
+export STUB_UAA_PORT=${STUB_UAA_PORT-1340}
+export STUB_AWS_PORT=${STUB_AWS_PORT-1341}
+export STUB_PROMETHEUS_PORT=${STUB_PROMETHEUS_PORT-1342}
+export STUB_PLATFORM_METRICS_PORT=${STUB_PLATFORM_METRICS_PORT-1343}
+
+export ACCOUNTS_URL=$(service_domain "accounts")
+export BILLING_URL=$(service_domain "billing")
+export API_URL=$(service_domain "api")
+export UAA_URL=$(service_domain "uaa")
+export AUTHORIZATION_URL=$(service_domain "uaa")
+
+export AWS_CLOUDWATCH_ENDPOINT=http://0:${STUB_AWS_PORT}
+export PROMETHEUS_ENDPOINT=http://0:${STUB_PROMETHEUS_PORT}
+export PROMETHEUS_USERNAME=not-used
+export PROMETHEUS_PASSWORD=not-used
+
+read -p $'Enter the PaaS accounts secret: (credhub get -q -n "/concourse/main/create-cloudfoundry/paas_accounts_password")\n' accounts_secret
+export ACCOUNTS_SECRET="${accounts_secret}"
+
+read -p $'Enter the Notify API key: (credhub get -q -n "/concourse/main/create-cloudfoundry/notify_api_key")\n' notify_api_key
+export NOTIFY_API_KEY="${notify_api_key}"
+export NOTIFY_WELCOME_TEMPLATE_ID="1859ce68-f133-4218-ac6e-a8ef32a41292"
+
+
+export OAUTH_CLIENT_ID=paas-admin-local
+export OAUTH_CLIENT_SECRET=local-dev
+export AWS_REGION=eu-west-2
+export GOOGLE_CLIENT_ID=googleclientid
+export GOOGLE_CLIENT_SECRET=googleclientsecret
+
+export ENABLE_FAKE_AWS_CREDENTIALS=true
+
+export PLATFORM_METRICS_ENDPOINT=http://0:${STUB_PLATFORM_METRICS_PORT-1343}
+
+## Start the dev server
+npm start

--- a/config/use-dev-env.sh
+++ b/config/use-dev-env.sh
@@ -32,7 +32,8 @@ export API_URL=$(service_domain "api")
 export UAA_URL=$(service_domain "uaa")
 export AUTHORIZATION_URL=$(service_domain "uaa")
 
-export AWS_CLOUDWATCH_ENDPOINT=http://0:${STUB_AWS_PORT}
+export AWS_REGION=eu-west-1
+export AWS_CLOUDWATCH_ENDPOINT="https://monitoring.${AWS_REGION}.amazonaws.com"
 export PROMETHEUS_ENDPOINT=http://0:${STUB_PROMETHEUS_PORT}
 export PROMETHEUS_USERNAME=not-used
 export PROMETHEUS_PASSWORD=not-used
@@ -44,14 +45,10 @@ read -p $'Enter the Notify API key: (credhub get -q -n "/concourse/main/create-c
 export NOTIFY_API_KEY="${notify_api_key}"
 export NOTIFY_WELCOME_TEMPLATE_ID="1859ce68-f133-4218-ac6e-a8ef32a41292"
 
-
 export OAUTH_CLIENT_ID=paas-admin-local
 export OAUTH_CLIENT_SECRET=local-dev
-export AWS_REGION=eu-west-2
 export GOOGLE_CLIENT_ID=googleclientid
 export GOOGLE_CLIENT_SECRET=googleclientsecret
-
-export ENABLE_FAKE_AWS_CREDENTIALS=true
 
 export PLATFORM_METRICS_ENDPOINT=http://0:${STUB_PLATFORM_METRICS_PORT-1343}
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "scrape:performance": "ts-node src/scripts/performance.ts",
     "start": "export PORT=${PORT-3000}; export LOG_LEVEL=${LOG_LEVEL-warn}; if [ \"$NODE_ENV\" = 'production' ]; then npm run -s start:production; else npm run -s start:dev; fi",
     "start:dev": "NODE_ENV=development ENABLE_WATCH=true ENABLE_SERVER=true ALLOW_INSECURE_SESSION=true npm run -s build",
+    "start:dev:with-cf-dev-env": "./config/use-dev-env.sh",
     "start:stub-api": "./stub-api/start-stub-api.sh",
     "start:with-stub-api": "./stub-api/start-with-stub-api.sh",
     "start:production": "NODE_ENV=production ALLOW_INSECURE_SESSION=true npm run -s build && node dist/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,10 +84,10 @@ async function main() {
     awsCloudwatchEndpoint: process.env.AWS_CLOUDWATCH_ENDPOINT,
     awsRegion,
     awsResourceTaggingAPIEndpoint: process.env.AWS_RESOURCE_TAGGING_API_ENDPOINT,
-    awsCredentials: !process.env.ENABLE_FAKE_AWS_CREDENTIALS? undefined : {
+    awsCredentials: process.env.ENABLE_FAKE_AWS_CREDENTIALS === 'true' ? {
       accessKeyId: "FAKE_ACCESS_KEY_ID",
       secretAccessKey: "FAKE_SECRET_ACCESS_KEY",
-    },
+    } : undefined,
     billingAPI: expectEnvVariable('BILLING_URL'),
     cloudFoundryAPI,
     domainName: expectEnvVariable('DOMAIN_NAME'),


### PR DESCRIPTION
What
----

Enables paas-admin to use the APIs of a CF dev env. This is a quality of life enhancement.

Run `npm run start:dev:with-cf-dev-env DEPLOY_ENV`. 

It will only work in development environments once [an enabling PR in `paas-cf`](https://github.com/alphagov/paas-cf/pull/2848) has gone out. It's currently only deployed in `dev03`.

How to review
-------------
Code review
Try it out

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
