### PR TITLE
Update org quota display

### DIFF
--- a/src/components/spaces/controllers.test.tsx
+++ b/src/components/spaces/controllers.test.tsx
@@ -241,14 +241,14 @@ describe('spaces test suite', () => {
       .reply(200, data.services);
     const response = await spaces.listSpaces(ctx, { organizationGUID });
 
-    expect(response.body).toContain('Quota usage');
-    expect(response.body).toContain('5.0%');
-    expect(response.body).toMatch(
+    expect(response.body).toContain('Assigned quota');
+    expect(response.body).toContain('name-1996');
+    expect(response.body).not.toMatch(
       /Using\s+1[.]00\s<abbr role="tooltip" tabindex="0" data-module="tooltip" aria-label="gibibytes">GiB<\/abbr>\s+of memory/m,
     );
 
     expect(response.body).toContain('Spaces');
-    expect(response.body).toMatch(/0[.]00.*GiB.*\s+of\s+20[.]00.*GiB/m);
+    expect(response.body).toMatch(/0*\s.*B.*\s+of\s+20[.]00.*GiB/m);
     expect(response.body).toMatch(/1[.]00.*GiB.*\s+of\s+no limit/m);
     expect(
       spacesMissingAroundInlineElements(response.body as string),

--- a/src/components/spaces/views.test.tsx
+++ b/src/components/spaces/views.test.tsx
@@ -351,10 +351,6 @@ describe(SpacesPage, () => {
     );
     expect(container.querySelectorAll('table tbody tr')).toHaveLength(2);
     expect(container.querySelector('h1')).toHaveTextContent(organization.entity.name);
-    expect(container.querySelector('h2 + span')).toHaveTextContent('20.0%');
-    expect(container.querySelector('p')).toHaveTextContent(
-      'Using 1.00 GiB of memory out of a maximum of 5.00 GiB.',
-    );
     expect(queryByText('View team members')).toBeTruthy();
     expect(queryByText('Trial')).toBeTruthy();
     expect(queryByText('Trial organisations have limited access to backing services')).toBeTruthy();
@@ -380,6 +376,40 @@ describe(SpacesPage, () => {
     expect(container.querySelector('table tbody tr')).toBeTruthy();
     expect(queryByText('Manage this organization')).toBeTruthy();
     expect(queryByText(`There is 1 space in ${organization.entity.name}.`)).toBeTruthy();
+  });
+
+  it('should ONLY show qouta usage calculation for org managers', () => {
+    const { container } = render(
+      <SpacesPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        isAdmin={false}
+        isManager={true}
+        isBillingManager={false}
+        organization={organization}
+        spaces={[space, { ...space, quota: undefined }]}
+        users={[null]}
+      />,
+    );
+    expect(container.querySelectorAll('.org-summary-stat__value')[0]).toHaveTextContent('default');
+    expect(container.querySelectorAll('.org-summary-stat__value')[1]).toHaveTextContent('20.0%');
+    expect(container.querySelectorAll('.org-summary-stat__context').length).toBe(1);
+  });
+
+  it('should NOT show qouta usage calculation for NON org managers and only show assigned quota name', () => {
+    const { container } = render(
+      <SpacesPage
+        linkTo={route => `__LINKS_TO__${route}`}
+        isAdmin={false}
+        isManager={false}
+        isBillingManager={false}
+        organization={organization}
+        spaces={[space, { ...space, quota: undefined }]}
+        users={[null]}
+      />,
+    );
+    expect(container.querySelectorAll('.org-summary-stat__value')[0]).toHaveTextContent('default');
+    expect(container.querySelectorAll('.org-summary-stat__value')[0]).not.toHaveTextContent('20.0%');
+    expect(container.querySelectorAll('.org-summary-stat__context').length).toBe(0);
   });
 
   it('should highlight suspended state in main heading', () => {

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -193,16 +193,22 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-third">
           <div className="org-summary-stat">
+            <h2 className="org-summary-stat__heading">Assigned quota</h2>
+            <span className="org-summary-stat__value">
+              {props.organization.quota.entity.name}
+            </span>
+          </div>
+          {props.isManager ?
+          <>
+          <div className="org-summary-stat">
             <h2 className="org-summary-stat__heading">Quota usage</h2>
-
-            <span className="org-summary-stat__figure">
+            <span className="org-summary-stat__value">
               {help.percentage(
                 props.organization.memory_allocated,
                 props.organization.quota.entity.memory_limit,
               )}
             </span>
           </div>
-
           <p className="org-summary-stat__context govuk-body">
             Using{' '}
             {help.bytesToHuman(props.organization.memory_allocated * MEBIBYTE)}{' '}
@@ -212,6 +218,10 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
             )}
             .
           </p>
+          </>
+            : <></>
+          }
+          
 
           {props.isAdmin ? <p className="govuk-body">
             <a
@@ -236,7 +246,7 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
           <div className="org-summary-stat">
             <h2 className="org-summary-stat__heading">Team members</h2>
 
-            <span className="org-summary-stat__figure">
+            <span className="org-summary-stat__value">
               {props.users.length}
             </span>
           </div>
@@ -262,7 +272,7 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
           <div className="org-summary-stat">
             <h2 className="org-summary-stat__heading">Billing</h2>
 
-            <span className="org-summary-stat__figure">
+            <span className="org-summary-stat__value">
               {props.organization.quota.entity.name === 'default'
                 ? 'Trial'
                 : 'Billable'}

--- a/src/layouts/govuk.screen.scss
+++ b/src/layouts/govuk.screen.scss
@@ -44,7 +44,7 @@ $govuk-breakpoints: (
     min-height: 1.25;
   }
 
-  .org-summary-stat__figure {
+  .org-summary-stat__value {
     font-size: 36px;
     line-height: 1.1111;
     font-weight: 700;


### PR DESCRIPTION
What
----

- Add name of assigned quota
- Update tests

If viewer has `org manager` role: show detailed breakdown as before, else only show the assigned quota name.

Why
----

Information display differs depending on viewing user's role. Only for org managers are resources calculate correctly.

Visual changes
---------------

### Before
**org manager view**

![Screenshot 2022-08-31 at 08 13 13](https://user-images.githubusercontent.com/3758555/187616269-bfa16f51-f763-4c7c-9c36-226abd33fc08.png)

**regular view**

![Screenshot 2022-08-31 at 08 12 49](https://user-images.githubusercontent.com/3758555/187616353-97e47002-bcbf-486a-9901-1de63b6717de.png)

### After

**org manager view**

![Screenshot 2022-08-31 at 08 15 56](https://user-images.githubusercontent.com/3758555/187616714-d497bf51-02a2-437e-80ba-8fd15b63d40f.png)

**regular view**

![Screenshot 2022-08-31 at 08 15 31](https://user-images.githubusercontent.com/3758555/187616774-b7821dfe-bd1a-434e-a563-0f5043d67c01.png)



How to review
-------------

- tests pass
- review code
- optionally deploy to an env, and view with different roles

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
