### PR TITLE
UserPage: make robust to missing `lastLogon` or `groups` information

### DIFF
--- a/src/components/users/views.test.tsx
+++ b/src/components/users/views.test.tsx
@@ -67,6 +67,22 @@ describe(UserPage, () => {
     );
     expect(queryByText('This user is a member of 3 orgs.')).toBeTruthy();
   });
+
+  it('should handle missing properties', () => {
+    // it's unclear what information is guaranteed to be present
+    // in e.g. a UAA response, and we should try not to fail to
+    // render a page if some elements are missing.
+    const { queryByText } = render(
+      <UserPage
+        organizations={[]}
+        linkTo={linker}
+        user={{}}
+      />,
+    );
+    expect(queryByText('User')).toBeTruthy();
+    expect(queryByText('Orgs')).toBeTruthy();
+    expect(queryByText('UAA Groups')).toBeTruthy();
+  });
 });
 
 describe(PasswordResetRequest, () => {

--- a/src/components/users/views.tsx
+++ b/src/components/users/views.tsx
@@ -90,7 +90,7 @@ export function UserPage(props: IUserPageProps): ReactElement {
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">Last logon</dt>
           <dd className="govuk-summary-list__value">
-            {format(new Date(props.lastLogon), DATE_TIME)}
+            {props.lastLogon && format(new Date(props.lastLogon), DATE_TIME)}
           </dd>
         </div>
       </dl>
@@ -107,7 +107,7 @@ export function UserPage(props: IUserPageProps): ReactElement {
       <h3 className="govuk-heading-m">UAA Groups</h3>
 
       <ul className="govuk-list govuk-list--bullet">
-        {props.groups.map(group => (
+        {props.groups && props.groups.map(group => (
           <li key={group.display}>
             <code>{group.display}</code>
           </li>


### PR DESCRIPTION
What
----

I discovered a user with no `lastLogon` information in UAA, causing their `UserPage` to fail to render. It's not always clear what information _is_ going to be present in e.g. a UAA response, so let's make an attempt at being slightly robust to this.

How to review
-------------

:eyes: at tests.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
