### PR TITLE
convert user search input to a valid one

### DIFF
--- a/src/components/platform-admin/redirect.ts
+++ b/src/components/platform-admin/redirect.ts
@@ -6,11 +6,13 @@ async function findUser(
   _params: IParameters,
   body: any,
 ): Promise<IResponse> {
-  const emailOrUserGUID = body['email-or-user-guid'];
+  let emailOrUserGUID = body['email-or-user-guid'];
 
   if (typeof emailOrUserGUID === 'undefined' || emailOrUserGUID === '') {
     throw new Error('Field email-or-user-guid is undefined or blank');
   }
+
+  emailOrUserGUID = emailOrUserGUID.trim().toLowerCase()
 
   return await Promise.resolve({
     redirect: ctx.linkTo('users.get', { emailOrUserGUID }),


### PR DESCRIPTION
What
----

At the moment the user input isn't stripping whitespaces and email addresses aren't lowercased before being passed as a parameter for user lookup, so a 404 is returned even though the user exists

Example: 
- https://admin.london.cloud.service.gov.uk/users/Mark.Buckley@digital.cabinet-office.gov.uk 
vs
- https://admin.london.cloud.service.gov.uk/users/mark.buckley@digital.cabinet-office.gov.uk


Using [trim()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) and [toLowercase()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) to turn the string into a 'valid' search parameter.
Our user GUIDs are all lowercase, so no affect on them. 



How to review
-------------

deploy to dev env and search for your account with spaces and uppercase letters

Who can review
---------------
not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
