### PR TITLE
Downgrade puppeteer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,13 +112,8 @@
         "pegjs": "^0.10.0",
         "pegjs-loader": "^0.5.6",
         "pino-pretty": "^7.6.1",
-<<<<<<< HEAD
-        "puppeteer": "^18.0.5",
+        "puppeteer": "^17.1.3",
         "sass": "^1.55.0",
-=======
-        "puppeteer": "^18.0.3",
-        "sass": "^1.54.9",
->>>>>>> 7da9440d (Bump @types/react from 18.0.20 to 18.0.21)
         "sass-loader": "^13.0.2",
         "stylelint": "^14.12.1",
         "stylelint-config-gds": "^0.2.0",
@@ -16199,9 +16194,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "node_modules/puppeteer": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.5.tgz",
-      "integrity": "sha512-s4erjxU0VtKojPvF+KvLKG6OHUPw7gO2YV1dtOsoryyCbhrs444fXb4QZqGWuTv3V/rgSCUzeixxu34g0ZkSMA==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.3.tgz",
+      "integrity": "sha512-tVtvNSOOqlq75rUgwLeDAEQoLIiBqmRg0/zedpI6fuqIocIkuxG23A7FIl1oVSkuSMMLgcOP5kVhNETmsmjvPw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -31767,9 +31762,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "puppeteer": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.5.tgz",
-      "integrity": "sha512-s4erjxU0VtKojPvF+KvLKG6OHUPw7gO2YV1dtOsoryyCbhrs444fXb4QZqGWuTv3V/rgSCUzeixxu34g0ZkSMA==",
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.3.tgz",
+      "integrity": "sha512-tVtvNSOOqlq75rUgwLeDAEQoLIiBqmRg0/zedpI6fuqIocIkuxG23A7FIl1oVSkuSMMLgcOP5kVhNETmsmjvPw==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
     "pino-pretty": "^7.6.1",
-    "puppeteer": "^18.0.3",
+    "puppeteer": "^17.1.3",
     "sass": "^1.55.0",
     "sass-loader": "^13.0.2",
     "stylelint": "^14.12.1",


### PR DESCRIPTION
What
----

It looks like expect-puppeteer isn't ready to support v18 yet as it causes
```
    [object Object] is not supported

      112 |       await page.goto(PAAS_ADMIN_BASE_URL);
      113 |
    > 114 |       await puppeteer_expect(page).toFill('input[name=username]', managerUserEmail);
```

error - see https://deployer.london.staging.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-admin/builds/2517

So we're downgrading until then.

How to review
-------------

can run locally against a dev env with

```
Executing the acceptance tests against dev environment:

export PAAS_ADMIN_BASE_URL=https://admin.${DEPLOY_ENV}.dev.cloudpipeline.digital
export CF_API_BASE_URL=https://api.${DEPLOY_ENV}.dev.cloudpipeline.digital
export ACCOUNTS_API_BASE_URL=https://accounts.${DEPLOY_ENV}.dev.cloudpipeline.digital
export ACCOUNTS_USERNAME=admin
export ACCOUNTS_PASSWORD= # get this value from credhub using `credhub get -n /concourse/main/create-cloudfoundry/paas_accounts_password`

export ADMIN_USERNAME=admin
export ADMIN_PASSWORD= # get this value from credhub using `credhub get -n /${DEPLOY_ENV}/${DEPLOY_ENV}/cf_admin_password`

npm run test:acceptance
```

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
