### PR TITLE
Update github actions packages

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -12,10 +12,10 @@ jobs:
       TEST_TIMEOUT: 60000
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version-file: "package.json"
       - run: npm ci
 
       - name: Build


### PR DESCRIPTION
What
----

- Use latest version of checkout and setup-node
- Read node version from package.json instead



How to review
-------------

github actions tests run on node 16 (as per https://github.com/alphagov/paas-admin/blob/main/package.json#L154)

https://github.com/alphagov/paas-admin/actions/runs/3242038143/jobs/5314763063#step:3:11

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
