### PR TITLE
Group dependabot updates for weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,46 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "03:00"
+  directory: /
   open-pull-requests-limit: 10
+  # Group packages into shared PR
+  groups:
+    aws-sdk:
+      patterns:
+        - '@aws-sdk/*'
+
+    test:
+      patterns:
+        - '@testing-library/*'
+        - 'cheerio'
+        - 'supertest'
+        - 'nock'
+        - 'puppeteer'
+
+    lint:
+      patterns:
+        - '@typescript-eslint/*'
+        - 'eslint'
+        - 'eslint-*'
+        - 'stylelint'
+        - 'stylelint-*'
+
+    types:
+      patterns:
+        - '@types/*'
+
+      # Exclude packages in other groups
+      exclude-patterns:
+        - '@types/aws-sdk'
+        - '@types/eslint'
+
+  # Schedule run every Monday, local time
+  schedule:
+    interval: weekly
+    time: '03:00'
+    timezone: 'Europe/London'
+
+  versioning-strategy: increase
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
What
----

Initial setup to group dependabot PRs into groups for 1 weekly PR.

This is to lessen the burden of updates when there is no Frontend developer on the team from April.

New groups will be added as we go along. If a dependency isn't in a group an individual PR will continue to be raised



🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
