### PR TITLE
Update contact managers form

### DIFF
--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -269,17 +269,6 @@ export const router = new Router([
     path: '/platform-admin/create-org',
   },
   {
-    action: platformAdmin.contactOrganisationManagers,
-    name: 'platform-admin.contact-organization-managers',
-    path: '/platform-admin/contact-organisation-managers',
-  },
-  {
-    action: platformAdmin.contactOrganisationManagersPost,
-    method: 'post',
-    name: 'platform-admin.contact-organization-managers.post',
-    path: '/platform-admin/contact-organisation-managers',
-  },
-  {
     action: marketplace.listServices,
     name: 'marketplace.view',
     path: '/marketplace',

--- a/src/components/app/router.ts
+++ b/src/components/app/router.ts
@@ -47,6 +47,17 @@ export const router = new Router([
     path: '/organisations/:organizationGUID/edit',
   },
   {
+    action: organizations.emailManagersForm,
+    name: 'admin.organizations.email-managers',
+    path: '/organisations/:organizationGUID/email-managers',
+  },
+  {
+    action: organizations.emailManagersFormPost,
+    method: 'post',
+    name: 'admin.organizations.email-managers.post',
+    path: '/organisations/:organizationGUID/email-managers',
+  },
+  {
     action: spaces.listApplications,
     name: 'admin.organizations.spaces.applications.list',
     path: '/organisations/:organizationGUID/spaces/:spaceGUID/applications',

--- a/src/components/organizations/controllers.test.tsx
+++ b/src/components/organizations/controllers.test.tsx
@@ -15,9 +15,10 @@ import { createTestContext } from '../app/app.test-helpers';
 import { IContext } from '../app/context';
 import { CLOUD_CONTROLLER_ADMIN, Token } from '../auth';
 
-import { editOrgData, updateOrgData } from './controllers';
+import { constructZendeskRequesterObject, editOrgData, emailManagersForm, emailManagersFormPost, emailManagersZendeskContent, updateOrgData } from './controllers';
 
 import { listOrganizations } from '.';
+import * as cfData from '../../lib/cf/cf.test.data';
 
 const organizations = JSON.stringify(
   wrapResources(
@@ -35,8 +36,6 @@ const organizations = JSON.stringify(
   ),
 );
 
-const tokenKey = 'secret';
-
 function extractOrganizations(responseBody: string): ReadonlyArray<string> {
   const re = /(Organisation\sname:)\s(.-(trial-)?org-name(-\d)?)/g;
   const matches = [];
@@ -52,14 +51,40 @@ function extractOrganizations(responseBody: string): ReadonlyArray<string> {
   }
 }
 
+//reusable test user context function
+const createTestUserContext = (isAdmin = false, userId = 'uaa-id-253') => {
+  const scope = isAdmin? [CLOUD_CONTROLLER_ADMIN ]: []
+  
+  const time = Math.floor(Date.now() / 1000);
+  const rawToken = {
+    exp: time + 24 * 60 * 60,
+    origin: 'uaa',
+    scope: scope,
+    user_id: userId,
+  };
+  const accessToken = jwt.sign(rawToken, 'secret');
+  const token = new Token(accessToken, ['secret']);
+  return createTestContext({token})
+}
+
+const nonAdminUserContext:IContext = createTestUserContext();
+const adminUserContext:IContext = createTestUserContext(true);
+
+let nockCF: nock.Scope;
+let nockZD: nock.Scope;
+let nockAccounts: nock.Scope;
+let nockUAA: nock.Scope;
+
+nockCF = nock('https://example.com/api');
+nockZD = nock('https://example.com/zendesk');
+nockAccounts = nock('https://example.com/accounts');
+nockUAA = nock('https://example.com/uaa');
+
+
 describe('organizations test suite', () => {
-  const ctx: IContext = createTestContext();
-  let nockCF: nock.Scope;
 
   beforeEach(() => {
     nock.cleanAll();
-
-    nockCF = nock(ctx.app.cloudFoundryAPI);
 
     nockCF
       .get('/v2/organizations')
@@ -81,13 +106,13 @@ describe('organizations test suite', () => {
   });
 
   it('should show the organisation pages', async () => {
-    const response = await listOrganizations(ctx, {});
+    const response = await listOrganizations(nonAdminUserContext, {});
 
     expect(response.body).toContain('Organisations');
   });
 
   it('should sort the organisations by name', async () => {
-    const response = await listOrganizations(ctx, {});
+    const response = await listOrganizations(nonAdminUserContext, {});
 
     const matches = extractOrganizations(response.body as string);
     expect(matches.length).toBe(5);
@@ -99,7 +124,7 @@ describe('organizations test suite', () => {
   });
 
   it('should report the org quotas for both trial and billable orgs', async () => {
-    const response = await listOrganizations(ctx, {});
+    const response = await listOrganizations(nonAdminUserContext, {});
 
     expect(response.body).toMatch(/a-org-name-4.*(?!Trial)Billable/ms);
     expect(response.body).toMatch(/a-trial-org-name.*(?!Billable)Trial/ms);
@@ -110,7 +135,7 @@ describe('organizations test suite', () => {
 });
 
 describe(editOrgData, () => {
-  let nockCF: nock.Scope;
+
   const organization = {
     guid: '__ORG_GUID__',
     metadata: { annotations: { owner: 'Testing Departament' } },
@@ -132,42 +157,17 @@ describe(editOrgData, () => {
   };
 
   describe('when not a platform admin', () => {
-    const time = Math.floor(Date.now() / 1000);
-    const rawToken = {
-      exp: time + 24 * 60 * 60,
-      origin: 'uaa',
-      scope: [],
-      user_id: 'uaa-id-253',
-    };
-    const accessToken = jwt.sign(rawToken, tokenKey);
-
-    const token = new Token(accessToken, [tokenKey]);
-    const ctx: IContext = createTestContext({ token });
 
     it('should return an error', async () => {
-      await expect(editOrgData(ctx, {})).rejects.toThrow(
+      await expect(editOrgData(nonAdminUserContext, {})).rejects.toThrow(
         /Not a platform admin/,
       );
     });
   });
 
   describe('when platform admin', () => {
-    const time = Math.floor(Date.now() / 1000);
-    const rawToken = {
-      exp: time + 24 * 60 * 60,
-      origin: 'uaa',
-      scope: [CLOUD_CONTROLLER_ADMIN],
-      user_id: 'uaa-id-253',
-    };
-    const accessToken = jwt.sign(rawToken, tokenKey);
-
-    const token = new Token(accessToken, [tokenKey]);
-    const ctx: IContext = createTestContext({ token });
 
     beforeEach(() => {
-      nock.cleanAll();
-
-      nockCF = nock(ctx.app.cloudFoundryAPI);
 
       nockCF
         .get(`/v3/organizations/${organization.guid}`)
@@ -196,7 +196,7 @@ describe(editOrgData, () => {
     });
 
     it('should correctly parse data into a form', async () => {
-      const response = await editOrgData(ctx, { organizationGUID: organization.guid });
+      const response = await editOrgData(adminUserContext, { organizationGUID: organization.guid });
 
       expect(response.status).toBeUndefined();
       expect(response.body).toContain(`Organisation ${organization.name}`);
@@ -205,7 +205,7 @@ describe(editOrgData, () => {
 });
 
 describe(updateOrgData, () => {
-  let nockCF: nock.Scope;
+
   const organization = {
     guid: '__ORG_GUID__',
     metadata: { annotations: { owner: 'Testing Departament' } },
@@ -225,43 +225,17 @@ describe(updateOrgData, () => {
 
 
   describe('when not a platform admin', () => {
-    const time = Math.floor(Date.now() / 1000);
-    const rawToken = {
-      exp: time + 24 * 60 * 60,
-      origin: 'uaa',
-      scope: [],
-      user_id: 'uaa-id-253',
-    };
-    const accessToken = jwt.sign(rawToken, tokenKey);
-
-    const token = new Token(accessToken, [tokenKey]);
-    const ctx: IContext = createTestContext({ token });
 
     it('should return an error', async () => {
-      await expect(updateOrgData(ctx, params, body)).rejects.toThrow(
+      await expect(updateOrgData(nonAdminUserContext, params, body)).rejects.toThrow(
         /Not a platform admin/,
       );
     });
   });
 
   describe('when platform admin', () => {
-    const time = Math.floor(Date.now() / 1000);
-    const rawToken = {
-      exp: time + 24 * 60 * 60,
-      origin: 'uaa',
-      scope: [CLOUD_CONTROLLER_ADMIN],
-      user_id: 'uaa-id-253',
-    };
-    const accessToken = jwt.sign(rawToken, tokenKey);
-
-    const token = new Token(accessToken, [tokenKey]);
-    const ctx: IContext = createTestContext({ token });
 
     beforeEach(() => {
-      nock.cleanAll();
-
-      nockCF = nock(ctx.app.cloudFoundryAPI);
-
       nockCF
         .get(`/v3/organizations/${organization.guid}`)
         .reply(200, organization)
@@ -282,10 +256,301 @@ describe(updateOrgData, () => {
     });
 
     it('should parse the success message correctly', async () => {
-      const response = await updateOrgData(ctx, params, body);
+      const response = await updateOrgData(adminUserContext, params, body);
 
       expect(response.status).toBeUndefined();
       expect(response.body).toContain('Organisation successfully updated');
     });
   });
+});
+
+describe(emailManagersForm, () => {
+  describe('when not a platform admin', () => {
+
+    it('should return an error', async () => {
+      await expect(emailManagersForm(nonAdminUserContext, {} as any)).rejects.toThrow(
+        /Not a platform admin/,
+      );
+    });
+  });
+  describe('when platform admin', () => {
+    const organizationGUID = 'a7aff246-5f5b-4cf8-87d8-f316053e4a20';
+
+    beforeEach(() => {
+      nockCF
+        .get(`/v2/organizations/${organizationGUID}/user_roles`)
+        .times(2)
+        .reply(200, cfData.userRolesForOrg)
+
+        .get(`/v2/organizations/${organizationGUID}`)
+        .reply(200, defaultOrg())
+
+        .get(`/v2/organizations/${organizationGUID}/spaces`)
+        .times(2)
+        .reply(200, cfData.spaces)
+      });
+
+    afterEach(() => {
+      nockCF.on('response', () => {
+        nockCF.done();
+      });
+  
+      nock.cleanAll();
+    });
+
+    it('should render the page correctly', async () => {
+
+      const response = await emailManagersForm(adminUserContext, { organizationGUID: organizationGUID });
+
+      expect(response.body).toContain('the-system_domain-org-name');
+      expect(response.body).toContain('Email organisation managers');
+      expect(response.body).toContain('Email billing managers');
+      expect(response.body).toContain('Email space managers');
+      expect(response.body).toContain('Select a space');
+      expect(response.body).toContain('Message');
+    });
+  });
+});
+
+describe(emailManagersFormPost, () => {
+  describe('when not a platform admin', () => {
+
+    it('should return an error', async () => {
+      await expect(emailManagersFormPost(nonAdminUserContext, {}, {} as any)).rejects.toThrow(
+        /Not a platform admin/,
+      );
+    });
+  });
+  describe('when platform admin', () => {
+    let ctx: IContext;
+
+    const organizationGUID = 'a7aff246-5f5b-4cf8-87d8-f316053e4a20';
+    const spaceGUID = '5489e195-c42b-4e61-bf30-323c331ecc01';
+    const mockAccountsUser = {
+      user_email: 'tester@test.com',
+      username: 'tester@test.com',
+      user_uuid: 'uaa-id-253',
+    }
+    const platformAdmin = {
+      id: 'platform-admin',
+      userName: 'platform-admin@fake.cabinet-office.gov.uk',
+      name: { familyName: 'Stub', givenName: 'User' },
+      emails: [{
+        value: 'platform-admin@fake.cabinet-office.gov.uk',
+        primary: false,
+      }],
+    }
+
+    beforeEach(() => {
+      // special user context to have matching data from test data set
+      ctx = createTestUserContext(true, 'platform-admin');
+      nockCF
+        .get(`/v2/organizations/${organizationGUID}/user_roles`)
+        .times(2)
+        .reply(200, cfData.userRolesForOrg)
+
+        .get(`/v2/organizations/${organizationGUID}`)
+        .reply(200, defaultOrg())
+
+        .get(`/v2/organizations/${organizationGUID}/spaces`)
+        .times(2)
+        .reply(200, cfData.spaces)
+      
+    });
+
+    afterEach(() => {
+      nockAccounts.done();
+      nockUAA.done();
+      nockCF.on('response', () => {
+        nockCF.done();
+      });
+  
+      nock.cleanAll();
+    });
+
+    it('should create a zendesk ticket correctly', async () => {
+      nockZD
+        .post('/tickets.json')
+        .reply(201, {});
+
+      nockAccounts
+        .get('/users/uaa-id-253')
+        .reply(200, mockAccountsUser)
+
+      nockUAA
+        .get('/Users/platform-admin')
+        .reply(200, platformAdmin)
+        .post('/oauth/token?grant_type=client_credentials')
+        .reply(200, '{"access_token": "FAKE_ACCESS_TOKEN"}');
+
+      const response = await emailManagersFormPost(ctx, { organizationGUID: organizationGUID }, {
+        managerType: 'org_manager',
+        message: 'message text',
+        space: spaceGUID,
+      } as any);
+
+      expect(response.status).toBeUndefined();
+      expect(response.body).toContain('Message has been sent');
+      expect(response.body).toContain('A Zendesk ticket has also been created to track progress');
+    });
+
+    it('should throw validation errors when missing data has been submited', async () => {
+
+      const response = await emailManagersFormPost(ctx, { organizationGUID: organizationGUID }, {} as any);
+
+      expect(response.body).not.toContain('We have received your request');
+      expect(response.body).toContain('Error');
+      expect(response.body).toContain('Select a manager role');
+      expect(response.body).toContain('Enter your message');
+    });
+
+    it('should throw an error if org has no managers of selected type', async () => {
+      const response = await emailManagersFormPost(ctx, { organizationGUID: organizationGUID }, {
+        managerType: 'billing_manager',
+        message: 'message text',
+      } as any);
+
+      expect(response.body).not.toContain('We have received your request');
+      expect(response.body).toContain('Error');
+      expect(response.body).toContain('Select organisation does not have any of the selected manager roles');
+    });
+
+    it('should throw an error if space manager option was selected but space was not', async () => {
+
+      const response = await emailManagersFormPost(ctx, { organizationGUID: organizationGUID }, {
+        managerType: 'space_manager',
+        message: 'message text',
+        space: '',
+      } as any);
+
+      expect(response.body).not.toContain('We have received your request');
+      expect(response.body).toContain('Error');
+      expect(response.body).toContain('Select a space');
+    });
+
+    it('should throw an error selected space has no managers', async () => {
+
+      nockCF
+      .get(`/v2/spaces/${spaceGUID}/user_roles`)
+      .reply(200, cfData.userRolesForSpace)
+
+      const response = await emailManagersFormPost(ctx, { organizationGUID: organizationGUID }, {
+        managerType: 'space_manager',
+        message: 'message text',
+        space: spaceGUID,
+      } as any);
+
+      expect(response.body).not.toContain('We have received your request');
+      expect(response.body).toContain('Error');
+      expect(response.body).toContain('Selected space does not have any space managers');
+    });
+  });
+});
+
+describe('helper functions', () => {
+  describe(emailManagersZendeskContent, () => {
+    // whitespace matters
+  const expectedOutputForSpaceManager = `
+Message content
+
+You are receiving this email as you are listed as a space manager of dream space in the test organisation in our NARNIA region.
+
+Thank you,
+GOV.UK PaaS`;
+
+    it('should output expected text', () => {
+      const zendeskEmailContent = emailManagersZendeskContent({
+        message: 'Message content',
+        managerType: 'space_manager',
+        space: 'dream',
+      },
+      'narnia',
+      'test',
+      );
+
+      expect(zendeskEmailContent).toEqual(expectedOutputForSpaceManager);
+    });
+    it('should output BILLING manager text if billign manager selected', () => {
+      const zendeskEmailContent = emailManagersZendeskContent({
+        message: 'Message content',
+        managerType: 'billing_manager',
+        space: 'dream',
+      },
+      'narnia',
+      'test',
+      );
+      expect(zendeskEmailContent).toContain('a billing manager');
+    });
+
+    it('should output ORG manager text if billign manager selected', () => {
+      const zendeskEmailContent = emailManagersZendeskContent({
+        message: 'Message content',
+        managerType: 'org_manager',
+        space: 'dream',
+      },
+      'narnia',
+      'test',
+      );
+      expect(zendeskEmailContent).toContain('an organisation manager');
+    });
+  });
+
+  describe(constructZendeskRequesterObject, () => {
+
+    it('should object with correct data if user is not null', () => {
+      const expectedOutput = {
+        name: 'Stub User',
+        locale_id: 1176,
+        email: 'stub-user@digital.cabinet-office.gov.uk',
+      };
+
+      const functionOutput = constructZendeskRequesterObject({
+        meta: {
+          version: 0,
+          created: '2019-01-01T00:00:00',
+          lastModified: '2019-01-02T00:00:00',
+        },
+        id: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
+        externalId: 'stub-user',
+        userName: 'stub-user@digital.cabinet-office.gov.uk',
+        origin: 'uaa',
+        active: true,
+        verified: true,
+        zoneId: 'uaa',
+        name: { familyName: 'User', givenName: 'Stub' },
+        emails: [
+          { value: 'stub-user@digital.cabinet-office.gov.uk', primary: true },
+        ],
+        schemas: [ 'urn:scim:schemas:core:1.0' ],
+        groups: [
+          {
+            display: 'cloud_controller.read',
+            type: 'DIRECT',
+            value: '177eb558-5e9a-42a5-9316-438aee2b88a4',
+          },
+        ],
+        phoneNumbers: [],
+        approvals: [],
+        passwordLastModified: '2019-01-01T00:00:00',
+        previousLogonTime: 1527032725657,
+        lastLogonTime: 1527032725657,
+      });
+
+      expect(functionOutput).toMatchObject(expectedOutput);
+    });
+
+    it('should output object with substitute data if user is null', () => {
+
+      const userIsNull = constructZendeskRequesterObject(null);
+
+      const expecteNullUserOutput = {
+        name: 'GOV.UK PaaS Admin',
+        locale_id: 1176,
+        email: 'gov-uk-paas-support@digital.cabinet-office.gov.uk',
+      };
+
+      expect(userIsNull).toMatchObject(expecteNullUserOutput);
+    });
+  });
+
 });

--- a/src/components/organizations/controllers.test.tsx
+++ b/src/components/organizations/controllers.test.tsx
@@ -15,7 +15,14 @@ import { createTestContext } from '../app/app.test-helpers';
 import { IContext } from '../app/context';
 import { CLOUD_CONTROLLER_ADMIN, Token } from '../auth';
 
-import { constructZendeskRequesterObject, editOrgData, emailManagersForm, emailManagersFormPost, emailManagersZendeskContent, updateOrgData } from './controllers';
+import { 
+  constructSubject,
+  constructZendeskRequesterObject,
+  editOrgData, emailManagersForm,
+  emailManagersFormPost,
+  emailManagersZendeskContent,
+  updateOrgData,
+} from './controllers';
 
 import { listOrganizations } from '.';
 import * as cfData from '../../lib/cf/cf.test.data';
@@ -551,6 +558,20 @@ GOV.UK PaaS`;
 
       expect(userIsNull).toMatchObject(expecteNullUserOutput);
     });
+  });
+
+  describe(constructSubject, () => {
+
+    it('should output default text if user subject not provided', () => {
+      const output = constructSubject('');
+      expect(output).toBe("[PaaS Support] About your organisation on GOV.UK PaaS");
+    });
+
+    it('should output user provided subject text', () => {
+      const output = constructSubject('Custom subject');
+      expect(output).toBe("[PaaS Support] Custom subject");
+    });
+
   });
 
 });

--- a/src/components/organizations/controllers.tsx
+++ b/src/components/organizations/controllers.tsx
@@ -49,6 +49,13 @@ function checkFormField(variable: string, field: string, message: string): Reado
   return errors;
 }
 
+export function constructSubject(userInput: string | undefined): string {
+  const prefix = "[PaaS Support]"
+  const defaultSubject = "About your organisation on GOV.UK PaaS"
+  let subject:string = userInput ? userInput : defaultSubject
+  return `${prefix} ${subject}`
+}
+
 export function constructZendeskRequesterObject(user: IUaaUser | null): any {
   const user_name = user === null ? 'GOV.UK PaaS Admin' : `${user!.name.givenName} ${user!.name.familyName}`;
   const user_email = user === null ? 'gov-uk-paas-support@digital.cabinet-office.gov.uk' : user!.emails[0].value;
@@ -378,7 +385,7 @@ export async function emailManagersFormPost(
         ctx.viewContext.location,
         organisation.entity.name),
       },
-      subject: '[PaaS Support] About your organisation on GOV.UK PaaS',
+      subject: constructSubject(body.subject),
       status: 'pending',
       tags: ['govuk_paas_support'],
       requester: constructZendeskRequesterObject(adminUser),

--- a/src/components/organizations/controllers.tsx
+++ b/src/components/organizations/controllers.tsx
@@ -1,14 +1,22 @@
 import lodash from 'lodash';
 import React from 'react';
 
+import * as zendesk from 'node-zendesk';
+
 import { Template } from '../../layouts';
 import CloudFoundryClient from '../../lib/cf';
-import { IOrganization } from '../../lib/cf/types';
 import { IParameters, IResponse, NotAuthorisedError } from '../../lib/router';
+import UAAClient, { IUaaUser } from '../../lib/uaa';
 import { IContext } from '../app/context';
+import { IValidationError } from '../errors/types';
 import { SuccessPage } from '../shared';
 
-import { EditOrganization, OrganizationsPage } from './views';
+import { EmailManagers, EditOrganization, OrganizationsPage, IEmailManagersFormValues, EmailManagersConfirmationPage } from './views';
+import { AccountsClient, IAccountsUser } from '../../lib/accounts';
+
+import { IOrganization, OrganizationUserRoles } from '../../lib/cf/types';
+
+const TITLE_EMAIL_MANAGERS = 'Email managers';
 
 interface IUpdateOrgDataBody {
   readonly name: string;
@@ -25,6 +33,49 @@ function sortOrganizationsByName(
 
   return organizationsCopy;
 }
+
+function checkFormField(variable: string, field: string, message: string): ReadonlyArray<IValidationError> {
+  const errors = [];
+
+  const isInvalid = !variable
+
+  if (isInvalid) {
+    errors.push({
+      field,
+      message,
+    });
+  }
+
+  return errors;
+}
+
+export function constructZendeskRequesterObject(user: IUaaUser | null): any {
+  const user_name = user === null ? 'GOV.UK PaaS Admin' : `${user!.name.givenName} ${user!.name.familyName}`;
+  const user_email = user === null ? 'gov-uk-paas-support@digital.cabinet-office.gov.uk' : user!.emails[0].value;
+
+return {
+    name: user_name,
+    // en-gb via https://developer.zendesk.com/api-reference/ticketing/account-configuration/locales/#list-available-public-locales
+    locale_id: 1176,
+    email: user_email,
+  };
+}
+
+// body of the zendesk email
+export function emailManagersZendeskContent(variables: IEmailManagersFormValues, region: string, organisation: string): string {
+  const managerType = variables.managerType === 'org_manager' ?
+    'an organisation manager ' : variables.managerType === 'billing_manager' ? 
+    'a billing manager' : `a space manager of ${variables.space} space`;
+  // whitespace matters
+    return `
+${variables.message}
+
+You are receiving this email as you are listed as ${managerType} in the ${organisation} organisation in our ${region.toUpperCase()} region.
+
+Thank you,
+GOV.UK PaaS`;
+}
+  
 
 export async function listOrganizations(
   ctx: IContext,
@@ -141,5 +192,214 @@ export async function updateOrgData(ctx: IContext, params: IParameters, body: IU
     body: template.render(<SuccessPage
       heading="Organisation successfully updated"
     />),
+  };
+}
+
+export async function emailManagersForm(ctx: IContext, params: IParameters): Promise<IResponse> {
+  if (!ctx.token.hasAdminScopes()) {
+    throw new NotAuthorisedError('Not a platform admin');
+  }
+
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const [
+    spaces,
+    organisation,
+  ] = await Promise.all([
+    cf.orgSpaces(params.organizationGUID),
+    cf.organization(params.organizationGUID),
+  ]);
+  
+  const template = new Template(ctx.viewContext, TITLE_EMAIL_MANAGERS);
+
+  template.breadcrumbs = [
+    { href: ctx.linkTo('admin.organizations'), text: 'Organisations' },
+    {
+      href: ctx.linkTo('admin.organizations.view', { organizationGUID: organisation.metadata.guid }),
+      text: organisation.entity.name,
+    },
+    { text: TITLE_EMAIL_MANAGERS },
+  ];
+
+  return {
+    body: template.render(<EmailManagers
+      organisation={organisation}
+      spaces={spaces}
+      csrf={ctx.viewContext.csrf}
+      linkTo={ctx.linkTo}
+    />),
+  };
+}
+
+export async function emailManagersFormPost(
+  ctx: IContext, _params: IParameters, body: IEmailManagersFormValues,
+): Promise<IResponse> {
+  if (!ctx.token.hasAdminScopes()) {
+    throw new NotAuthorisedError('Not a platform admin');
+  }
+
+  const cf = new CloudFoundryClient({
+    accessToken: ctx.token.accessToken,
+    apiEndpoint: ctx.app.cloudFoundryAPI,
+    logger: ctx.app.logger,
+  });
+
+  const [
+    spaces,
+    organisation,
+  ] = await Promise.all([
+    cf.orgSpaces(_params.organizationGUID),
+    cf.organization(_params.organizationGUID),
+  ]);
+
+  const uaa = new UAAClient({
+    apiEndpoint: ctx.app.uaaAPI,
+    clientCredentials: {
+      clientID: ctx.app.oauthClientID,
+      clientSecret: ctx.app.oauthClientSecret,
+    },
+  });
+
+  const accountsClient = new AccountsClient({
+    apiEndpoint: ctx.app.accountsAPI,
+    logger: ctx.app.logger,
+    secret: ctx.app.accountsSecret,
+  });
+
+  const errors = [];
+
+  // check if any fields are missing
+  // if so, create error messages
+  errors.push(
+    ...checkFormField(body.managerType, 'managerType', 'Select a manager role'),
+    ...checkFormField(body.message, 'message', 'Enter your message'),
+  );
+
+  // if they've selected a space manager role, but not selected a space
+  if(body.managerType === 'space_manager' && body.space === '') {
+    errors.push(
+      ...checkFormField(body.space, 'space', 'Select a space'),
+    );
+  }
+
+  let emailAddressesArray:ReadonlyArray<any> = [];
+  let filteredManagers:ReadonlyArray<any> = [];
+  // different CF call needed to get org users and space users
+  // we also need to look into paas-accounts for their actual email address
+  if (body.space !== '' && body.managerType === 'space_manager') {
+    
+    const usersForGivenSpace = await cf.usersForSpace(body.space);
+    filteredManagers = await Promise.all(
+      usersForGivenSpace.filter(user => user.entity.space_roles.includes(body.managerType))
+        .map(async manager => await accountsClient.getUser(manager.metadata.guid)),
+    );
+  } else {
+    const usersForGivenOrg = await cf.usersForOrganization(_params.organizationGUID);
+    filteredManagers = await Promise.all(
+      usersForGivenOrg.filter(user => user.entity.organization_roles.includes(body.managerType as unknown as OrganizationUserRoles))
+        .map(async manager => await accountsClient.getUser(manager.metadata.guid)),
+    );
+  }
+
+  // create a zendesk api-friendly array of email address objects
+  emailAddressesArray = Array.from(
+    new Set(
+      filteredManagers
+        .filter((user): user is IAccountsUser => !!user)
+        .filter(user => user.email)
+        .map(user => ({ user_email: user.email })),
+    ),
+  );
+
+  // if manager role type has been selected but there are no users with selected role, update the error message
+  // message property is readonly so cannot just update the message
+  if (emailAddressesArray.length === 0 && body.managerType !== 'space_manager') {
+    /* istanbul ignore next */
+    const managerTypeErrorIndex = errors.findIndex(
+      error => error.field === 'managerType',
+    );
+    errors.splice(managerTypeErrorIndex, 0, { field: 'managerType', message: 'Select organisation does not have any of the selected manager roles' });
+  }
+  // selected space does not have any space managers
+  if (emailAddressesArray.length === 0 && body.managerType === 'space_manager' && body.space !== '') {
+    /* istanbul ignore next */
+    const spaceErrorIndex = errors.findIndex(
+      error => error.field === 'space',
+    );
+    errors.splice(spaceErrorIndex, 0, { field: 'space', message: 'Selected space does not have any space managers' });
+  }
+    
+  const template = new Template(ctx.viewContext, TITLE_EMAIL_MANAGERS);
+  template.breadcrumbs = [
+    { href: ctx.linkTo('admin.organizations'), text: 'Organisations' },
+    {
+      href: ctx.linkTo('admin.organizations.view', { organizationGUID: organisation.metadata.guid }),
+      text: organisation.entity.name,
+    },
+    { text: TITLE_EMAIL_MANAGERS },
+  ];
+  
+  // if there are errors, rerender the page with error messages
+  if (errors.length > 0) {
+
+    template.title = `Error: ${TITLE_EMAIL_MANAGERS}`;
+
+    return {
+      body: template.render(<EmailManagers
+        organisation={organisation}
+        spaces={spaces}
+        errors={errors}
+        values={body}
+        csrf={ctx.viewContext.csrf}
+        linkTo={ctx.linkTo}
+      />),
+    };
+  }
+
+  // get admin user details to populate requester field for zendesk
+  const adminUser: IUaaUser | null = await uaa.getUser(ctx.token.userID);
+
+  const spaceName = spaces.filter(space => space.metadata.guid === body.space).map(space => space.entity.name)
+
+ // send zendesk api request with all the data
+  const client = zendesk.createClient(ctx.app.zendeskConfig);
+  await client.tickets.create({
+    ticket: {
+      comment: {
+        body: emailManagersZendeskContent({
+          message: body.message,
+          managerType: body.managerType,
+          space: spaceName as any,
+        },
+        ctx.viewContext.location,
+        organisation.entity.name),
+      },
+      subject: '[PaaS Support] About your organisation on GOV.UK PaaS',
+      status: 'pending',
+      tags: ['govuk_paas_support'],
+      requester: constructZendeskRequesterObject(adminUser),
+      email_ccs: emailAddressesArray,
+    },
+  });
+
+  template.title = 'Message has been sent';
+
+  return {
+    body: template.render(
+      <EmailManagersConfirmationPage
+        linkTo={ctx.linkTo}
+        heading={'Message has been sent'}
+        text={'A Zendesk ticket has also been created to track progress.'}
+      >
+        <a className="govuk-link"
+          href="/organisations">
+            Back to list of organisations
+        </a>.
+      </EmailManagersConfirmationPage>,
+    ),
   };
 }

--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -41,6 +41,7 @@ export interface IEmailManagersFormValues {
   readonly message: string;
   readonly managerType: string;
   readonly space: string;
+  readonly subject?: string
 }
 
 interface IEmailManagersFormProperties extends IFormProperties {
@@ -552,6 +553,10 @@ export function EmailManagers(props: IEmailManagersFormProperties): ReactElement
               </div>
             </div>
           </fieldset>
+        </div>
+        <div className="govuk-form-group">
+          <label className="govuk-label" htmlFor="subject">Email subject (optional)</label>
+          <input className="govuk-input" id="subject" name="subject" type="text" spellCheck="false"   defaultValue={props.values?.subject} />
         </div>
         <div className={`govuk-form-group ${
             props.errors?.some(e => e.field === 'message')

--- a/src/components/platform-admin/controllers.test.tsx
+++ b/src/components/platform-admin/controllers.test.tsx
@@ -1,13 +1,10 @@
 import cheerio from 'cheerio';
 import jwt from 'jsonwebtoken';
-import nock from 'nock';
 import lodash from 'lodash'
 
 import { spacesMissingAroundInlineElements } from '../../layouts/react-spacing.test';
-import { AccountsClient } from '../../lib/accounts';
 import CloudFoundryClient from '../../lib/cf';
 import { IResponse } from '../../lib/router';
-import UAAClient from '../../lib/uaa';
 import { createTestContext } from '../app/app.test-helpers';
 import { IContext } from '../app/context';
 import { Token } from '../auth';
@@ -15,10 +12,6 @@ import { CLOUD_CONTROLLER_ADMIN } from '../auth/has-role';
 import { v3Org as defaultV3Org } from '../../lib/cf/test-data/org';
 
 import {
-  constructZendeskRequesterObject,
-  contactOrganisationManagers,
-  contactOrganisationManagersPost,
-  contactOrgManagersZendeskContent,
   createOrganization,
   createOrganizationForm,
   filterOutRealOrganisations,
@@ -31,34 +24,7 @@ jest.mock('../../lib/accounts');
 jest.mock('../../lib/uaa');
 
 const mockOrg = { metadata: { annotations: { owner: 'TEST_OWNER' } } };
-const contactManagersMockOrg = { guid: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20', name: 'an-org', suspended: false };
-const mockCfUser = {
-  metadata: {
-    guid: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
-  },
-  entity: {
-    username: 'user@uaa.example.com',
-    organization_roles: ['org_manager'],
-  },
-};
-const mockUaaUser = {
-  id: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
-  userName: 'uaa-id-253@fake.cabinet-office.gov.uk',
-  name: { familyName: 'Stub', givenName: 'User' },
-  emails: [{
-    value: 'uaa-id-253@fake.cabinet-office.gov.uk',
-    primary: false,
-  }],
-};
-const mockAccountsUser = {
-    email: 'uaa-id-253@fake.cabinet-office.gov.uk',
-    username: 'uaa-id-253@fake.cabinet-office.gov.uk',
-    uuid: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
-};
-
 const tokenKey = 'secret';
-
-let nockZD: nock.Scope;
 
 describe(viewHomepage, () => {
   describe('when not a platform admin', () => {
@@ -270,241 +236,7 @@ describe(createOrganization, () => {
   });
 });
 
-describe(contactOrganisationManagers, () => {
-  describe('when not a platform admin', () => {
-    const time = Math.floor(Date.now() / 1000);
-    const rawToken = {
-      exp: time + 24 * 60 * 60,
-      origin: 'uaa',
-      scope: [],
-      user_id: 'uaa-id-253',
-    };
-    const accessToken = jwt.sign(rawToken, tokenKey);
-
-    const token = new Token(accessToken, [tokenKey]);
-    const ctx: IContext = createTestContext({ token });
-
-    it('should return an error', async () => {
-      await expect(contactOrganisationManagers(ctx, {} as any)).rejects.toThrow(
-        /Not a platform admin/,
-      );
-    });
-  });
-  describe('when platform admin', () => {
-    let ctx: IContext;
-    beforeEach(() => {
-
-      const time = Math.floor(Date.now() / 1000);
-      const rawToken = {
-        exp: time + 24 * 60 * 60,
-        origin: 'uaa',
-        scope: [CLOUD_CONTROLLER_ADMIN],
-        user_id: 'uaa-id-253',
-      };
-      const accessToken = jwt.sign(rawToken, tokenKey);
-
-      const token = new Token(accessToken, [tokenKey]);
-
-      ctx = createTestContext({ token });
-
-      // @ts-ignore
-      CloudFoundryClient.mockClear();
-    });
-
-    afterEach(() => {
-      nock.cleanAll();
-    });
-
-    it('should render the page correctly', async () => {
-      // @ts-ignore
-      CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ contactManagersMockOrg ]));
-
-      const response = await contactOrganisationManagers(ctx, {} as any);
-
-      expect(response.body).toContain('a7aff246-5f5b-4cf8-87d8-f316053e4a20');
-      expect(response.body).toContain('Contact organisation managers');
-      expect(response.body).toContain('Organisation name');
-      expect(response.body).toContain('Manager role');
-      expect(response.body).toContain('Message');
-    });
-  });
-});
-
-describe(contactOrganisationManagersPost, () => {
-  let ctx: IContext;
-  beforeEach(() => {
-
-    const time = Math.floor(Date.now() / 1000);
-    const rawToken = {
-      exp: time + 24 * 60 * 60,
-      origin: 'uaa',
-      scope: [CLOUD_CONTROLLER_ADMIN],
-      user_id: 'uaa-id-253',
-    };
-    const accessToken = jwt.sign(rawToken, tokenKey);
-
-    const token = new Token(accessToken, [tokenKey]);
-
-    ctx = createTestContext({ token });
-
-    // @ts-ignore
-    CloudFoundryClient.mockClear();
-    // @ts-ignore
-    UAAClient.mockClear();
-    // @ts-ignore
-    AccountsClient.mockClear();
-
-    nock.cleanAll();
-    nockZD = nock(ctx.app.zendeskConfig.remoteUri);
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
-  it('should create a zendesk ticket correctly', async () => {
-    // @ts-ignore
-    CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ contactManagersMockOrg ]));
-     // @ts-ignore
-    CloudFoundryClient.prototype.usersForOrganization.mockReturnValueOnce(Promise.resolve([ mockCfUser ]));
-    // @ts-ignore
-    UAAClient.prototype.getUser.mockReturnValueOnce(Promise.resolve(mockUaaUser));
-    // @ts-ignore
-    AccountsClient.prototype.getUser.mockReturnValueOnce(Promise.resolve(mockAccountsUser));
-
-
-    nockZD
-      .post('/tickets.json')
-      .reply(201, {});
-
-    const response = await contactOrganisationManagersPost(ctx, {}, {
-      organisation: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-      managerRole: 'org_manager',
-      message: 'message text',
-    } as any);
-
-    expect(response.status).toBeUndefined();
-    expect(response.body).toContain('Message has been sent');
-    expect(response.body).toContain('A Zendesk ticket has also been created to track progress');
-  });
-
-  it('should throw validation errors when missing data has been submited', async () => {
-    // @ts-ignore
-    CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ contactManagersMockOrg ]));
-
-    const response = await contactOrganisationManagersPost(ctx, {}, {} as any);
-
-    expect(response.status).toEqual(400);
-    expect(response.body).not.toContain('We have received your request');
-    expect(response.body).toContain('Error');
-    expect(response.body).toContain('Select an organisation');
-    expect(response.body).toContain('Select a manager role');
-    expect(response.body).toContain('Enter your message');
-  });
-
-  it('should throw and error if org has no managers of selected type', async () => {
-    // @ts-ignore
-    CloudFoundryClient.prototype.v3Organizations.mockReturnValueOnce(Promise.resolve([ contactManagersMockOrg ]));
-     // @ts-ignore
-    CloudFoundryClient.prototype.usersForOrganization.mockReturnValueOnce(Promise.resolve([]));
-    // @ts-ignore
-    UAAClient.prototype.getUser.mockReturnValueOnce(Promise.resolve([]));
-    // @ts-ignore
-    AccountsClient.prototype.getUser.mockReturnValueOnce(Promise.resolve([mockAccountsUser]));
-
-    const response = await contactOrganisationManagersPost(ctx, {}, {
-      organisation: 'a7aff246-5f5b-4cf8-87d8-f316053e4a20',
-      managerRole: 'billing_manager',
-      message: 'message text',
-    } as any);
-
-    expect(response.status).toEqual(400);
-    expect(response.body).not.toContain('We have received your request');
-    expect(response.body).toContain('Error');
-    expect(response.body).toContain('Select organisation does not have any of the selected manager roles');
-  });
-
-});
-
 describe('helper functions', () => {
-  describe(contactOrgManagersZendeskContent, () => {
-    const zendeskEmailContent = contactOrgManagersZendeskContent({
-      organisation: 'test',
-      message: 'Message content',
-      managerRole: 'billing_manager',
-    },'narnia');
-
-    // whitespace matters
-    const expectedOutput = `
-Message content
-
-You are receiving this email as you are listed as a billing manager of the test organisation in our NARNIA region.
-
-Thank you,
-GOV.UK PaaS`;
-
-    it('should output expected text', () => {
-      expect(zendeskEmailContent).toEqual(expectedOutput);
-    });
-  });
-
-  describe(constructZendeskRequesterObject, () => {
-
-    it('should object with correct data if user is not null', () => {
-      const expectedOutput = {
-        name: 'Stub User',
-        locale_id: 1176,
-        email: 'stub-user@digital.cabinet-office.gov.uk',
-      };
-
-      const functionOutput = constructZendeskRequesterObject({
-        meta: {
-          version: 0,
-          created: '2019-01-01T00:00:00',
-          lastModified: '2019-01-02T00:00:00',
-        },
-        id: '99022be6-feb8-4f78-96f3-7d11f4d476f1',
-        externalId: 'stub-user',
-        userName: 'stub-user@digital.cabinet-office.gov.uk',
-        origin: 'uaa',
-        active: true,
-        verified: true,
-        zoneId: 'uaa',
-        name: { familyName: 'User', givenName: 'Stub' },
-        emails: [
-          { value: 'stub-user@digital.cabinet-office.gov.uk', primary: true },
-        ],
-        schemas: [ 'urn:scim:schemas:core:1.0' ],
-        groups: [
-          {
-            display: 'cloud_controller.read',
-            type: 'DIRECT',
-            value: '177eb558-5e9a-42a5-9316-438aee2b88a4',
-          },
-        ],
-        phoneNumbers: [],
-        approvals: [],
-        passwordLastModified: '2019-01-01T00:00:00',
-        previousLogonTime: 1527032725657,
-        lastLogonTime: 1527032725657,
-      });
-
-      expect(functionOutput).toMatchObject(expectedOutput);
-    });
-
-    it('should output object with substitute data if user is null', () => {
-
-      const userIsNull = constructZendeskRequesterObject(null);
-
-      const expecteNullUserOutput = {
-        name: 'GOV.UK PaaS Admin',
-        locale_id: 1176,
-        email: 'gov-uk-paas-support@digital.cabinet-office.gov.uk',
-      };
-
-      expect(userIsNull).toMatchObject(expecteNullUserOutput);
-    });
-  });
 
   describe(filterOutRealOrganisations, () => {
     it('should return only real organisations', () => {

--- a/src/components/platform-admin/controllers.tsx
+++ b/src/components/platform-admin/controllers.tsx
@@ -1,30 +1,22 @@
-import * as zendesk from 'node-zendesk';
 import React from 'react';
 
 import { Template } from '../../layouts';
-import { AccountsClient, IAccountsUser } from '../../lib/accounts';
 import CloudFoundryClient from '../../lib/cf';
 import { IV3OrganizationResource } from '../../lib/cf/types';
 import { IParameters, IResponse, NotAuthorisedError } from '../../lib/router';
-import UAAClient, { IUaaUser } from '../../lib/uaa';
 import { IContext } from '../app/context';
 import { Token } from '../auth';
-import { IValidationError } from '../errors/types';
 
 import { validateNewOrganization } from './validators';
 import {
-  ContactOrganisationManagersConfirmationPage,
-  ContactOrganisationManagersPage,
   CreateOrganizationPage,
   CreateOrganizationSuccessPage,
-  IContactOrganisationManagersPageValues,
   INewOrganizationUserBody,
   PlatformAdministratorPage,
 } from './views';
 
 
 const TITLE_CREATE_ORG = 'Create Organisation';
-const TITLE_EMAIL_ORG_MANAGERS = 'Email organisation managers';
 
 function throwErrorIfNotAdmin({ token }: { readonly token: Token }): void {
   if (token.hasAdminScopes()) {
@@ -32,58 +24,6 @@ function throwErrorIfNotAdmin({ token }: { readonly token: Token }): void {
   }
 
   throw new NotAuthorisedError('Not a platform admin');
-}
-
-// form field validations
-function validateEmailMessage({ message }: IContactOrganisationManagersPageValues): ReadonlyArray<IValidationError> {
-  const errors = [];
-
-  if (!message) {
-    errors.push({
-      field: 'message',
-      message: 'Enter your message',
-    });
-  }
-
-  return errors;
-}
-
-function validateOrgSelection({ organisation }: IContactOrganisationManagersPageValues): ReadonlyArray<IValidationError> {
-  const errors = [];
-
-  if (!organisation) {
-    errors.push({
-      field: 'organisation',
-      message: 'Select an organisation',
-    });
-  }
-
-  return errors;
-}
-
-function validateManagerRoleSelection({ managerRole }: IContactOrganisationManagersPageValues): ReadonlyArray<IValidationError> {
-  const errors = [];
-
-  if (!managerRole) {
-    errors.push({
-      field: 'managerRole',
-      message: 'Select a manager role',
-    });
-  }
-
-  return errors;
-}
-
-// body of the zendesk email
-export function contactOrgManagersZendeskContent(variables: IContactOrganisationManagersPageValues, region: string): string {
-// whitespace matters
-  return `
-${variables.message}
-
-You are receiving this email as you are listed as ${variables.managerRole === 'org_manager' ? 'an organisation' : 'a billing'} manager of the ${variables.organisation} organisation in our ${region.toUpperCase()} region.
-
-Thank you,
-GOV.UK PaaS`;
 }
 
 export function sortOrganisationsByName(organisations: ReadonlyArray<IV3OrganizationResource>): ReadonlyArray<IV3OrganizationResource> {
@@ -94,19 +34,6 @@ export function sortOrganisationsByName(organisations: ReadonlyArray<IV3Organiza
 
 export function filterOutRealOrganisations(organisations: ReadonlyArray<IV3OrganizationResource>): ReadonlyArray<IV3OrganizationResource> {
   return organisations.filter(org => !org.name.match(/^(CATS?|ACC|BACC|SMOKE|PERF|AIVENBACC|ASATS)-/));
-}
-
-// construct requester object for zendesk api
-export function constructZendeskRequesterObject(user: IUaaUser | null): any {
-  const user_name = user === null ? 'GOV.UK PaaS Admin' : `${user!.name.givenName} ${user!.name.familyName}`;
-  const user_email = user === null ? 'gov-uk-paas-support@digital.cabinet-office.gov.uk' : user!.emails[0].value;
-
-return {
-    name: user_name,
-    // en-gb via https://developer.zendesk.com/api-reference/ticketing/account-configuration/locales/#list-available-public-locales
-    locale_id: 1176,
-    email: user_email,
-  };
 }
 
 export async function createOrganizationForm(ctx: IContext, _params: IParameters): Promise<IResponse> {
@@ -185,168 +112,6 @@ export async function createOrganization(
       linkTo={ctx.linkTo}
       organizationGUID={organization.guid}
     />),
-  };
-}
-
-// intial form display
-export async function contactOrganisationManagers(
-  ctx: IContext, _params: IParameters,
-): Promise<IResponse> {
-  throwErrorIfNotAdmin(ctx);
-
-  const cf = new CloudFoundryClient({
-    accessToken: ctx.token.accessToken,
-    apiEndpoint: ctx.app.cloudFoundryAPI,
-    logger: ctx.app.logger,
-  });
-
-  const orgsList = await cf.v3Organizations()
-    .then(filterOutRealOrganisations)
-    .then(sortOrganisationsByName)
-
-  const template = new Template(ctx.viewContext, TITLE_EMAIL_ORG_MANAGERS);
-
-return {
-    body: template.render(<ContactOrganisationManagersPage
-      linkTo={ctx.linkTo}
-      csrf={ctx.viewContext.csrf}
-      orgs={orgsList}
-    />),
-  };
-}
-
-// when form is submitted
-export async function contactOrganisationManagersPost(
-  ctx: IContext, _params: IParameters, body: IContactOrganisationManagersPageValues,
-): Promise<IResponse> {
-  throwErrorIfNotAdmin(ctx);
-
-  const cf = new CloudFoundryClient({
-    accessToken: ctx.token.accessToken,
-    apiEndpoint: ctx.app.cloudFoundryAPI,
-    logger: ctx.app.logger,
-  });
-
-  const uaa = new UAAClient({
-    apiEndpoint: ctx.app.uaaAPI,
-    clientCredentials: {
-      clientID: ctx.app.oauthClientID,
-      clientSecret: ctx.app.oauthClientSecret,
-    },
-  });
-
-  const accountsClient = new AccountsClient({
-    apiEndpoint: ctx.app.accountsAPI,
-    logger: ctx.app.logger,
-    secret: ctx.app.accountsSecret,
-  });
-
-  const errors = [];
-
-  // check if any fields are missing
-  // if so, create error messages
-  errors.push(
-    ...validateOrgSelection(body),
-    ...validateManagerRoleSelection(body),
-    ...validateEmailMessage(body),
-  );
-
-  const template = new Template(ctx.viewContext);
-  const orgsList = await cf.v3Organizations()
-    .then(filterOutRealOrganisations)
-    .then(sortOrganisationsByName)
-  let orgUserEmails:ReadonlyArray<any> = [];
-
-  // get email adfresses for all managers for the selected type and organisation
-  if (body.organisation) {
-    const usersForGivenOrg = await cf.usersForOrganization(body.organisation);
-    // we need to look into paas-accounts for their actual email address
-    const filteredManagers = await Promise.all(
-      usersForGivenOrg.filter(user => user.entity.organization_roles.includes(body.managerRole))
-        .map(async manager => await accountsClient.getUser(manager.metadata.guid)),
-    );
-
-    // create a zendesk api-friendly array of email address objects
-    orgUserEmails = Array.from(
-      new Set(
-        filteredManagers
-          .filter((user): user is IAccountsUser => !!user)
-          .map(user => ({ user_email: user.email })),
-      ),
-    );
-
-    // if manager role type has been selected but there are no users with selected role, update the error message
-    // message property is readonly so cannot just update the message
-    if (orgUserEmails.length === 0 && body.managerRole ) {
-      /* istanbul ignore next */
-      const managerRoleErrorIndex = errors.findIndex(
-        error => error.field === 'managerRole',
-      );
-      errors.splice(managerRoleErrorIndex, 0, { field: 'managerRole', message: 'Select organisation does not have any of the selected manager roles' });
-    }
-  }
-
-  // if there are errors, rerender the page with error messages
-  if (errors.length > 0) {
-
-    template.title = `Error: ${TITLE_EMAIL_ORG_MANAGERS}`;
-
-    return {
-      body: template.render(<ContactOrganisationManagersPage
-        csrf={ctx.viewContext.csrf}
-        linkTo={ctx.linkTo}
-        errors={errors}
-        orgs={orgsList}
-        values={body}
-      />),
-      status: 400,
-    };
-  }
-
-  // get org name from selected org guid
-  const orgDisplayName = orgsList
-    .filter(org => org.guid === body.organisation)
-    .map(org => org.name)
-    .toString();
-
-  // get admin user details to populate requester field for zendesk
-  const adminUser: IUaaUser | null = await uaa.getUser(ctx.token.userID);
-
- // send zendesk api request with all the data
-  const client = zendesk.createClient(ctx.app.zendeskConfig);
-  await client.tickets.create({
-    ticket: {
-      comment: {
-        body: contactOrgManagersZendeskContent({
-          organisation: orgDisplayName,
-          message: body.message,
-          managerRole: body.managerRole,
-        },
-        ctx.viewContext.location),
-      },
-      subject: '[PaaS Support] About your organisation on GOV.UK PaaS',
-      status: 'pending',
-      tags: ['govuk_paas_support'],
-      requester: constructZendeskRequesterObject(adminUser),
-      email_ccs: orgUserEmails,
-    },
-  });
-
-  template.title = 'Message has been sent';
-
-  return {
-    body: template.render(
-      <ContactOrganisationManagersConfirmationPage
-        linkTo={ctx.linkTo}
-        heading={'Message has been sent'}
-        text={'A Zendesk ticket has also been created to track progress.'}
-      >
-        <a className="govuk-link"
-          href="/platform-admin/contact-organisation-managers">
-            Contact more organisation managers
-        </a>.
-      </ContactOrganisationManagersConfirmationPage>,
-    ),
   };
 }
 

--- a/src/components/platform-admin/views.test.tsx
+++ b/src/components/platform-admin/views.test.tsx
@@ -7,8 +7,6 @@ import React from 'react';
 import { IParameters } from '../../lib/router';
 
 import {
-  ContactOrganisationManagersConfirmationPage,
-  ContactOrganisationManagersPage,
   CreateOrganizationPage,
   CreateOrganizationSuccessPage,
 } from './views';
@@ -44,79 +42,5 @@ describe(CreateOrganizationSuccessPage, () => {
 
     expect(container.innerHTML)
       .toContain('href="__LINKS_TO__admin.organizations.users.invite_WITH_organizationGUID=ORG_GUID"');
-  });
-});
-
-describe(ContactOrganisationManagersPage, () => {
-  it('should correctly render the form', () => {
-    const orgs = [{ name: 'a-different-org', guid: '123', suspended: false }];
-    const {container } = render (<ContactOrganisationManagersPage
-      csrf="CSRF_TOKEN"
-      linkTo={linker}
-      orgs={orgs}
-    />);
-
-    expect(container.querySelector('#organisation')).toHaveTextContent('a-different-org');
-    expect(container.querySelector('#managerRole')).toHaveTextContent('Billing manager');
-    expect(container.querySelector('#managerRole')).toHaveTextContent('Organisation manager');
-  });
-
-  it('should correctly render the form errors', () => {
-    const orgs = [{ name: 'a-different-org', guid: '123', suspended: false }];
-    const {container } = render (<ContactOrganisationManagersPage
-      csrf="CSRF_TOKEN"
-      linkTo={linker}
-      orgs={orgs}
-      errors={
-        [
-          { field: 'organisation', message: 'Select an organisation' },
-          { field: 'managerRole', message: 'Select a manager role' },
-          { field: 'message', message: 'Enter your message' },
-        ]
-      }
-    />);
-
-    expect(container.querySelector('.govuk-error-summary')).toBeTruthy();
-    expect(container.querySelectorAll('.govuk-error-summary li')).toHaveLength(3);
-    expect(container.querySelectorAll('.govuk-error-message')).toHaveLength(3);
-    expect(container.querySelector('#organisation-error')).toHaveTextContent('Select an organisation');
-    expect(container.querySelector('#managerRole-error')).toHaveTextContent('Select a manager role');
-    expect(container.querySelector('#message-error')).toHaveTextContent('Enter your message');
-  });
-
-  it('should use provided form values on resubmission', () => {
-    const orgs = [{ name: 'a-different-org', guid: '123', suspended: true }];
-    const {container } = render (<ContactOrganisationManagersPage
-      csrf="CSRF_TOKEN"
-      linkTo={linker}
-      orgs={orgs}
-      values={{
-        organisation: '123',
-        managerRole: 'billing_manager',
-        message: 'Text message',
-      }}
-    />);
-
-    expect(container.querySelector('#organisation option:checked')).toHaveTextContent('a-different-org (suspended)');
-    expect(container.querySelector('#managerRole option:checked')).toHaveTextContent('Billing manager');
-    expect(container.querySelector('#message')).toHaveValue('Text message');
-  });
-});
-
-describe(ContactOrganisationManagersConfirmationPage, () => {
-  it('should render the page with all provided properties', () => {
-    const {container } = render (
-      <ContactOrganisationManagersConfirmationPage
-          linkTo={route => `__LINKS_TO__${route}`}
-          heading={'confirmation panel heading'}
-          text={'confirmation panel text'}
-        >
-          children text
-        </ContactOrganisationManagersConfirmationPage>,
-    );
-
-    expect(container.querySelector('.govuk-panel__title')).toHaveTextContent('confirmation panel heading');
-    expect(container.querySelector('.govuk-panel__body')).toHaveTextContent('confirmation panel text');
-    expect(container.querySelector('.govuk-body')).toHaveTextContent('children text');
   });
 });

--- a/src/components/platform-admin/views.tsx
+++ b/src/components/platform-admin/views.tsx
@@ -1,9 +1,6 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement } from 'react';
 
 import { SLUG_REGEX } from '../../layouts';
-import {
-  OrganizationUserRoles,
-} from '../../lib/cf/types';
 import { RouteLinker } from '../app';
 import { IValidationError } from '../errors/types';
 import { SuccessPage } from '../org-users/views';
@@ -35,29 +32,6 @@ interface ICreateOrganizationPageProperties extends IFormProperties {
     readonly owner: string;
   }>;
 }
-
-export interface IContactOrganisationManagersPageValues {
-  readonly organisation: string;
-  readonly message: string;
-  readonly managerRole: OrganizationUserRoles;
-}
-
-interface IContactOrganisationManagersPageProperties extends IFormProperties {
-  readonly orgs: ReadonlyArray<{
-    readonly guid: string;
-    readonly name: string;
-    readonly suspended: boolean;
-  }>;
-  readonly values?: IContactOrganisationManagersPageValues;
-}
-
-interface ContactOrganisationManagersConfirmationPageProperties {
-  readonly heading: string;
-  readonly text: string;
-  readonly children: ReactNode;
-  readonly linkTo: RouteLinker;
-}
-
 
 function Costs(props: IFormProperties): ReactElement {
   return (
@@ -177,11 +151,6 @@ function Organizations(props: IProperties): ReactElement {
         <li>
           <a className="govuk-link" href={props.linkTo('admin.reports.organizations')}>
             View trial and billable organisations
-          </a>
-        </li>
-        <li>
-          <a className="govuk-link" href={props.linkTo('platform-admin.contact-organization-managers')}>
-            Contact organisation managers
           </a>
         </li>
       </ul>
@@ -317,194 +286,4 @@ export function CreateOrganizationSuccessPage(props: ICreateOrganizationSuccessP
     text={'You still need to invite people and assign permissions.'}
     >
   </SuccessPage>);
-}
-
-export function ContactOrganisationManagersPage(props: IContactOrganisationManagersPageProperties): ReactElement {
-  return (<div className="govuk-grid-row">
-    <div className="govuk-grid-column-two-thirds">
-      <form method="post" noValidate>
-        <h1 className="govuk-heading-xl">Contact organisation managers</h1>
-
-        <input type="hidden" name="_csrf" value={props.csrf} />
-
-        {props.errors
-          ? <div 
-              className="govuk-error-summary"
-              aria-labelledby="error-summary-title"
-              role="alert"
-              data-module="govuk-error-summary"
-            >
-              <h2 className="govuk-error-summary__title" id="error-summary-title">
-                There is a problem
-              </h2>
-              <div className="govuk-error-summary__body">
-                <ul className="govuk-list govuk-error-summary__list">
-                  {props.errors.map((error, index) => (
-                    <li key={index}><a href={`#${error.field}`}>{error.message}</a></li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          : null
-        }
-
-        <p className="govuk-body">
-        This form will create a Zendesk ticket and send an email to all selected managers of an organisation.
-        </p>
-
-        <div className={`govuk-form-group ${
-            props.errors?.some(e => e.field === 'organisation')
-              ? 'govuk-form-group--error'
-              : ''
-          }`}>
-          <label className="govuk-label" htmlFor="organisation">
-            Organisation name
-          </label>
-          {props.errors
-            ?.filter(error => error.field === 'organisation')
-            .map((error, index) => (
-              <p
-                key={index}
-                id="organisation-error"
-                className="govuk-error-message"
-              >
-                <span className="govuk-visually-hidden">Error:</span>{' '}
-                {error.message}
-              </p>
-            ))}
-          <select
-            className={`govuk-select ${
-              props.errors?.some(e => e.field === 'organisation')
-                  ? 'govuk-select--error'
-                  : ''
-              }`}
-            id="organisation"
-            name="organisation"
-            aria-describedby={
-              props.errors?.some(e => e.field === 'organisation')
-                ? 'organisation-error'
-                : ''
-            }
-          >
-            <option value="">Select an organisation</option>
-            {props.orgs.map(org => (
-              <option key={org.guid} selected={org.guid === props.values?.organisation} value={org.guid}>{org.name} { org.suspended ? '(suspended)' : null }</option>
-            ))},
-          </select>
-        </div>
-
-        <div className={`govuk-form-group ${
-            props.errors?.some(e => e.field === 'managerRole')
-              ? 'govuk-form-group--error'
-              : ''
-          }`}>
-          <label className="govuk-label" htmlFor="managerRole">
-            Manager role
-          </label>
-          {props.errors
-            ?.filter(error => error.field === 'managerRole')
-            .map((error, index) => (
-              <p
-                key={index}
-                id="managerRole-error"
-                className="govuk-error-message"
-              >
-                <span className="govuk-visually-hidden">Error:</span>{' '}
-                {error.message}
-              </p>
-            ))}
-          <select
-            className={`govuk-select ${
-              props.errors?.some(e => e.field === 'managerRole')
-                  ? 'govuk-select--error'
-                  : ''
-              }`}
-            id="managerRole"
-            name="managerRole"
-            aria-describedby={
-              props.errors?.some(e => e.field === 'managerRole')
-                ? 'managerRole-error'
-                : ''
-            }
-          >
-            <option value="">Select manager role</option>
-            <option value="billing_manager" selected={props.values?.managerRole === 'billing_manager'}>Billing manager</option>
-            <option value="org_manager" selected={props.values?.managerRole === 'org_manager'}>Organisation manager</option>
-          </select>
-        </div>
-
-        <div className={`govuk-form-group ${
-            props.errors?.some(e => e.field === 'message')
-              ? 'govuk-form-group--error'
-              : ''
-          }`}>
-          <label className="govuk-label" htmlFor="message">
-            Message
-          </label>
-          {props.errors
-            ?.filter(error => error.field === 'message')
-            .map((error, index) => (
-              <p
-                key={index}
-                id="message-error"
-                className="govuk-error-message"
-              >
-                <span className="govuk-visually-hidden">Error:</span>{' '}
-                {error.message}
-              </p>
-            ))}
-
-          <textarea
-            className={`govuk-textarea ${
-              props.errors?.some(e => e.field === 'message')
-                  ? 'govuk-textarea--error'
-                  : ''
-              }`}
-            id="message"
-            name="message"
-            aria-describedby={
-              props.errors?.some(e => e.field === 'message')
-                ? 'message-error message-hint'
-                : 'message-hint'
-            }
-            rows={8}
-            defaultValue={props.values?.message}
-          />
-        </div>
-
-        <p className="govuk-body">
-        Message will automatically include the following:
-        <div id="message-hint" className="govuk-hint">
-          You are receiving this email as you are listed as a [manager_role] manager of the [organisation_name] organisation in our [paas_region] region.<br /><br />
-          Thank you,<br />
-          GOV.UK PaaS
-          </div>
-        </p>
-
-        <button className="govuk-button" data-module="govuk-button" data-prevent-double-click="true">
-          Send
-        </button>
-      </form>
-    </div>
-
-  </div>);
-}
-
-export function ContactOrganisationManagersConfirmationPage(props: ContactOrganisationManagersConfirmationPageProperties): ReactElement {
-  return (
-    <div className="govuk-grid-row">
-      <div className="govuk-grid-column-two-thirds">
-        <div className="govuk-panel govuk-panel--confirmation">
-          <h1 className="govuk-panel__title">
-            {props.heading}
-          </h1>
-          <div className="govuk-panel__body">
-            {props.text}
-          </div>
-        </div>
-
-        <p className="govuk-body">{props.children}</p>
-      </div>
-    </div>
-  );
 }

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -232,6 +232,15 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
             </a>
           </p> : <></>}
 
+          {props.isAdmin ? <p className="govuk-body">
+            <a
+              href={props.linkTo('admin.organizations.email-managers', { organizationGUID: props.organization.metadata.guid })}
+              className="govuk-link"
+            >
+              Email space or organisation managers
+            </a>
+          </p> : <></>}
+
           <p className="govuk-body">
             <a
               href="https://docs.cloud.service.gov.uk/managing_apps.html#quotas"


### PR DESCRIPTION
What
----

- move email org managers form from `/plaform-admin` to `organisations/<orgGUID>` path - shift of https://github.com/alphagov/paas-admin/pull/2033
- enhance the form with the ability to email space managers for the org only
- add ability to provide custom email/zendesk subject

Why
---
Sometimes we wish to only contact certain manager roles.
Move to a new path under org so that we can avoid expensive calls to all orgs for all their spaces and only call for the ones under the current org.


https://www.pivotaltracker.com/story/show/183155106
https://www.pivotaltracker.com/story/show/180991740

How to review
-------------
 - suggest reviewing by commit
 - run locally (with zendesk api credentials from the credentials store)
 or
- deploy to a dev env

Who can review
---------------

not @kr8n3r 

Visuals
----
### Default form
![form](https://user-images.githubusercontent.com/3758555/189101001-0bb7bce4-39c3-430a-9a5a-83999b7f9fc3.png)

### Form with error if no managers of selected type exist
![form-error-if-no-managers](https://user-images.githubusercontent.com/3758555/189101008-806da0f9-1f97-4347-ba50-003d4faff91f.png)

### Link to the form on the org page
![org-page-link-to-the-form](https://user-images.githubusercontent.com/3758555/189101009-20a5b1dd-5671-4912-92e1-183cda6182d2.png)

### Zendesk tickets with text from form inputs
![zendesk-org-managers-text](https://user-images.githubusercontent.com/3758555/189101012-61b400af-a736-4b46-bcfc-e7fe64f9a223.png)
![zendesk-space-manager-text](https://user-images.githubusercontent.com/3758555/189101014-3d7c451c-28d8-4155-8815-91f94c5f1bb0.png)
![zendesk-ticket-custom-subject](https://user-images.githubusercontent.com/3758555/189101636-e2283755-070c-472b-a313-6d37ae2cbe3d.png)


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
