### PR TITLE
Add requester details to zendesk support ticket if logged in

### DIFF
--- a/src/@types/node-zendesk/index.d.ts
+++ b/src/@types/node-zendesk/index.d.ts
@@ -660,6 +660,7 @@ declare module 'node-zendesk' {
       }
 
       interface ResponsePayload {
+          readonly id: number;
           readonly ticket: ResponseModel;
           readonly audit: Audit;
       }

--- a/src/components/account/account_user.test.ts
+++ b/src/components/account/account_user.test.ts
@@ -26,6 +26,15 @@ describe('AccountUser', () => {
     });
   });
 
+  describe('id', () => {
+    it('returns the users id', () => {
+      const uaaUser: any = { id: '11111' };
+
+      const acctUser = new AccountUser(uaaUser);
+      expect(acctUser.id).toEqual('11111');
+    });
+  });
+
   describe('authenticationMethod', () => {
     it('returns u&p if the user\'s origin is uaa', () => {
       const uaaUser: any = { origin: 'uaa' };

--- a/src/components/account/account_user.ts
+++ b/src/components/account/account_user.ts
@@ -11,6 +11,10 @@ export class AccountUser {
     return this.user.userName;
   }
 
+  get id(): string {
+    return this.user.id;
+  }
+
   get authenticationMethod(): string {
     switch (this.user.origin) {
       case 'uaa':


### PR DESCRIPTION
What
----

If the requester of our support forms is logged into paas-admin, we want to include their cloudfoundry details in the ticket as a private comment, so that we can quickly check that they have appropriate roles.

If they're not logged in or don't have an account, we also include that in the comment.

On form submission we check the session for user token and check UAA if the user exists. If not we, return an empty object.

If they do, we do a lookup if they're members of any organisations and if so what are their roles.

Once all the information is collated, we first create the zendesk ticket and then update it with the requester details in the private comment.

How to review
-------------

- best reviewed by commits
- can deploy to a dev env to test scenarios (or look at screenshot below)

Who can review
---------------

not @kr8n3r 

---
Not logged in
![Screenshot 2022-07-04 at 10 01 46](https://user-images.githubusercontent.com/3758555/177138406-8b90d2ef-eae1-4ee8-991e-d2e11087885c.png)

Logged in but no roles
![Screenshot 2022-07-04 at 10 03 07](https://user-images.githubusercontent.com/3758555/177138417-58dab973-768f-41f2-8122-06565d2f15c6.png)


All the data
![Screenshot 2022-07-04 at 10 05 13](https://user-images.githubusercontent.com/3758555/177138423-c9639ecc-6e5f-4452-ad69-f63ef2e40882.png)


🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨


