### PR TITLE
Modify org users table display

### DIFF
--- a/src/components/org-users/views.test.tsx
+++ b/src/components/org-users/views.test.tsx
@@ -382,6 +382,22 @@ describe(OrganizationUsersPage, () => {
     expect($('tbody tr:nth-child(2) td:nth-child(7)').text()).toContain(lastLogonTimeFormatted);
     
   });
+
+  it('should not show a table of users if there are no users', () => {
+    const NoUsers = {};
+    const markup = shallow(
+      <OrganizationUsersPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        organizationGUID="ORG_GUID"
+        privileged={false}
+        users={NoUsers}
+        userExtraInfo={{}}
+      />,
+    );
+    const $ = cheerio.load(markup.html());
+    expect($('table').length).toEqual(0);
+    expect($('body').text()).toContain('There are currently no team members');
+  });
 });
 
 describe(SuccessPage, () => {
@@ -411,3 +427,4 @@ describe(SuccessPage, () => {
     expect($('.govuk-body').text()).toContain('children text');
   });
 });
+

--- a/src/components/org-users/views.tsx
+++ b/src/components/org-users/views.tsx
@@ -714,6 +714,7 @@ export function OrganizationUsersPage(
             </div>
           </div>
           <h2 className="govuk-heading-m">Current team members</h2>
+          {Object.keys(props.users).length > 0 ? (
           <div className="scrollable-table-container">
             <table className="govuk-table user-list-table">
             <thead className="govuk-table__head">
@@ -833,6 +834,7 @@ export function OrganizationUsersPage(
             </tbody>
           </table>
           </div>
+          ):(<p>There are currently no team members.</p>)}
         </div>
       </div>
     </>


### PR DESCRIPTION
What
----

[There are cases](https://admin.london.cloud.service.gov.uk/organisations/d96a0801-7a7c-4706-b546-cf4ca9b4ad31/users) where an org might not contain any members.
Currently we still show the table header which is not right.

This PR checks if any users exists and if not, does not render the table at all.

## Visual changes

### Before

![Screenshot 2022-04-14 at 09 41 20](https://user-images.githubusercontent.com/3758555/163349785-6e9b9923-e6a4-47d8-97e6-f01e52501493.png)

### After

![Screenshot 2022-04-14 at 09 41 03](https://user-images.githubusercontent.com/3758555/163349830-97177ca2-58d7-4611-b4fa-f1e414fba53e.png)


How to review
-------------

- check test passes
- can deploy locally or to a dev env and remove all users from an org to check

Who can review
---------------
not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
