### PR TITLE
Raise dependabot open pr limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION


What
----

Raise dependabot open pr limit

By default the limit is 5 PRs. That creates a false impression that there are only a few updates necessary.

Raising to the max 10 PR limit will paint a clearer picture.

Config as per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

How to review
-------------

- agree or disagree with the change 

Who can review
---------------

anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
