### PR TITLE
Mitigate billing data performance issues

### DIFF
--- a/src/components/platform-admin/views.tsx
+++ b/src/components/platform-admin/views.tsx
@@ -129,7 +129,7 @@ function Costs(props: IFormProperties): ReactElement {
           </div>
         </div>
 
-        <button className="govuk-button" type="submit">
+        <button className="govuk-button" type="submit" data-module="preventMultiClick">
           View costs
         </button>
       </form>

--- a/src/components/spaces/views.tsx
+++ b/src/components/spaces/views.tsx
@@ -317,6 +317,7 @@ export function SpacesPage(props: ISpacesPageProperties): ReactElement {
               >
                 Explore your costs and usage
               </a>
+              <span className="govuk-body-s govuk-!-display-block">(for large organisation it takes a while, so please wait)</span>
             </p>,
           )}
         </div>

--- a/src/frontend/javascript/init.js
+++ b/src/frontend/javascript/init.js
@@ -53,3 +53,16 @@ if ($tooltips) {
 // Find first skip link module to enhance.
 var $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
 new SkipLink($skipLink).init()
+
+
+var $preventMultiClickBtns = document.querySelectorAll('[data-module="preventMultiClick"]');
+if ($preventMultiClickBtns) {
+  for (var i = 0; i < $preventMultiClickBtns.length; i++) {
+    $preventMultiClickBtns[i].addEventListener("click", function () {
+      this.form.submit();
+      this.setAttribute("disabled", "disabled");
+      this.textContent = "Loading data...";
+      this.setAttribute("aria-disabled", "true");
+    });
+  };
+}


### PR DESCRIPTION
What
----

Add notice to users on teh org page to only click once and wait

![image](https://github.com/alphagov/paas-admin/assets/3758555/b988571d-7996-457a-be0e-acbbe6b6be1f)

On platform admin cost page, once button is clicked, we disable it and display a loading message
![Screenshot 2023-12-07 at 12 15 19](https://github.com/alphagov/paas-admin/assets/3758555/9a4a8fe3-9b83-4e02-bfbe-396bd6448bcf)



How to review
-------------

Tested on dev03

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
