### PR TITLE
Fix metrics graphs

### DIFF
--- a/src/components/charts/line-graph.scss
+++ b/src/components/charts/line-graph.scss
@@ -1,3 +1,12 @@
+$graphcolours: (
+  "1": govuk-colour("orange"),
+  "2": govuk-colour("pink"),
+  "3": govuk-colour("light-blue"),
+  "4": govuk-colour("brown"),
+  "5": govuk-colour("green"),
+  "6": govuk-colour("turquoise"),
+);
+
 svg.govuk-paas-line-graph {
   max-width: 960px;
 
@@ -23,26 +32,20 @@ svg.govuk-paas-line-graph {
       stroke: govuk-colour("blue");
       stroke-width: 2.5px;
     }
-
-    &.series-1 {
-      stroke: govuk-colour("orange");
-    }
-
-    &.series-2 {
-      stroke: govuk-colour("pink");
-    }
   }
 
   .legend rect {
     fill: govuk-colour("blue");
   }
 
-  .legend-1 rect {
-    fill: govuk-colour("orange");
-  }
+  @each $graphcolour, $i in $graphcolours {
+    .legend-#{$graphcolour} rect {
+      fill: $i;
+    }
 
-  .legend-2 rect {
-    fill: govuk-colour("pink");
+    path.series-#{$graphcolour} {
+      stroke: $i;
+    }
   }
 
   .axis {


### PR DESCRIPTION
What
----

Make changes to graph lines and labels to make them more legible.

There are currently [live examples](https://admin.london.cloud.service.gov.uk/organisations/24993f52-c44f-4763-ac35-2a2c24a8807a/spaces/e39f44aa-8f1d-4551-952c-0127c2186b46/services/77409764-8e5d-485a-b280-6b60ab19fceb/metrics?rangeStart=2022-04-12T12%3A29%3A30Z&rangeStop=2022-04-13T12%3A29%3A30Z) of graphs than have more than two items and long legend names and it doesn't look great.

Changes in this PR dynamically adjust SVG `viewBox` to make room for vertically stacked legend items and position them below the axis.

Additionally, we only catered for two colours. We now cater for up to 6.

### Before
![Screenshot 2022-04-13 at 13 35 36](https://user-images.githubusercontent.com/3758555/163181136-24664aa0-e5c0-4ee3-9939-cffa53820827.png)


### After

![Screenshot 2022-04-13 at 13 20 20](https://user-images.githubusercontent.com/3758555/163180926-b1b0ecd4-8bd4-4e1d-b58b-b85a5802764b.png)

![Screenshot 2022-04-13 at 13 23 43](https://user-images.githubusercontent.com/3758555/163180928-bc0db7ec-b6fd-425a-b504-ef7b3e59531d.png)


How to review
-------------

- amend [stub](https://github.com/alphagov/paas-admin/blob/main/stub-api/stub-aws.ts#L33-L34) and add up to 6 items

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
