### PR TITLE
Display origin information for shared backing services

### DIFF
--- a/src/components/services/controllers.test.tsx
+++ b/src/components/services/controllers.test.tsx
@@ -15,6 +15,12 @@ nock('https://example.com/api')
   .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92')
   .times(1)
   .reply(200, data.serviceInstance)
+  .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_from')
+  .times(1)
+  .reply(200, {})
+  .get('/v2/service_instances/0d632575-bb06-4ea5-bb19-a451a9644d92/shared_to')
+  .times(1)
+  .reply(200, {})
   .get('/v2/service_plans/779d2df0-9cdd-48e8-9781-ea05301cedb1')
   .times(1)
   .reply(200, data.servicePlan)
@@ -36,7 +42,17 @@ nock('https://example.com/api')
     '/v2/user_provided_service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee',
   )
   .times(1)
-  .reply(200, data.userServiceInstance);
+  .reply(200, data.userServiceInstance)
+  .get(
+    '/v2/service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee/shared_from',
+  )
+  .times(1)
+  .reply(200, {})
+  .get(
+    '/v2/service_instances/54e4c645-7d20-4271-8c27-8cc904e1e7ee/shared_to',
+  )
+  .times(1)
+  .reply(200, {});
 
 const ctx: IContext = createTestContext();
 

