### PR TITLE
Cleanup old cookies for users

### DIFF
--- a/src/frontend/javascript/cookie-functions.js
+++ b/src/frontend/javascript/cookie-functions.js
@@ -1,0 +1,60 @@
+/* eslint-disable no-var, prefer-const */
+function Cookies () {
+  this.cookieName = 'govuk-paas-cookie-policy'
+  this.cookieDomain = 'cloud.service.gov.uk'
+  this.trackingId = 'UA-43115970-5'
+}
+
+Cookies.prototype.cookieCleanup = function () {
+  var isGaCookiePresent = !!(this.getCookie('_ga') && this.getCookie('_gid'))
+  var isPaasCookiePolicyCookiePresent = !!(this.getCookie(this.cookieName))
+  if (isGaCookiePresent) {
+    var gtagCookie = '_gat_gtag_' + this.trackingId.replace(/-/g, '_')
+
+    this.setCookie('_ga', '', { days: -1 })
+    this.setCookie('_gid', '', { days: -1 })
+    this.setCookie(gtagCookie, '', { days: -1 })
+  }
+
+  if (isPaasCookiePolicyCookiePresent) {
+    this.setCookie(this.cookieName, '', { days: -1 })
+  }
+}
+
+Cookies.prototype.setCookie = function (name, values, options) {
+  /* istanbul ignore next */
+  if (typeof options === 'undefined') {
+    options = {}
+  }
+
+  var cookieString = name + '=' + values
+  /* istanbul ignore next */
+  if (options.days) {
+    var date = new Date()
+    date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000))
+    cookieString = cookieString + '; expires=' + date.toGMTString() + ';domain=' + this.cookieDomain + '; path=/'
+  }
+  /* istanbul ignore next */
+  if (document.location.protocol === 'https:') {
+    cookieString = cookieString + '; Secure'
+  }
+
+  document.cookie = cookieString
+}
+
+Cookies.prototype.getCookie = function (name) {
+  var nameEQ = name + '='
+  var cookies = document.cookie.split(';')
+  for (var i = 0, len = cookies.length; i < len; i++) {
+    var cookie = cookies[i]
+    while (cookie.charAt(0) === ' ') {
+      cookie = cookie.substring(1, cookie.length)
+    }
+    if (cookie.indexOf(nameEQ) === 0) {
+      return decodeURIComponent(cookie.substring(nameEQ.length))
+    }
+  }
+  return null
+}
+
+export default Cookies

--- a/src/frontend/javascript/cookie-functions.test.js
+++ b/src/frontend/javascript/cookie-functions.test.js
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import Cookies from './cookie-functions'
+const cookies = new Cookies()
+
+const paasPolicyCookie = 'govuk-paas-cookie-policy'
+const randomOtherCookie = 'myCookie'
+
+describe("cookie clenaup function", () => {
+
+  afterEach(() => {
+    // reset cookies after each test
+    cookies.setCookie(paasPolicyCookie, '', { days: -1 })
+    cookies.setCookie(randomOtherCookie, '', { days: -1 })
+  })
+
+  it('if a govuk-paas-cookie-policy cookie exists, it should be deleted', () => {
+    cookies.cookieDomain = '' // to be able to set a cookie in test env
+    cookies.setCookie(paasPolicyCookie, 'no', { days: 1 })
+    cookies.cookieCleanup()
+
+    expect(document.cookie).not.toContain(paasPolicyCookie)
+  })
+
+  it('if a non govuk-paas-cookie-policy cookie exists, it should not be deleted', () => {
+    cookies.cookieDomain = '' // to be able to set a cookie in test env
+    cookies.setCookie(randomOtherCookie, 'test', { days: 1 })
+    cookies.cookieCleanup()
+
+    expect(document.cookie).toContain(randomOtherCookie)
+    expect(document.cookie).not.toContain(paasPolicyCookie)
+  })
+
+  it('if GA cookies exists, they should be deleted', () => {
+    cookies.cookieDomain = '' // to be able to set a cookie in test env
+    cookies.setCookie('_ga', 'test', { days: 1 })
+    cookies.setCookie('_gid', 'test', { days: 1 })
+    cookies.cookieCleanup()
+
+    expect(document.cookie).toBe('')
+  })
+})

--- a/src/frontend/javascript/init.js
+++ b/src/frontend/javascript/init.js
@@ -9,6 +9,11 @@ import {
 } from 'govuk-frontend'
 
 import Tooltip from './tooltip';
+import Cookies from './cookie-functions'
+
+var cookies = new Cookies()
+
+cookies.cookieCleanup()
 
 // there is ever only one header per page
 var $header = document.querySelector('[data-module="govuk-header"]')


### PR DESCRIPTION
What
----

In https://github.com/alphagov/paas-admin/pull/2908 we removed GA cookie
generation from paasmin. Together with https://github.com/alphagov/paas-product-pages/pull/203
and https://github.com/alphagov/paas-tech-docs/pull/456 we no longer
track and create cookies, but now need to delete those cookies for
users that have them.

Once user visit admin old cookies will be deleted.

This is a copy of the function introduced on product pages in https://github.com/alphagov/paas-product-pages/pull/203/commits/5af6ad92cfd27a51d1f6d15d565fbd1423cc9cbd
which is running on prod now.


How to review
-------------

- tests paas

Who can review
---------------

not @kr8n3r 
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
