### PR TITLE
Decommissioned

### DIFF
--- a/src/components/app/app.test.ts
+++ b/src/components/app/app.test.ts
@@ -506,28 +506,28 @@ describe('app test suite', () => {
   });
 
   describe('support pages', () => {
-    it('should be able to access support page without login', async () => {
+    it('should not be able to access support page without login', async () => {
       const app = init(config);
       const response = await request(app).get('/support');
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(403);
     });
 
-    it('should be able to access /support/contact-us page without login', async () => {
+    it('should not be able to access /support/contact-us page without login', async () => {
       const app = init(config);
       const response = await request(app).get('/support/contact-us');
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(403);
     });
 
-    it('should be able to access /support/something-wrong-with-service page without login', async () => {
+    it('should not be able to access /support/something-wrong-with-service page without login', async () => {
       const app = init(config);
       const response = await request(app).get('/support/something-wrong-with-service');
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(403);
     });
 
-    it('should be able to access /support/help-using-paas page without login', async () => {
+    it('should not be able to access /support/help-using-paas page without login', async () => {
       const app = init(config);
       const response = await request(app).get('/support/help-using-paas');
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(403);
     });
   });
 });

--- a/src/components/support/controllers.test.tsx
+++ b/src/components/support/controllers.test.tsx
@@ -11,6 +11,7 @@ import { createTestContext } from '../app/app.test-helpers';
 import { Token } from '../auth';
 
 import * as controller from './controllers';
+import { NotAuthorisedError } from '../../lib/router';
 
 const token = jwt.sign(
   {
@@ -29,6 +30,27 @@ let ctx: IContext = createTestContext({
 });
 
 let nockZD: nock.Scope;
+
+describe('not authorised access to /support forms', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+
+    nockZD = nock(ctx.app.zendeskConfig.remoteUri);
+  });
+
+  afterEach(() => {
+    nockZD.done();
+
+    nock.cleanAll();
+  });
+
+  it('should show a "not authorised" error page to user that is not logged in when accessing any support form', async () => {
+    await expect(controller.SupportSelectionForm(ctx, {})).rejects.toThrow(NotAuthorisedError)
+    await expect(controller.SomethingWrongWithServiceForm(ctx)).rejects.toThrow(NotAuthorisedError)
+    await expect(controller.HelpUsingPaasForm(ctx)).rejects.toThrow(NotAuthorisedError)
+    await expect(controller.ContactUsForm(ctx, {})).rejects.toThrow(NotAuthorisedError)
+  });
+});
 
 describe(controller.HandleContactUsFormPost, () => {
   beforeEach(() => {

--- a/src/components/support/controllers.tsx
+++ b/src/components/support/controllers.tsx
@@ -2,7 +2,7 @@ import * as zendesk from 'node-zendesk';
 import React from 'react';
 
 import { Template } from '../../layouts';
-import { IParameters, IResponse } from '../../lib/router';
+import { IParameters, IResponse, NotAuthorisedError } from '../../lib/router';
 import { IContext } from '../app';
 
 import UAAClient from '../../lib/uaa';
@@ -210,6 +210,10 @@ function contactUsContent(variables: IContactUsFormValues): string {
 
 export async function SupportSelectionForm (ctx: IContext, _params: IParameters): Promise<IResponse> {
 
+  if (!ctx.viewContext.authenticated) {
+    throw new NotAuthorisedError('Available to logged-in users only');
+  }
+
   const template = new Template(ctx.viewContext, 'Get support');
 
   return await Promise.resolve({
@@ -256,6 +260,10 @@ export async function HandleSupportSelectionFormPost (
 }
 
 export async function SomethingWrongWithServiceForm (ctx: IContext): Promise<IResponse> {
+
+  if (!ctx.viewContext.authenticated) {
+    throw new NotAuthorisedError('Available to logged-in users only');
+  }
 
   const template = new Template(ctx.viewContext, 'Something’s wrong with my live service');
 
@@ -344,6 +352,10 @@ export async function HandleSomethingWrongWithServiceFormPost(
 
 export async function HelpUsingPaasForm (ctx: IContext): Promise<IResponse> {
 
+  if (!ctx.viewContext.authenticated) {
+    throw new NotAuthorisedError('Available to logged-in users only');
+  }
+
   const template = new Template(ctx.viewContext, 'I need some help using GOV.UK PaaS');
 
   return await Promise.resolve({
@@ -414,6 +426,10 @@ export async function HandleHelpUsingPaasFormPost(
 }
 
 export async function ContactUsForm (ctx: IContext, _params: IParameters): Promise<IResponse> {
+
+  if (!ctx.viewContext.authenticated) {
+    throw new NotAuthorisedError('Available to logged-in users only');
+  }
 
   const template = new Template(ctx.viewContext, 'Contact us');
 

--- a/src/components/support/views.tsx
+++ b/src/components/support/views.tsx
@@ -110,10 +110,6 @@ export function SupportSelectionPage(props: ISupportSelectionFormProperties): Re
           <></>
         )}
       <h1 className="govuk-heading-l">Get support</h1>
-      <div className="govuk-inset-text">
-      <p className="govuk-body">GDS is <a href="https://gds.blog.gov.uk/2022/07/12/why-weve-decided-to-decommission-gov-uk-paas-platform-as-a-service/" className="govuk-link"> decommissioning GOV.UK PaaS</a> by 23 December 2023. We&apos;re no longer accepting new trial accounts.</p>
-      <p className="govuk-body">Read our <a href="https://www.cloud.service.gov.uk/migration-guidance/" className="govuk-link">migration guidance</a> for tenants.</p>
-      </div>
       <form noValidate method="post">
         <input type="hidden" name="_csrf" value={props.csrf} />
         <div className={`govuk-form-group ${

--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -89,14 +89,14 @@ export function Header(props: IHeaderProperties): ReactElement {
               id="navigation"
               className="govuk-header__navigation-list"
             >
-              <li className="govuk-header__navigation-item">
+              {props.authenticated ? <li className="govuk-header__navigation-item">
                 <a
                   className="govuk-header__link" 
                   href="/support"
                 >
                   Support
                 </a>
-              </li>
+                </li> : undefined}
               {props.authenticated ? <li className="govuk-header__navigation-item">
                 <a
                   className="govuk-header__link"

--- a/src/layouts/partials.tsx
+++ b/src/layouts/partials.tsx
@@ -176,6 +176,7 @@ export function Footer({ authenticated }: IFooterProperties): ReactElement {
   return (
     <footer className="govuk-footer govuk-!-display-none-print" role="contentinfo">
       <div className="govuk-width-container ">
+      {authenticated ? 
         <div className="govuk-footer__navigation">
           <div className="govuk-footer__section govuk-grid-column-one-half">
             <h2 className="govuk-footer__heading govuk-heading-m">Support</h2>
@@ -198,11 +199,11 @@ export function Footer({ authenticated }: IFooterProperties): ReactElement {
                   Raise an issue
                 </a>
               </li>
-              {authenticated ? <li className="govuk-footer__list-item">
+              <li className="govuk-footer__list-item">
                 <a className="govuk-footer__link" href="/support/static-ip">
                   Static IPs
                 </a>
-              </li> : null}
+              </li>
               <li className="govuk-footer__list-item">
                 <a 
                   className="govuk-footer__link"
@@ -215,16 +216,16 @@ export function Footer({ authenticated }: IFooterProperties): ReactElement {
           <div className="govuk-footer__section govuk-grid-column-one-half">
             <h2 className="govuk-footer__heading govuk-heading-m">Legal terms</h2>
             <ul className="govuk-footer__list">
-              {authenticated ? <li className="govuk-footer__list-item">
+              <li className="govuk-footer__list-item">
                 <a className="govuk-footer__link" href="/support/mou-crown">
                   Memorandum of understanding for Crown bodies
                 </a>
-              </li> : null}
-              {authenticated ? <li className="govuk-footer__list-item">
+              </li>
+              <li className="govuk-footer__list-item">
                 <a className="govuk-footer__link" href="/support/mou-non-crown">
                   Memorandum of understanding for non-Crown bodies
                 </a>
-              </li> : null}
+              </li>
               <li className="govuk-footer__list-item">
                 <a
                   className="govuk-footer__link"
@@ -260,8 +261,10 @@ export function Footer({ authenticated }: IFooterProperties): ReactElement {
             </ul>
           </div>
         </div>
-
+      : null}
+      {authenticated ? 
         <hr className="govuk-footer__section-break" />
+      : null}
 
         <div className="govuk-footer__meta">
           <div className="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/src/layouts/template.test.tsx
+++ b/src/layouts/template.test.tsx
@@ -36,7 +36,7 @@ describe(Template, () => {
     const markup = template.render(<p>This is just a test</p>);
 
     expect(markup).toContain(
-      '<title lang="en">GOV.UK Platform as a Service - Administration Tool</title>',
+      '<title lang="en">[Decommissioned] GOV.UK Platform as a Service - Administration Tool</title>',
     );
   });
   it('should html encode special characters in the title', () => {

--- a/src/layouts/template.tsx
+++ b/src/layouts/template.tsx
@@ -46,7 +46,7 @@ export class Template {
         <head>
           <meta charSet="utf-8" />
           <title lang="${this._language}">${sanitizedTitle ||
-      'GOV.UK Platform as a Service - Administration Tool'}</title>
+      '[Decommissioned] GOV.UK Platform as a Service - Administration Tool'}</title>
           <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
           <meta name="theme-color" content="${themeColor}" />
           <meta name="csrf-token" content="${this.ctx.csrf}" />
@@ -79,6 +79,16 @@ export class Template {
               />
 
               <div className="govuk-width-container">
+                <div className="govuk-phase-banner">
+                  <p className="govuk-phase-banner__content">
+                    <strong className="govuk-tag govuk-phase-banner__content__tag">
+                      decommissioned
+                    </strong>
+                    <span className="govuk-phase-banner__text">
+                    Thanks to everyone who has used our platform over the years.
+                    </span>
+                  </p>
+                </div>
                 {this._subnav
                   ? <SubNavigation title={this._subnav.title} items={this._subnav.items} />
                   : undefined}
@@ -86,7 +96,6 @@ export class Template {
                 {this._breadcrumbs
                   ? <Breadcrumbs items={this._breadcrumbs} />
                   : undefined}
-
                 <Main>{page}</Main>
               </div>
 


### PR DESCRIPTION
What
----

Changes to admin for post 23/12/2023

- move support forms behind login for authorised users only
- add 'decommissioned' phase banner and message
- add 'decommissioned' to 'title' property
- move footer links behind log-in as they're only relevant to authorised users
- some header links behind log-in as they're only relevant to authorised users


shows unavailable support forms, header and footer link restrictions and phase banner
![Screenshot 2023-12-07 at 15 12 07](https://github.com/alphagov/paas-admin/assets/3758555/0455c38e-f5e5-480f-80c3-a585db60c0ec)


How to review
-------------

deploy to a dev env
visit /support without logging in, it will show an error message

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
