### PR TITLE
Removes nhs.uk from allowed email addresses

### DIFF
--- a/src/components/support/controllers.test.tsx
+++ b/src/components/support/controllers.test.tsx
@@ -77,7 +77,7 @@ describe(controller.HandleSignupFormPost, () => {
     expect(response.status).toEqual(400);
     expect(response.body).not.toContain('We have received your request');
     expect(response.body).toContain('Error');
-    expect(response.body).toContain('We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, marinemanagement.org.uk, ukri.org, .police.uk or police.uk email addresses');
+    expect(response.body).toContain('We only accept .gov.uk, .mod.uk, nhs.net, digitalaccessibilitycentre.org, marinemanagement.org.uk, ukri.org, .police.uk or police.uk email addresses');
   });
 
   it('should throw a validation error when option to add additional users was selected but no email addresses entered', async () => {

--- a/src/components/support/controllers.tsx
+++ b/src/components/support/controllers.tsx
@@ -260,7 +260,7 @@ function validateServiceTeam({ service_team }: ISupportFormServiceTeam): Readonl
 function validateSignupEmail({ email }: ISignupForm): ReadonlyArray<IDualValidationError> {
   const errors = [];
 
-  const allowedEmailAddresses = /(.+\.gov\.uk|.+nhs\.(net|uk)|.+mod\.uk|.+digitalaccessibilitycentre\.org|.+marinemanagement\.org\.uk|.+ukri\.org|.+\.police\.uk|police\.uk.)$/;
+  const allowedEmailAddresses = /(.+\.gov\.uk|.+nhs\.net|.+mod\.uk|.+digitalaccessibilitycentre\.org|.+marinemanagement\.org\.uk|.+ukri\.org|.+\.police\.uk|police\.uk.)$/;
 
   if (!email || !VALID_EMAIL.test(email)) {
     errors.push({
@@ -272,7 +272,7 @@ function validateSignupEmail({ email }: ISignupForm): ReadonlyArray<IDualValidat
   if (email && VALID_EMAIL.test(email) && !allowedEmailAddresses.test(email)) {
     errors.push({
       field: 'email',
-      message: 'We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, digitalaccessibilitycentre.org, marinemanagement.org.uk, ukri.org, .police.uk or police.uk email addresses',
+      message: 'We only accept .gov.uk, .mod.uk, nhs.net, digitalaccessibilitycentre.org, marinemanagement.org.uk, ukri.org, .police.uk or police.uk email addresses',
       messageExtra: `
         If you work for a government organisation or public body with a different email address, please contact us on
         <a class="govuk-link"

--- a/src/components/support/views.test.tsx
+++ b/src/components/support/views.test.tsx
@@ -326,7 +326,7 @@ describe(SignUpPage, () => {
       } as any}
       errors={[{
         field: 'email',
-        message: 'We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, .police.uk or police.uk email addresses',
+        message: 'We only accept .gov.uk, .mod.uk, nhs.net, .police.uk or police.uk email addresses',
         messageExtra: 'If you work for a government organisation or public body with a different email address, please contact us on <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>',
       },
     ]}
@@ -334,7 +334,7 @@ describe(SignUpPage, () => {
     const $ = cheerio.load(markup.html());
     expect($('.govuk-error-summary')).toHaveLength(1);
     expect($('.govuk-error-summary li')).toHaveLength(1);
-    expect($('.govuk-error-summary li:first-child').text()).toContain('We only accept .gov.uk, .mod.uk, nhs.net, nhs.uk, .police.uk or police.uk email addresses');
+    expect($('.govuk-error-summary li:first-child').text()).toContain('We only accept .gov.uk, .mod.uk, nhs.net, .police.uk or police.uk email addresses');
     expect($('#email-error span:last-child').html()).toContain('If you work for a government organisation or public body with a different email address, please contact us on <a class="govuk-link" href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>');
     expect($('input#person_is_manager:checked')).toHaveLength(1);
     expect($('input#invite_users:checked')).toHaveLength(1);


### PR DESCRIPTION


What
----

Removes nhs.uk from allowed email addresses
We have been informed by cyber that anyone working for the nhs should be using an nhs.net account. The nhs.net ones are unaccounted for and might be compromised

How to review
-------------

Check all references to nhs.uk have been removed

Who can review
---------------

Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
