### PR TITLE
Add SameSite attribute to cookies

### DIFF
--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -79,6 +79,7 @@ describe('app test suite', () => {
     expect(response.header['set-cookie'].join('|')).toContain(
       'pazmin-session.sig',
     );
+    expect(response.header['set-cookie'][0]).toContain('samesite=lax');
   });
 
   it('should server a null cohort permissions policy header', async () => {
@@ -252,6 +253,7 @@ describe('app test suite', () => {
     it('should authenticate successfully', () => {
       expect(response.status).toEqual(302);
       expect(response.header['set-cookie'][0]).toContain('pazmin-session');
+      expect(response.header['set-cookie'][0]).toContain('samesite=lax');
     });
 
     it('should redirect to organisations when accessed root', async () => {

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -106,6 +106,7 @@ export default function(config: IAppConfig): express.Express {
       keys: [config.sessionSecret],
       name: 'pazmin-session',
       secure: !config.allowInsecureSession,
+      sameSite: 'lax',
     }),
   );
 


### PR DESCRIPTION
What
----

SameSite prevents the browser from sending this cookie along with cross-site requests. The main goal is to mitigate the risk of cross-origin information leakage. It also provides some protection against cross-site request forgery attacks.

We set it to "Lax" as it provides a reasonable balance between security and usability for websites that want to maintain user’s logged-in session after the user arrives from an external link.

[Notify admin also uses "lax"](https://github.com/alphagov/notifications-admin/blob/main/app/config.py#L57)

**Before**
<img width="1158" alt="Screenshot 2023-06-07 at 09 19 11" src="https://github.com/alphagov/paas-admin/assets/3758555/0c6dde22-1725-471d-aa88-aba0de0bbaf6">

**After**
<img width="1148" alt="Screenshot 2023-06-07 at 09 24 37" src="https://github.com/alphagov/paas-admin/assets/3758555/c2822764-28fa-4f0c-80af-5851ac231ca3">


How to review
-------------

deploy to dev env - currently deployed to dev05
check cookies in browser dev tools

Who can review
---------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
