### PR TITLE
Remove request-promise-native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,6 @@
         "pegjs-loader": "^0.5.6",
         "pino-pretty": "^7.6.0",
         "puppeteer": "^13.5.2",
-        "request-promise-native": "^1.0.9",
         "sass": "^1.49.11",
         "sass-loader": "^12.6.0",
         "stylelint": "^14.6.1",
@@ -16608,39 +16607,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
     "node_modules/request/node_modules/qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -17452,15 +17418,6 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stream-shift": {
@@ -32276,26 +32233,6 @@
         }
       }
     },
-    "request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.19"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "dev": true,
-      "requires": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -32923,12 +32860,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
     },
     "stream-shift": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "pegjs-loader": "^0.5.6",
     "pino-pretty": "^7.6.0",
     "puppeteer": "^13.5.2",
-    "request-promise-native": "^1.0.9",
     "sass": "^1.49.11",
     "sass-loader": "^12.6.0",
     "stylelint": "^14.6.1",

--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -1,9 +1,3 @@
-// JSDOM requires request-promise-native, which doesn't load in the presence of Jest
-// This results in errors like the following:
-//   Unable to expose method "then" at Object.plumbing.exposePromiseMethod ...
-// Mocking request-promise-native is a workaround. See https://github.com/request/request-promise/issues/247.
-jest.mock('request-promise-native');
-
 import { endOfMonth, format, startOfMonth } from 'date-fns';
 import jwt from 'jsonwebtoken';
 import nock from 'nock';


### PR DESCRIPTION
What
----
Remove request-promise-native

Package deprecated and JSDOM (Jest's DOM) has moved away from it -
https://github.com/jsdom/jsdom/commit/f51f2ecca8b8beab28f12d91df4ab3eb963faa22 and
https://github.com/jsdom/jsdom/pull/3092


How to review
-------------

tests pass

Who can review
---------------

anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
