### PR TITLE
Run on Node20( lts)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/Hydrogen
+lts/Iron

--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: 18-alpine
+    tag: 20-alpine
 inputs:
   - name: repo
 run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,8 +126,8 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "18.x.x",
-        "npm": ">=8.x.x"
+        "node": "20.x.x",
+        "npm": ">=10.x.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -155,8 +155,8 @@
     }
   },
   "engines": {
-    "node": "18.x.x",
-    "npm": ">=8.x.x"
+    "node": "20.x.x",
+    "npm": ">=10.x.x"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -49,7 +49,9 @@ describe('server test suite', () => {
       request(`http://localhost:${port}`)
         .get('/')
         .timeout(500),
-    ).rejects.toThrow(/ECONNREFUSED/);
+    ).rejects.toMatchObject ({
+      code: 'ECONNREFUSED',
+    });
   });
 
   it('should replace the handler when updated', async () => {


### PR DESCRIPTION
What
----

Changes required to make admin run on [node 20](https://nodejs.org/en/blog/release/v20.11.0)

- Specify package.json engine versions
- Update .nvmrc to specify latest lts version
- Update test due to a change in Node
- Tell CI to run on node 20

## Why

[Node 18 in now in maintenance mode and will be EOL April 2025](https://nodejs.org/en/about/previous-releases). Time to get on the new long-term support version

How to review
-------------

deploy to dev env or run locally

Who can review
---------------

anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
