### PR TITLE
Run on Node 18

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     env:
       NODE_ENV: development

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/Gallium
+lts/Hydrogen

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "16.x.x",
+        "node": "18.x.x",
         "npm": ">=8.x.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     }
   },
   "engines": {
-    "node": "16.x.x",
+    "node": "18.x.x",
     "npm": ">=8.x.x"
   },
   "jest": {


### PR DESCRIPTION
What
----

Update version on node to 18, which is current LTS.

Why?
Because  [node 16 will stop being supported](https://github.com/nodejs/release#release-schedule) before we close shop 

How to review
-------------

- test pass
- optionally deploy to dev env to check it runs (currently deployed to dev01)

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
