### PR TITLE
Update qs package dependency for request 2.88.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16477,14 +16477,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/request/node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -31806,18 +31798,13 @@
         "mime-types": "~2.1.19",
         "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
+        "qs": "^6.11.0",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.1"
   },
+  "overrides": {
+    "request@2.88.2": {
+      "qs": "^6.11.0"
+    }
+  },
   "engines": {
     "node": "16.x.x",
     "npm": ">=8.x.x"


### PR DESCRIPTION
What
----

`node-zendesk` requires `request` which is deprecated. In turn `request` depends on `qs v6.5.2` which contains vulnerability - https://github.com/alphagov/paas-admin/security/dependabot/29

To mitigate, we use the [npm overrides property](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides) and force a patched version of qs for request only.

where `request` is used

```
└─┬ node-zendesk@2.2.0
  └── request@2.88.2
```
**Before**
```
├─┬ body-parser@1.20.1
│ └── qs@6.11.0 deduped
├─┬ express@4.18.2
│ └── qs@6.11.0 deduped
├─┬ node-zendesk@2.2.0
│ └─┬ request@2.88.2
│   └── qs@6.5.2
├── qs@6.11.0
└─┬ supertest@6.3.3
  └─┬ superagent@8.0.6
    ├─┬ formidable@2.1.1
    │ └── qs@6.11.0 deduped
    └── qs@6.11.0 deduped
```
**After**
```
├─┬ body-parser@1.20.1
│ └── qs@6.11.0 deduped
├─┬ express@4.18.2
│ └── qs@6.11.0 deduped
├─┬ node-zendesk@2.2.0
│ └─┬ request@2.88.2
│   └── qs@6.11.0 deduped
├── qs@6.11.0
└─┬ supertest@6.3.3
  └─┬ superagent@8.0.6
    ├─┬ formidable@2.1.1
    │ └── qs@6.11.0 deduped
    └── qs@6.11.0 deduped
```
How to review
-------------

- tests pass
- zendesk tickets still get created - > currently deployed to dev03
![Screenshot 2022-12-15 at 11 33 17](https://user-images.githubusercontent.com/3758555/207849147-755160a5-b329-4d2b-a570-2e4344187db1.png)


Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
