### PR TITLE
Fix password reset error handling

### DIFF
--- a/src/components/users/controllers.test.tsx
+++ b/src/components/users/controllers.test.tsx
@@ -532,6 +532,30 @@ describe(users.resetPassword, () => {
     expect(response.status).toEqual(400);
     expect(response.body).toContain('should contain a special character');
   });
+
+  it('should throw an error if the new password is the same as old password', async () => {
+
+    nockUAA
+      .post('/oauth/token?grant_type=client_credentials')
+      .reply(200, '{"access_token": "FAKE_ACCESS_TOKEN"}')
+
+      .post('/password_change')
+      .reply(422, {
+          "error_description":"Your new password cannot be the same as the old password.",
+          "error":"invalid_password",
+          "message":"Your new password cannot be the same as the old password.",
+        },
+      );
+
+    const response = await users.resetPassword(ctx, {}, {
+      code: '1234567890',
+      password: 'password-STR0NG-like-j3nk1n$',
+      passwordConfirmation: 'password-STR0NG-like-j3nk1n$',
+    })
+
+    expect(response.status).toEqual(422);
+    expect(response.body).toContain('Your new password cannot be the same as the old password');
+  });
 });
 
 describe(users.checkPasswordAgainstPolicy, () => {

--- a/src/components/users/controllers.tsx
+++ b/src/components/users/controllers.tsx
@@ -316,13 +316,25 @@ export async function resetPassword(ctx: IContext, _params: IParameters, body: I
       clientSecret: ctx.app.oauthClientSecret,
     },
   });
+  try {
+    await uaa.resetPassword(body.code, body.password);
+    return {
+      body: template.render(<PasswordResetSuccess
+        title="Password successfully reset"
+        message="You may now log in with the use of your email and password."
+      />),
+    };
 
-  await uaa.resetPassword(body.code, body.password);
-
-  return {
-    body: template.render(<PasswordResetSuccess
-      title="Password successfully reset"
-      message="You may now log in with the use of your email and password."
-    />),
-  };
+  } catch (error:any) {
+    return {
+      body: template.render(<PasswordResetSetPasswordForm
+        csrf={ctx.viewContext.csrf}
+        code={body.code}
+        passwordDoesNotMeetPolicy={true}
+        passwordDoesNotMeetPolicyMessage={error.data.message}
+      />),
+      status: error.response.status,
+    }
+  }
 }
+

--- a/src/lib/uaa/uaa.ts
+++ b/src/lib/uaa/uaa.ts
@@ -45,6 +45,7 @@ async function request(endpoint: string, method: string, url: string, opts: any)
     let err: any;
     if (typeof response.data === 'object') {
       err = new Error(`${msg} and data ${JSON.stringify(response.data)}`);
+      err.data = response.data;
     } else {
       err = new Error(msg);
     }


### PR DESCRIPTION
What
----

Wrap the password reset request in a `try...catch` block so that when there is an error in the response, we show the error in the form instead of the the "Sorry there's been a problem" page.

As discovered in https://govuk.zendesk.com/agent/tickets/5079686, UAA does not like if users try to reset the password that matches the existing password, returning
```
UAAClient: post /password_change failed with status 422 and data {"error_description":"Your new password cannot be the same as the old password.","error":"invalid_password","message":"Your new password cannot be the same as the old password."}
```

We did not cater for this scenario. This change

- exposes the error object in the UAA response if it exists so that, we can use it in the form
- wraps the password reset request in a `try...catch` block so that when there is an error in the response, we show the error in the form with the message from the response

How to review
-------------

- try to reset user password with the same password
- deploy to dev env and compare with current prod

Who can review
---------------

not @kr8n3r 

New error message
----
![Screenshot 2022-09-23 at 11 34 05](https://user-images.githubusercontent.com/3758555/191943255-3f7b2a7b-f6fc-43eb-a6a7-ccd135c2dbf0.png)


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
