### PR TITLE
Revert "Bump puppeteer from 14.1.2 to 14.2.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "pegjs": "^0.10.0",
         "pegjs-loader": "^0.5.6",
         "pino-pretty": "^7.6.1",
-        "puppeteer": "^14.2.1",
+        "puppeteer": "^14.1.2",
         "sass": "^1.52.2",
         "sass-loader": "^13.0.0",
         "stylelint": "^14.8.5",
@@ -7983,9 +7983,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1001819",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
-      "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ==",
+      "version": "0.0.982423",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.982423.tgz",
+      "integrity": "sha512-FnVW2nDbjGNw1uD/JRC+9U5768W7e1TfUwqbDTcSsAu1jXFjITSX8w3rkW5FEpHRMPPGpvNSmO1pOpqByiWscA==",
       "dev": true
     },
     "node_modules/dezalgo": {
@@ -16520,15 +16520,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.2.1.tgz",
-      "integrity": "sha512-cIEsAbEbNYqHbkvdZY4+YSdxVwh4YFqOHSezuLpu46XAYlKkQeAMdJQ+mDAxg9v77gIn8PHJ6PlftIVsWKRACA==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.1.2.tgz",
+      "integrity": "sha512-Nsyy1f7pT2KyBb15u8DHi4q3FfrIqOptAV0r4Bd1lAp2pHz8T0o4DO+On1yWZ7jFbcx1w3AqZ/e7nKqnc3Vwyg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1001819",
+        "devtools-protocol": "0.0.982423",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",
@@ -16537,7 +16537,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.7.0"
+        "ws": "8.6.0"
       },
       "engines": {
         "node": ">=14.1.0"
@@ -19834,9 +19834,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
+      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -26082,9 +26082,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1001819",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
-      "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ==",
+      "version": "0.0.982423",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.982423.tgz",
+      "integrity": "sha512-FnVW2nDbjGNw1uD/JRC+9U5768W7e1TfUwqbDTcSsAu1jXFjITSX8w3rkW5FEpHRMPPGpvNSmO1pOpqByiWscA==",
       "dev": true
     },
     "dezalgo": {
@@ -32612,14 +32612,14 @@
       }
     },
     "puppeteer": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.2.1.tgz",
-      "integrity": "sha512-cIEsAbEbNYqHbkvdZY4+YSdxVwh4YFqOHSezuLpu46XAYlKkQeAMdJQ+mDAxg9v77gIn8PHJ6PlftIVsWKRACA==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.1.2.tgz",
+      "integrity": "sha512-Nsyy1f7pT2KyBb15u8DHi4q3FfrIqOptAV0r4Bd1lAp2pHz8T0o4DO+On1yWZ7jFbcx1w3AqZ/e7nKqnc3Vwyg==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1001819",
+        "devtools-protocol": "0.0.982423",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",
@@ -32628,7 +32628,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.7.0"
+        "ws": "8.6.0"
       }
     },
     "qs": {
@@ -35170,9 +35170,9 @@
       }
     },
     "ws": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
+      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
     "pino-pretty": "^7.6.1",
-    "puppeteer": "^14.2.1",
+    "puppeteer": "^14.1.2",
     "sass": "^1.52.2",
     "sass-loader": "^13.0.0",
     "stylelint": "^14.8.5",


### PR DESCRIPTION
Reverts alphagov/paas-admin#2733

Acceptance test failing
https://deployer.london.staging.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-admin/builds/2136.1