### PR TITLE
Include paas-admin costs in the PMO csv download

### DIFF
--- a/src/components/reports/controllers.test.tsx
+++ b/src/components/reports/controllers.test.tsx
@@ -70,7 +70,7 @@ describe('organisations report helpers', () => {
     );
   });
 
-  it('filterRealOrgs should filter out tests and admin', () => {
+  it('filterRealOrgs should filter out tests, but include admin', () => {
     const orgs = [
       lodash.merge(defaultOrgv3(), { name: 'govuk-doggos' }),
       lodash.merge(defaultOrgv3(), { name: 'admin' }),
@@ -83,9 +83,10 @@ describe('organisations report helpers', () => {
 
     const filteredOrgs = t.filterRealOrgs(orgs);
 
-    expect(filteredOrgs.length).toEqual(2);
+    expect(filteredOrgs.length).toEqual(3);
     expect(filteredOrgs[0].name).toEqual('govuk-doggos');
-    expect(filteredOrgs[1].name).toEqual('department-for-coffee');
+    expect(filteredOrgs[1].name).toEqual('admin');
+    expect(filteredOrgs[2].name).toEqual('department-for-coffee');
   });
 
   it('filterTrialOrgs should filter out billable orgs and sort asc', () => {
@@ -1826,7 +1827,7 @@ describe('cost report grouping functions', () => {
     });
   });
 
-  it('filterRealOrgs should filter out tests and admin', () => {
+  it('filterRealOrgs should filter out tests but include admin', () => {
     const orgs = [
       { ...defaultOrgv3(), name: 'govuk-doggos' },
       { ...defaultOrgv3(), name: 'admin' },
@@ -1839,9 +1840,10 @@ describe('cost report grouping functions', () => {
 
     const filteredOrgs = reports.filterRealOrgs(orgs);
 
-    expect(filteredOrgs.length).toEqual(2);
+    expect(filteredOrgs.length).toEqual(3);
     expect(filteredOrgs[0].name).toEqual('govuk-doggos');
-    expect(filteredOrgs[1].name).toEqual('department-for-coffee');
+    expect(filteredOrgs[1].name).toEqual('admin');
+    expect(filteredOrgs[2].name).toEqual('department-for-coffee');
   });
 
   it('filterBillableOrgs should filter out trial orgs', () => {

--- a/src/components/reports/controllers.tsx
+++ b/src/components/reports/controllers.tsx
@@ -242,10 +242,6 @@ export function filterRealOrgs(
       return false;
     }
 
-    if (org.name === 'admin') {
-      return false;
-    }
-
     return true;
   });
 }


### PR DESCRIPTION
What
----

- Include paas-admin costs in the PMO csv download

How to review
-------------

- deploy to a dev env
- go to admin, select 'Spend for PMO team in CSV format', open downloaded csv and check 'admin' is included in the file

Who can review
---------------

not @kr8n3r 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
