### PR TITLE
Add UK Research and Innovation to the list of owners

### DIFF
--- a/src/components/organizations/owners.ts
+++ b/src/components/organizations/owners.ts
@@ -51,5 +51,6 @@ export const owners = [
   'Public Health England',
   'Student Awards Agency Scotland',
   'UK Export Finance',
+  'UK Research and Innovation',
   'UK Space Agency',
 ]


### PR DESCRIPTION

What
----
Add UK Research and Innovation to the list of owners
We had a trial account request from someone in UK Research and Innovation

How to review
-------------

Check that it's the same name as it appears in https://www.gov.uk/government/organisations


Who can review
---------------

Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
