### PR TITLE
Add migration owner notice

### DIFF
--- a/src/components/organizations/views.tsx
+++ b/src/components/organizations/views.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 
 import { bytesToHuman, MEBIBYTE } from '../../layouts';
-import { NotificationBanner } from '../../layouts/partials';
 import { IOrganization, IOrganizationQuota, IV3OrganizationQuota, IV3OrganizationResource } from '../../lib/cf/types';
 import { RouteLinker } from '../app';
 import { ISpace } from '../../lib/cf/types';
@@ -106,7 +105,6 @@ export function OrganizationsPage(
 
   return (
     <>
-      <NotificationBanner />
 
       <h1 className="govuk-heading-l">Organisations</h1>
 

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -26,6 +26,7 @@ import {
   Totals,
   EventTimestamps,
 } from '../events';
+import { NotificationBanner } from '../../layouts/partials';
 
 export interface IEnhancedApplication extends IApplication {
   readonly summary: IApplicationSummary;
@@ -191,6 +192,9 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
       </h1>
 
       <div className="govuk-grid-row">
+        <div className="govuk-grid-column-full">
+          <NotificationBanner />
+        </div>
         <div className="govuk-grid-column-one-third">
           <div className="org-summary-stat">
             <h2 className="org-summary-stat__heading">Assigned quota</h2>

--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -394,9 +394,10 @@ export function NotificationBanner(): ReactElement {
       </div>
       <div className="govuk-notification-banner__content">
         <h3 className="govuk-notification-banner__heading">
-          GOV.UK PaaS is being decommissioned
+          Migration guidance and request for migration owner details
         </h3>
-        <p className="govuk-body"><a className="govuk-notification-banner__link" href="https://cloud.service.gov.uk">Read more about it</a>.</p>
+        <p className="govuk-body">We have <a className="govuk-notification-banner__link" href="https://cloud.service.gov.uk/migration-guidance/">published migration guidance</a> for tenants.</p>
+        <p className="govuk-body">We&apos;re confirming the migration owner for service or services in this space. <a className="govuk-notification-banner__link" href="/support/contact-us">Please tell us</a> who the responsible person is in your organisation.</p>
       </div>      
     </div>
     </>


### PR DESCRIPTION
What
----

- remove deprecation notice from organisation list page
- update notification banner with
  - link to migration guidance
  - link to contact form and ask to let us know about the service's migration owner
- add banner to spaces page

<img width="1224" alt="Screenshot 2022-11-02 at 16 02 18" src="https://user-images.githubusercontent.com/3758555/199540038-713aa8db-3e0e-45f8-8d43-e9ab490ee361.png">


How to review
-------------

deploy to env or run locally


Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
