### PR TITLE
Switch to new Chrome headless mode

### DIFF
--- a/acceptance-tests/main.test.ts
+++ b/acceptance-tests/main.test.ts
@@ -15,7 +15,6 @@ const {
   ACCOUNTS_PASSWORD,
   ADMIN_USERNAME,
   ADMIN_PASSWORD,
-  HEADLESS,
 } = process.env;
 if (!PAAS_ADMIN_BASE_URL) { throw 'PAAS_ADMIN_BASE_URL environment variable not set'; }
 if (!CF_API_BASE_URL) { throw 'CF_API_BASE_URL environment variable not set'; }
@@ -56,7 +55,7 @@ describe('paas-admin', () => {
         '--disable-dev-shm-usage',
         '--no-sandbox',
       ],
-      headless: !HEADLESS ? true : HEADLESS == 'true',
+      headless: 'new',
     });
     let page: Page;
 


### PR DESCRIPTION
[We're getting lots of warnings about Chrome { headless: true } related to the new headless mode in v112](https://deployer.london.staging.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/deploy-paas-admin/builds/3282#L64421a05:32)

Chrome’s Headless mode gets an upgrade: introducing --headless=new https://developer.chrome.com/articles/new-headless/

Additionally update logic for headless mode: always run headless unless explicitly specified. We don't set a HEADLESS env variable anywhere

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