--- a/src/components/services/controllers.tsx
+++ b/src/components/services/controllers.tsx
@@ -41,6 +41,9 @@ export async function viewService(
     ? await cf.servicePlan(service.entity.service_plan_guid)
     : undefined;
 
+  const sharedFrom = await cf.sharedFrom(params.serviceGUID)
+  const sharedTo = await cf.sharedTo(params.serviceGUID)
+  
   const summarisedService = {
     entity: service.entity,
     metadata: service.metadata,
@@ -48,6 +51,8 @@ export async function viewService(
       ? await cf.service(servicePlan.entity.service_guid)
       : undefined,
     service_plan: servicePlan,
+    shared_from: sharedFrom,
+    shared_to: sharedTo,
   };
 
   const template = new Template(

--- a/src/components/services/views.test.tsx
+++ b/src/components/services/views.test.tsx
@@ -119,14 +119,40 @@ describe(ServicePage, () => {
     expect(container.querySelector('td.status')).toHaveTextContent('success');
   });
 
-  it('should fallback to default values', () => {
+  it('should display SHARED TO data if the service has been shared to other spaces and/or orgs', () => {
     const service = ({
-      entity: { name: 'service-name', tags: [] },
+      entity: {
+        last_operation: { state: 'success' },
+        name: 'service-name',
+        tags: [],
+      },
       metadata: { guid: 'SERVICE_GUID' },
+      shared_from: {
+        space_guid: 'SPACE_GUID',
+        space_name: 'test space',
+        organization_name: 'test org',
+      },
+      shared_to: {
+        resources: [
+          {
+            space_guid: '3310e016-2276-40c3-92a8-af7552444bbd',
+            space_name: 'test space',
+            organization_name: 'test org',
+          },
+        ],
+      },
     } as unknown) as IServiceInstance;
     const { container } = render(
       <ServicePage
-        service={service}
+        service={{
+          ...service,
+          service: ({
+            entity: { label: 'service-label' },
+          } as unknown) as IService,
+          service_plan: ({
+            entity: { name: 'service-plan-name' },
+          } as unknown) as IServicePlan,
+        }}
         linkTo={route => `__LINKS_TO__${route}`}
         routePartOf={route =>
           route === 'admin.organizations.spaces.services.view'
@@ -136,10 +162,63 @@ describe(ServicePage, () => {
         spaceGUID="SPACE_GUID"
       />,
     );
-    expect(container.querySelector('td.label')).toHaveTextContent('User Provided Service');
-    expect(container.querySelector('td.plan')).toHaveTextContent('N/A');
-    expect(container.querySelector('td.status')).toHaveTextContent('N/A');
+    expect(container.querySelector('td.label')).toHaveTextContent('service-label');
+    expect(container.querySelector('td.plan')).toHaveTextContent('service-plan-name');
+    expect(container.querySelector('td.status')).toHaveTextContent('success');
+    expect(container.querySelector('td.sharedTo')).toHaveTextContent('space test space in organisation test org');
+    expect(container.querySelector('td.sharedFrom')).toBeFalsy();
   });
+
+  it('should display SHARED FROM data if the service has been shared from another spaces and/or orgs', () => {
+    const service = ({
+      entity: {
+        last_operation: { state: 'success' },
+        name: 'service-name',
+        tags: [],
+      },
+      metadata: { guid: 'SERVICE_GUID' },
+      shared_from: {
+        space_guid: 'guid',
+        space_name: 'test space',
+        organization_name: 'test org',
+      },
+      shared_to: {
+        resources: [
+          {
+            space_guid: '3310e016-2276-40c3-92a8-af7552444bbd',
+            space_name: 'test space',
+            organization_name: 'test org',
+          },
+        ],
+      },
+    } as unknown) as IServiceInstance;
+    const { container } = render(
+      <ServicePage
+        service={{
+          ...service,
+          service: ({
+            entity: { label: 'service-label' },
+          } as unknown) as IService,
+          service_plan: ({
+            entity: { name: 'service-plan-name' },
+          } as unknown) as IServicePlan,
+        }}
+        linkTo={route => `__LINKS_TO__${route}`}
+        routePartOf={route =>
+          route === 'admin.organizations.spaces.services.view'
+        }
+        organizationGUID="ORG_GUID"
+        pageTitle="test"
+        spaceGUID="SPACE_GUID"
+      />,
+    );
+    expect(container.querySelector('td.label')).toHaveTextContent('service-label');
+    expect(container.querySelector('td.plan')).toHaveTextContent('service-plan-name');
+    expect(container.querySelector('td.status')).toHaveTextContent('success');
+    expect(container.querySelector('td.sharedFrom')).toHaveTextContent('space test space in organisation test org');
+    expect(container.querySelector('td.sharedTo')).toBeFalsy();
+  });
+
 });
 
 describe(ServiceLogsPage, () => {

--- a/src/components/services/views.tsx
+++ b/src/components/services/views.tsx
@@ -5,7 +5,7 @@ import React, { ReactElement, ReactNode } from 'react';
 import { DATE_TIME } from '../../layouts/constants';
 import { Abbreviation, bytesToHuman } from '../../layouts/helpers';
 import { CommandLineAlternative } from '../../layouts/partials';
-import { IService, IServiceInstance, IServicePlan } from '../../lib/cf/types';
+import { IService, IServiceInstance, IServicePlan, IShareServiceDetails } from '../../lib/cf/types';
 import { RouteActiveChecker, RouteLinker } from '../app';
 
 interface IEnhancedServiceInstance extends IServiceInstance {
@@ -204,6 +204,30 @@ export function ServicePage(props: IServicePageProperties): ReactElement {
                   {props.service.entity.tags.join(', ')}
                 </td>
               </tr>
+              {props.service.shared_from && props.service.shared_from.space_guid !== props.spaceGUID ? 
+                <tr className="govuk-table__row">
+                  <th scope="row" className="govuk-table__header">
+                    Shared from
+                  </th>
+                  <td className="govuk-table__cell sharedFrom">
+                    space <span className="govuk-!-font-weight-bold">{props.service.shared_from.space_name}</span> in organisation <span className="govuk-!-font-weight-bold">{props.service.shared_from.organization_name}</span>
+                  </td>
+                </tr>
+              : '' }
+            {props.service.shared_from && props.service.shared_from.space_guid === props.spaceGUID ? 
+              <tr className="govuk-table__row">
+                <th scope="row" className="govuk-table__header">
+                  Shared to
+                </th>
+                <td className="govuk-table__cell sharedTo">
+                  <ul className="govuk-list">
+                  {props.service.shared_to!.resources.map((item:IShareServiceDetails) => (
+                      <li key={item.space_guid}>space <span className="govuk-!-font-weight-bold">{item.space_name}</span> in organisation <span className="govuk-!-font-weight-bold">{item.organization_name}</span></li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+                : '' }
             </tbody>
           </table>
           </div>

--- a/src/lib/cf/cf.ts
+++ b/src/lib/cf/cf.ts
@@ -448,6 +448,18 @@ export default class CloudFoundryClient {
     return response.data;
   }
 
+  public async sharedFrom(serviceGUID: string): Promise<cf.IShareServiceDetails> {
+    const response = await this.request('get', `/v2/service_instances/${serviceGUID}/shared_from`);
+
+    return response.data;
+  }
+
+  public async sharedTo(serviceGUID: string): Promise<cf.ISharedToServiceDetails> {
+    const response = await this.request('get', `/v2/service_instances/${serviceGUID}/shared_to`);
+
+    return response.data;
+  }
+
   public async createUser(userId: string): Promise<cf.IUser> {
     const response = await this.request('post', '/v2/users', { guid: userId });
 

--- a/src/lib/cf/types.ts
+++ b/src/lib/cf/types.ts
@@ -373,6 +373,15 @@ export interface IV3Service<T> {
   };
 }
 
+export interface IShareServiceDetails {
+  readonly space_guid: string;
+  readonly space_name: string;
+  readonly organization_name: string;
+}
+export interface ISharedToServiceDetails {
+  readonly resources: ReadonlyArray<IShareServiceDetails>;
+}
+
 export interface IServicePlan {
   readonly entity: {
     readonly active: boolean;
@@ -449,6 +458,8 @@ export interface IServiceInstance {
     readonly type: string;
   };
   readonly metadata: IMetadata;
+  readonly shared_from?: IShareServiceDetails;
+  readonly shared_to?: ISharedToServiceDetails;
 }
 
 export interface IServiceSummary {
@@ -472,11 +483,8 @@ export interface IServiceSummary {
       readonly version: string;
     };
   };
-  readonly shared_from: {
-    readonly organization_name: string;
-    readonly space_guid: string;
-    readonly space_name: string;
-  };
+  readonly shared_from?: IShareServiceDetails;
+  readonly shared_to?: ISharedToServiceDetails;
 }
 
 export interface IV3SpaceRequest {


### PR DESCRIPTION
What
----

Display information if a service is shared from or to another space and/or org.

### Display SHARED TO if the service is shared to any other spaces and/or orgs
<img width="824" alt="Screenshot 2022-08-18 at 14 38 25" src="https://user-images.githubusercontent.com/3758555/185409091-6c530b39-0b19-459d-b3d2-0377a72aad4b.png">

### Display SHARED FROM if the service is shared from another space and/or org
<img width="821" alt="Screenshot 2022-08-18 at 14 38 33" src="https://user-images.githubusercontent.com/3758555/185409099-287a8cd0-5c0c-4cd8-ad2c-b25a5b97fabd.png">

### Don't display anything if the service is not shared
<img width="831" alt="Screenshot 2022-08-18 at 14 38 40" src="https://user-images.githubusercontent.com/3758555/185409101-41a00f3a-0b54-4d19-8017-471aa1fb4089.png">


How to review
-------------

- review code
- tests pass
- compare data (`cf service`) on dev 01 where
`admin/healthchecks/shared-s3-bucket` is shared with `admin/public` and `govuk-paas/sandbox` spaces

Who can review
---------------

not @kr8n3r

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
